### PR TITLE
Standardize uint toJson

### DIFF
--- a/src/types/basic/uint.ts
+++ b/src/types/basic/uint.ts
@@ -151,6 +151,10 @@ export class BigIntUintType extends UintType<bigint> {
     return value;
   }
   toJson(value: bigint): Json {
-    return value.toString();
+    if (this.byteLength > 4) {
+      return value.toString();
+    } else {
+      return Number(value);
+    }
   }
 }


### PR DESCRIPTION
resolve https://github.com/ChainSafe/ssz/issues/34

current approach:

for `uint8`, `uint16`, `uint32`, `toJson` returns a `number`, else (`uint48` and higher) returns a `string`

an alternative approach could be:

for every `uint`, `toJson` returns a `string` (no matter the bit/bytelength)