### PR TITLE
Add isFooType functions

### DIFF
--- a/src/types/basic/abstract.ts
+++ b/src/types/basic/abstract.ts
@@ -2,11 +2,36 @@
 import {Json} from "../../interface";
 
 /**
+ * Check if `type` is an instance of `typeSymbol` type
+ *
+ * Used by various isFooType functions
+ */
+export function isTypeOf(type: unknown, typeSymbol: symbol): boolean {
+  return (
+    type &&
+    (type as BasicType<unknown>)._typeSymbols &&
+    (type as BasicType<unknown>)._typeSymbols.has &&
+    (type as BasicType<unknown>)._typeSymbols.has(typeSymbol)
+  );
+}
+
+/**
  * A BasicType is a terminal type, which has no flexibility in its representation.
  *
  * It is serialized as, at maximum, 32 bytes and merkleized as, at maximum, a single chunk
  */
 export class BasicType<T> {
+  /**
+   * Symbols used to track the identity of a type
+   *
+   * Used by various isFooType functions
+   */
+  _typeSymbols: Set<symbol>;
+
+  constructor() {
+    this._typeSymbols = new Set();
+  }
+
   isBasic(): this is BasicType<T> {
     return true;
   }

--- a/src/types/basic/boolean.ts
+++ b/src/types/basic/boolean.ts
@@ -1,7 +1,17 @@
 import {Json} from "../../interface";
-import {BasicType} from "./abstract";
+import {BasicType, isTypeOf} from "./abstract";
+
+export const BOOLEAN_TYPE = Symbol.for("ssz/BooleanType");
+
+export function isBooleanType(type: unknown): type is BooleanType {
+  return isTypeOf(type, BOOLEAN_TYPE);
+}
 
 export class BooleanType extends BasicType<boolean> {
+  constructor() {
+    super();
+    this._typeSymbols.add(BOOLEAN_TYPE);
+  }
   size(): number {
     return 1;
   }

--- a/src/types/basic/uint.ts
+++ b/src/types/basic/uint.ts
@@ -24,7 +24,17 @@ export class UintType<T> extends BasicType<T> {
   }
 }
 
+export const NUMBER_UINT_TYPE = Symbol.for("ssz/NumberUintType");
+
+export function isNumberUintType(type: unknown): type is NumberUintType {
+  return isTypeOf(type, NUMBER_UINT_TYPE);
+}
+
 export class NumberUintType extends UintType<number> {
+  constructor(options: IUintOptions) {
+    super(options);
+    this._typeSymbols.add(NUMBER_UINT_TYPE);
+  }
   assertValidValue(value: unknown): asserts value is number {
     if (!(Number.isSafeInteger(value as number) || value === Infinity)) {
       throw new Error("Uint value is not a number");
@@ -78,7 +88,17 @@ export class NumberUintType extends UintType<number> {
   }
 }
 
+export const BIGINT_UINT_TYPE = Symbol.for("ssz/BigIntUintType");
+
+export function isBigIntUintType(type: unknown): type is BigIntUintType {
+  return isTypeOf(type, BIGINT_UINT_TYPE);
+}
+
 export class BigIntUintType extends UintType<bigint> {
+  constructor(options: IUintOptions) {
+    super(options);
+    this._typeSymbols.add(BIGINT_UINT_TYPE);
+  }
   assertValidValue(value: unknown): asserts value is bigint {
     if (typeof value !== "bigint") {
       throw new Error("Uint value is not a bigint");

--- a/src/types/basic/uint.ts
+++ b/src/types/basic/uint.ts
@@ -1,15 +1,23 @@
 import {Json} from "../../interface";
-import {BasicType} from "./abstract";
+import {BasicType, isTypeOf} from "./abstract";
 
 export interface IUintOptions {
   byteLength: number;
 }
 
+export const UINT_TYPE = Symbol.for("ssz/UintType");
+
+export function isUintType<T>(type: unknown): type is UintType<T> {
+  return isTypeOf(type, UINT_TYPE);
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export class UintType<T> extends BasicType<T> {
   byteLength: number;
   constructor(options: IUintOptions) {
     super();
     this.byteLength = options.byteLength;
+    this._typeSymbols.add(UINT_TYPE);
   }
   size(): number {
     return this.byteLength;

--- a/src/types/composite/abstract.ts
+++ b/src/types/composite/abstract.ts
@@ -5,7 +5,7 @@ import {
   StructuralHandler, TreeHandler, ByteArrayHandler,
 } from "../../backings";
 
-import {BasicType} from "../basic";
+import {isTypeOf, BasicType} from "../basic";
 
 /**
  * A CompositeType is a type containing other types, and is flexible in its representation.
@@ -15,6 +15,17 @@ export class CompositeType<T extends object> {
   structural: StructuralHandler<T>;
   tree: TreeHandler<T>;
   byteArray: ByteArrayHandler<T>;
+
+  /**
+   * Symbols used to track the identity of a type
+   *
+   * Used by various isFooType functions
+   */
+  _typeSymbols: Set<symbol>;
+
+  constructor() {
+    this._typeSymbols = new Set();
+  }
 
   isBasic(): this is BasicType<T> {
     return false;

--- a/src/types/composite/bitList.ts
+++ b/src/types/composite/bitList.ts
@@ -1,6 +1,6 @@
 import {BitList} from "../../interface";
 import {BasicListType} from "./list";
-import {booleanType} from "../basic";
+import {booleanType, isTypeOf} from "../basic";
 import {
   BitListStructuralHandler,
   BitListTreeHandler,
@@ -10,11 +10,18 @@ export interface IBitListOptions {
   limit: number;
 }
 
+export const BITLIST_TYPE = Symbol.for("ssz/BitListType");
+
+export function isBitListType<T extends BitList=BitList>(type: unknown): type is BitListType {
+  return isTypeOf(type, BITLIST_TYPE);
+}
+
 export class BitListType extends BasicListType<BitList> {
   constructor(options: IBitListOptions) {
     super({elementType: booleanType, ...options});
     this.structural = new BitListStructuralHandler(this);
     this.tree = new BitListTreeHandler(this);
+    this._typeSymbols.add(BITLIST_TYPE);
   }
   chunkCount(): number {
     return Math.ceil(this.limit / 256);

--- a/src/types/composite/bitVector.ts
+++ b/src/types/composite/bitVector.ts
@@ -1,6 +1,6 @@
 import {BitVector} from "../../interface";
 import {BasicVectorType} from "./vector";
-import {booleanType} from "../basic";
+import {booleanType, isTypeOf} from "../basic";
 import {
   BitVectorStructuralHandler,
   BitVectorTreeHandler,
@@ -10,11 +10,18 @@ export interface IBitVectorOptions {
   length: number;
 }
 
+export const BITVECTOR_TYPE = Symbol.for("ssz/BitVectorType");
+
+export function isBitVectorType<T extends BitVector=BitVector>(type: unknown): type is BitVectorType {
+  return isTypeOf(type, BITVECTOR_TYPE);
+}
+
 export class BitVectorType extends BasicVectorType<BitVector> {
   constructor(options: IBitVectorOptions) {
     super({elementType: booleanType, ...options});
     this.structural = new BitVectorStructuralHandler(this);
     this.tree = new BitVectorTreeHandler(this);
+    this._typeSymbols.add(BITVECTOR_TYPE);
   }
   chunkCount(): number {
     return Math.ceil(this.length / 256);

--- a/src/types/composite/byteVector.ts
+++ b/src/types/composite/byteVector.ts
@@ -1,6 +1,6 @@
 import {ByteVector} from "../../interface";
 import {BasicVectorType} from "./vector";
-import {byteType} from "../basic";
+import {byteType, isTypeOf} from "../basic";
 import {
   ByteVectorStructuralHandler,
   ByteVectorTreeHandler
@@ -10,10 +10,17 @@ export interface IByteVectorOptions {
   length: number;
 }
 
+export const BYTEVECTOR_TYPE = Symbol.for("ssz/ByteVectorType");
+
+export function isByteVectorType<T extends ByteVector=ByteVector>(type: unknown): type is ByteVectorType {
+  return isTypeOf(type, BYTEVECTOR_TYPE);
+}
+
 export class ByteVectorType extends BasicVectorType<ByteVector> {
   constructor(options: IByteVectorOptions) {
     super({elementType: byteType, ...options});
     this.structural = new ByteVectorStructuralHandler(this);
     this.tree = new ByteVectorTreeHandler(this);
+    this._typeSymbols.add(BYTEVECTOR_TYPE);
   }
 }

--- a/src/types/composite/container.ts
+++ b/src/types/composite/container.ts
@@ -1,5 +1,6 @@
 import {ObjectLike} from "../../interface";
 import {CompositeType} from "./abstract";
+import {isTypeOf} from "../basic";
 import {Type} from "../type";
 import {
   ContainerStructuralHandler,
@@ -12,6 +13,12 @@ export interface IContainerOptions {
   fields: Record<string, Type<any>>;
 }
 
+export const CONTAINER_TYPE = Symbol.for("ssz/ContainerType");
+
+export function isContainerType<T extends ObjectLike=ObjectLike>(type: unknown): type is ContainerType<T> {
+  return isTypeOf(type, CONTAINER_TYPE);
+}
+
 export class ContainerType<T extends ObjectLike=ObjectLike> extends CompositeType<T> {
   // ES6 ensures key order is chronological
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -22,6 +29,7 @@ export class ContainerType<T extends ObjectLike=ObjectLike> extends CompositeTyp
     this.structural = new ContainerStructuralHandler(this);
     this.tree = new ContainerTreeHandler(this);
     this.byteArray = new ContainerByteArrayHandler(this);
+    this._typeSymbols.add(CONTAINER_TYPE);
   }
   isVariableSize(): boolean {
     return Object.values(this.fields).some((fieldType) => fieldType.isVariableSize());

--- a/src/types/composite/list.ts
+++ b/src/types/composite/list.ts
@@ -1,5 +1,6 @@
 import {List} from "../../interface";
 import {IArrayOptions, BasicArrayType, CompositeArrayType} from "./array";
+import {isTypeOf} from "../basic";
 import {
   BasicListStructuralHandler, CompositeListStructuralHandler,
   BasicListTreeHandler, CompositeListTreeHandler,
@@ -16,6 +17,13 @@ type ListTypeConstructor = {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   new<T extends List<any>>(options: IListOptions): ListType<T>;
 };
+
+export const LIST_TYPE = Symbol.for("ssz/ListType");
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isListType<T extends List<any>=List<any>>(type: unknown): type is ListType<T> {
+  return isTypeOf(type, LIST_TYPE);
+}
 
 // Trick typescript into treating ListType as a constructor
 export const ListType: ListTypeConstructor =
@@ -36,6 +44,7 @@ export class BasicListType<T extends List<unknown>=List<unknown>> extends BasicA
     this.structural = new BasicListStructuralHandler(this);
     this.tree = new BasicListTreeHandler(this);
     this.byteArray = new BasicListByteArrayHandler(this);
+    this._typeSymbols.add(LIST_TYPE);
   }
   isVariableSize(): boolean {
     return true;
@@ -53,6 +62,7 @@ export class CompositeListType<T extends List<object>=List<object>> extends Comp
     this.structural = new CompositeListStructuralHandler(this);
     this.tree = new CompositeListTreeHandler(this);
     this.byteArray = new CompositeListByteArrayHandler(this);
+    this._typeSymbols.add(LIST_TYPE);
   }
   isVariableSize(): boolean {
     return true;

--- a/src/types/composite/root.ts
+++ b/src/types/composite/root.ts
@@ -1,3 +1,4 @@
+import {isTypeOf} from "../basic";
 import {ByteVectorType} from "./byteVector";
 import {CompositeType} from "./abstract";
 
@@ -8,11 +9,18 @@ export interface IRootOptions<T extends object> {
   expandedType: CompositeType<T> | (() => CompositeType<T>);
 }
 
+export const ROOT_TYPE = Symbol.for("ssz/RootType");
+
+export function isRootType<T extends object=object>(type: unknown): type is RootType<T> {
+  return isTypeOf(type, ROOT_TYPE);
+}
+
 export class RootType<T extends object> extends ByteVectorType {
   _expandedType: CompositeType<T> | (() => CompositeType<T>);
   constructor(options: IRootOptions<T>) {
     super({length: 32});
     this._expandedType = options.expandedType;
+    this._typeSymbols.add(ROOT_TYPE);
   }
   get expandedType(): CompositeType<T> {
     if (typeof this._expandedType === "function") {

--- a/src/types/composite/vector.ts
+++ b/src/types/composite/vector.ts
@@ -1,5 +1,6 @@
 import {Vector} from "../../interface";
 import {IArrayOptions, BasicArrayType, CompositeArrayType} from "./array";
+import {isTypeOf} from "../basic";
 import {
   BasicVectorStructuralHandler, CompositeVectorStructuralHandler,
   BasicVectorTreeHandler, CompositeVectorTreeHandler,
@@ -8,6 +9,13 @@ import {
 
 export interface IVectorOptions extends IArrayOptions {
   length: number;
+}
+
+export const VECTOR_TYPE = Symbol.for("ssz/VectorType");
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function isVectorType<T extends Vector<any>=Vector<any>>(type: unknown): type is VectorType<T> {
+  return isTypeOf(type, VECTOR_TYPE);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -36,6 +44,7 @@ export class BasicVectorType<T extends Vector<unknown>=Vector<unknown>> extends 
     this.structural = new BasicVectorStructuralHandler(this);
     this.tree = new BasicVectorTreeHandler(this);
     this.byteArray = new BasicVectorByteArrayHandler(this);
+    this._typeSymbols.add(VECTOR_TYPE);
   }
   isVariableSize(): boolean {
     return false;
@@ -53,6 +62,7 @@ export class CompositeVectorType<T extends Vector<object>=Vector<object>> extend
     this.structural = new CompositeVectorStructuralHandler(this);
     this.tree = new CompositeVectorTreeHandler(this);
     this.byteArray = new CompositeVectorByteArrayHandler(this);
+    this._typeSymbols.add(VECTOR_TYPE);
   }
   isVariableSize(): boolean {
     return this.elementType.isVariableSize();

--- a/test/unit/isFooType.test.ts
+++ b/test/unit/isFooType.test.ts
@@ -1,0 +1,102 @@
+import {expect} from "chai";
+import * as src from "../../src";
+
+describe("isFooType", () => {
+  const cases: {
+    type: src.Type<any>;
+    isType: ((t: src.Type<any>) => boolean) | ((t: src.Type<any>) => boolean)[];
+    isntType?: ((t: src.Type<any>) => boolean) | ((t: src.Type<any>) => boolean)[];
+  }[] = [
+    {
+      type: new src.NumberUintType({byteLength: 4}),
+      isType: [
+        src.isUintType,
+        src.isNumberUintType,
+      ],
+      isntType: [
+        src.isBigIntUintType,
+        src.isContainerType,
+      ]
+    },
+    {
+      type: new src.BigIntUintType({byteLength: 4}),
+      isType: [
+        src.isUintType,
+        src.isBigIntUintType,
+      ],
+      isntType: [
+        src.isNumberUintType,
+        src.isContainerType,
+      ]
+    },
+    {
+      type: new src.BooleanType(),
+      isType: src.isBooleanType,
+      isntType: src.isNumberUintType,
+    },
+    {
+      type: new src.VectorType({
+        elementType: new src.NumberUintType({byteLength: 4}),
+        length: 4,
+      }),
+      isType: src.isVectorType,
+    },
+    {
+      type: new src.ListType({
+        elementType: new src.NumberUintType({byteLength: 4}),
+        limit: 4,
+      }),
+      isType: src.isListType,
+    },
+    {
+      type: new src.BitVectorType({
+        length: 4,
+      }),
+      isType: [
+        src.isVectorType,
+        src.isBitVectorType,
+      ],
+    },
+    {
+      type: new src.BitListType({
+        limit: 4,
+      }),
+      isType: [
+        src.isListType,
+        src.isBitListType,
+      ],
+    },
+    {
+      type: new src.ByteVectorType({
+        length: 4,
+      }),
+      isType: [
+        src.isVectorType,
+        src.isByteVectorType,
+      ],
+    },
+    {
+      type: new src.ContainerType({
+        fields: {
+          foo: new src.NumberUintType({byteLength: 4})
+        },
+      }),
+      isType: src.isContainerType,
+    },
+  ];
+  for (const {type, isType, isntType} of cases) {
+    for (const _isType of (Array.isArray(isType) ? isType : [isType])) {
+      it(`${type.constructor.name} should match ${_isType.name}`, () => {
+        expect(_isType(type)).to.be.true;
+      });
+    }
+    if (!isntType) {
+      return;
+    }
+    for (const _isntType of (Array.isArray(isntType) ? isntType : [isntType])) {
+      it(`${type.constructor.name} should not match ${_isntType.name}`, () => {
+        expect(_isntType(type)).to.be.false;
+      });
+    }
+  }
+});


### PR DESCRIPTION
Adds the following exported functions:
- `isUintType`
- `isNumberUintType`
- `isBigIntUintType`
- `isBooleanType`
- `isListType`
- `isVectorType`
- `isBitListType`
- `isBitVectorType`
- `isByteVectorType`
- `isContainerType`
- `isRootType`