### PR TITLE
Add ObjBacked wrapper type

### DIFF
--- a/src/backings/index.ts
+++ b/src/backings/index.ts
@@ -1,3 +1,4 @@
+export * from "./object";
 export * from "./structural";
 export * from "./tree";
 export * from "./byteArray";

--- a/src/backings/object.ts
+++ b/src/backings/object.ts
@@ -1,0 +1,20 @@
+import {BitList, BitVector, ByteVector, List, Vector} from "../interface";
+
+export type ObjBackedify<T> = {
+  [K in keyof T]: T[K] extends object ? ObjBacked<T[K]> : T[K];
+};
+
+export type IObjBacked<T extends object> = {
+  [K in keyof T]:
+  T[K] extends BitList ? boolean[]
+    : T[K] extends BitVector ? boolean[]
+      : T[K] extends ByteVector ? Uint8Array
+        : T[K] extends List<unknown> ? T[K][number][]
+          : T[K] extends Vector<unknown> ? T[K][number][]
+            : T[K];
+};
+
+/**
+ * Wrap an ssz type to explicitly be backed by primitive javascript objects
+ */
+export type ObjBacked<T extends object> = IObjBacked<T> & ObjBackedify<T>;


### PR DESCRIPTION
Add `ObjBacked` wrapper type to explicitly cast an ssz object to be backed by built-in javascript objects.

```typescript
// so we already have this
const b: TreeBacked<BeaconBlock> = ...;

b.body.voluntaryExits // type of List<VoluntaryExit>

b.body.randaoReveal // type of ByteVector

// adding this
const b: ObjBacked<BeaconBlock> = ...;

b.body.voluntaryExits // type of VoluntaryExit[]

b.body.randaoReveal // type of Uint8Array
```