### PR TITLE
Fix accidental memory overwrites

### DIFF
--- a/src/backings/tree/array.ts
+++ b/src/backings/tree/array.ts
@@ -86,9 +86,8 @@ export class BasicArrayTreeHandler<T extends ArrayLike<unknown>> extends TreeHan
   setProperty(target: Tree, property: number, value: T[number], expand=false): boolean {
     const chunkGindex = this.gindexOfChunk(target, this.getChunkIndex(property));
     // copy data from old chunk, use new memory to set a new chunk
-    const dataChunk = target.getRoot(chunkGindex);
     const chunk = new Uint8Array(32);
-    chunk.set(dataChunk);
+    chunk.set(target.getRoot(chunkGindex));
     this._type.elementType.toBytes(value, chunk, this.getChunkOffset(property));
     target.setRoot(chunkGindex, chunk, expand);
     return true;

--- a/src/backings/tree/bitVector.ts
+++ b/src/backings/tree/bitVector.ts
@@ -41,7 +41,8 @@ export class BitVectorTreeHandler extends BasicVectorTreeHandler<BitVector> {
   }
   setProperty(target: Tree, property: number, value: boolean): boolean {
     const chunkGindex = this.gindexOfChunk(target, this.getChunkIndex(property));
-    const chunk = target.getRoot(chunkGindex);
+    const chunk = new Uint8Array(32);
+    chunk.set(target.getRoot(chunkGindex));
     const byteOffset = this.getChunkOffset(property);
     if (value) {
       chunk[byteOffset] |= (1 << this.getBitOffset(property));


### PR DESCRIPTION
There were a few places where tree memory was being mutated.
This leads to cases where eg: a zeroNode gets overwritten.