### PR TITLE
Fix type errors

### DIFF
--- a/src/util/merkleize.ts
+++ b/src/util/merkleize.ts
@@ -19,7 +19,7 @@ export function merkleize(chunks: Buffer[], padFor = 0): Buffer {
       chunks.push(zeroHashes[layer]);
     }
     for (let i = 0; i < chunks.length; i += 2) {
-      chunks[i / 2] = hash(chunks[i], chunks[i + 1]);
+      chunks[i / 2] = Buffer.from(hash(chunks[i], chunks[i + 1]));
     }
     chunks.splice(chunks.length / 2, chunks.length / 2);
     layer++;
@@ -31,5 +31,5 @@ export function merkleize(chunks: Buffer[], padFor = 0): Buffer {
 export function mixInLength(root: Buffer, length: number): Buffer {
   const lengthBuf = Buffer.alloc(32);
   lengthBuf.writeUIntLE(length, 0, 6);
-  return hash(root, lengthBuf);
+  return Buffer.from(hash(root, lengthBuf));
 }

--- a/src/util/zeros.ts
+++ b/src/util/zeros.ts
@@ -5,5 +5,5 @@ import {hash} from "./hash";
 // create array of "zero hashes", successively hashed zero chunks
 export const zeroHashes = [Buffer.alloc(BYTES_PER_CHUNK)];
 for (let i = 0; i < 52; i++) {
-  zeroHashes.push(hash(zeroHashes[i], zeroHashes[i]));
+  zeroHashes.push(Buffer.from(hash(zeroHashes[i], zeroHashes[i])));
 }


### PR DESCRIPTION
A previous commit changed our `hash` implementation from `hash(Buffer) => Buffer` to `hash(Uint8Array) => Uint8Array`

This caused a few type errors that are cleaned up here.