### PR TITLE
Don't use BigInt in NumberUintType#toBytes

### DIFF
--- a/src/types/basic/uint.ts
+++ b/src/types/basic/uint.ts
@@ -61,11 +61,11 @@ export class NumberUintType extends UintType<number> {
         output[i] = 0xff;
       }
     } else {
-      let v = BigInt(value);
-      const MAX_BYTE = BigInt(0xff);
+      let v = value;
+      const MAX_BYTE = 0xff;
       for (let i = 0; i < this.byteLength; i ++) {
-        output[offset + i] = Number(v & MAX_BYTE);
-        v >>= BigInt(8);
+        output[offset + i] = v & MAX_BYTE;
+        v = Math.floor(v / 256);
       }
     }
     return offset + this.byteLength;


### PR DESCRIPTION
In `NumberUintType#toBytes`, instead of `BigInt` bitshifting, use `Math.floor`'d `number` division.
This allows environments which don't support `BigInt` to `hashTreeRoot` js objects.