### PR TITLE
Fix far future deserialization

### DIFF
--- a/src/types/basic/uint.ts
+++ b/src/types/basic/uint.ts
@@ -18,6 +18,15 @@ export class UintType<T> extends BasicType<T> {
 
 export class NumberUintType extends UintType<number> {
   assertValidValue(value: unknown): asserts value is number {
+    if (
+      value !== Infinity 
+        && (
+          !Number.isSafeInteger(value as number)
+          || value > (BigInt(2) ** (BigInt(8) * BigInt(this.byteLength)))
+        )
+    ) {
+      throw new Error("Uint value is not a number");
+    }
     if (value as number < 0) {
       throw new Error("Uint value must be gte 0");
     }

--- a/src/types/basic/uint.ts
+++ b/src/types/basic/uint.ts
@@ -55,9 +55,14 @@ export class NumberUintType extends UintType<number> {
     return Number(output);
   }
   fromJson(data: Json): number {
-    let n = Number(data);
-    if(n > Number.MAX_SAFE_INTEGER) {
+    let n: number;
+    const bigN = BigInt(data);
+    if (bigN === (BigInt(2) ** BigInt(64)) - BigInt(1)) {
       n = Infinity;
+    } else if (bigN < Number.MAX_SAFE_INTEGER) {
+      n = Number(bigN);
+    } else {
+      throw new Error("Uint value unsafe");
     }
     this.assertValidValue(n);
     return n;

--- a/src/types/basic/uint.ts
+++ b/src/types/basic/uint.ts
@@ -18,9 +18,6 @@ export class UintType<T> extends BasicType<T> {
 
 export class NumberUintType extends UintType<number> {
   assertValidValue(value: unknown): asserts value is number {
-    if (!(Number.isSafeInteger(value as number) || value === Infinity)) {
-      throw new Error("Uint value is not a number");
-    }
     if (value as number < 0) {
       throw new Error("Uint value must be gte 0");
     }
@@ -58,7 +55,10 @@ export class NumberUintType extends UintType<number> {
     return Number(output);
   }
   fromJson(data: Json): number {
-    const n = Number(data);
+    let n = Number(data);
+    if(n > Number.MAX_SAFE_INTEGER) {
+      n = Infinity;
+    }
     this.assertValidValue(n);
     return n;
   }

--- a/test/unit/regression.test.ts
+++ b/test/unit/regression.test.ts
@@ -13,8 +13,13 @@ describe("known issues", () => {
 
   it("far future epoch from json", function () {
     const Number = new NumberUintType({byteLength: 4});
-    const farFutureEpohc = Number.fromJson(18446744073709551615);
-    expect(farFutureEpohc).to.be.equal(Infinity);
+    const farFutureEpoch = Number.fromJson("18446744073709551615");
+    expect(farFutureEpoch).to.be.equal(Infinity);
+  });
+
+  it("too large number from json", function () {
+    const Number = new NumberUintType({byteLength: 4});
+    expect(() => Number.fromJson("18446744073709551616")).to.throw;
   });
 
 

--- a/test/unit/regression.test.ts
+++ b/test/unit/regression.test.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai";
 
-import {VectorType, ByteVectorType} from "../../src";
+import {VectorType, ByteVectorType, NumberUintType} from "../../src";
 
 describe("known issues", () => {
   it("default value of composite vector should be correct", () => {
@@ -10,4 +10,12 @@ describe("known issues", () => {
     });
     expect(Vec.defaultValue().length).to.equal(Vec.length);
   });
+
+  it("far future epoch from json", function () {
+    const Number = new NumberUintType({byteLength: 4});
+    const farFutureEpohc = Number.fromJson(18446744073709551615);
+    expect(farFutureEpohc).to.be.equal(Infinity);
+  });
+
+
 });


### PR DESCRIPTION
I realize we will also have issue because we serialize FAR_FUTURE_EPOCH as "Infinity" while other clients uses number defined in [spec](https://github.com/ethereum/eth2.0-specs/blob/dev/specs/phase0/beacon-chain.md#constants). 