### PR TITLE
Print type name in test declaration

### DIFF
--- a/test/unit/clone.test.ts
+++ b/test/unit/clone.test.ts
@@ -21,7 +21,7 @@ describe("clone", () => {
     {value: {v:[{a:1,b:2},{b:4,a:3}]}, type: ArrayObject, expected: true},
   ];
   for (const {type, value} of testCases) {
-    it(`should correctly perform clone for ${type}`, () => {
+    it(`should correctly perform clone for ${type.constructor.name}`, () => {
       const actual = type.clone(value);
       expect(type.equals(actual, value));
     });

--- a/test/unit/defaultValue.test.ts
+++ b/test/unit/defaultValue.test.ts
@@ -20,7 +20,7 @@ describe("defaultValue", () => {
     {type: ArrayObject, expected: {v: []}},
   ];
   for (const {type, expected} of testCases) {
-    it(`should correctly get the defaultValue for ${type}`, () => {
+    it(`should correctly get the defaultValue for ${type.constructor.name}`, () => {
       const actual = type.defaultValue();
       expect(type.equals(actual, expected));
     });

--- a/test/unit/deserialize.test.ts
+++ b/test/unit/deserialize.test.ts
@@ -64,7 +64,7 @@ describe("deserialize", () => {
     },
   ];
   for (const {type, value, expected} of testCases) {
-    it(`should correctly deserialize ${type}`, () => {
+    it(`should correctly deserialize ${type.constructor.name}`, () => {
       const actual = type.deserialize(Buffer.from(value, "hex"));
       assert.deepEqual(actual, expected);
     });

--- a/test/unit/equals.test.ts
+++ b/test/unit/equals.test.ts
@@ -58,7 +58,7 @@ describe("equals", () => {
     },
   ];
   for (const {type, value1, value2, expected} of testCases) {
-    it(`should correctly perform equal for ${type}`, () => {
+    it(`should correctly perform equal for ${type.constructor.name}`, () => {
       const actual = type.equals(value1, value2);
       expect(actual).to.equal(expected);
     });

--- a/test/unit/hashTreeRoot.test.ts
+++ b/test/unit/hashTreeRoot.test.ts
@@ -48,7 +48,7 @@ describe("hashTreeRoot", () => {
     {value: [], type: ArrayObject2, expected: ""},
   ];
   for (const {type, value} of testCases) {
-    it(`should correctly hash ${type}`, () => {
+    it(`should correctly hash ${type.constructor.name}`, () => {
       const actual = Buffer.from(type.hashTreeRoot(value)).toString("hex");
       assert(actual);
     });

--- a/test/unit/serialize.test.ts
+++ b/test/unit/serialize.test.ts
@@ -57,7 +57,7 @@ describe("serialize", () => {
     {value: [], type: ArrayObject2, expected: ""},
   ];
   for (const {type, value, expected} of testCases) {
-    it(`should correctly serialize ${type}`, () => {
+    it(`should correctly serialize ${type.constructor.name}`, () => {
       const actual = Buffer.from(type.serialize(value)).toString("hex");
       assert.equal(actual, expected);
     });


### PR DESCRIPTION
In test logs print
```
should correctly serialize ByteVectorType
```
instead of 
```
should correctly serialize [object Object]
```