### PR TITLE
Fix structural bitlist/bitvector hashtreeroot

### DIFF
--- a/src/backings/structural/bitList.ts
+++ b/src/backings/structural/bitList.ts
@@ -77,7 +77,7 @@ export class BitListStructuralHandler extends BasicListStructuralHandler<BitList
   }
   chunk(value: BitList, index: number): Uint8Array {
     const output = new Uint8Array(32);
-    const byteLength = Math.min(32, this.getByteLength(value) - index);
+    const byteLength = Math.min(32, this.getByteLength(value) - index * 32);
     for (let i = 0; i < byteLength; i++) {
       output[i] = this.getByte(value, i + index);
     }

--- a/test/unit/errors.test.ts
+++ b/test/unit/errors.test.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import { describe, it } from "mocha";
 
 import { ArrayObject } from "./objects";
+import { Type, BitListType, toHexString } from "../../src";
 
 describe.skip("deserialize errors", () => {
   const testCases: {
@@ -21,6 +22,26 @@ describe.skip("deserialize errors", () => {
   for (const { type, value, error } of testCases) {
     it(`should correctly deserialize ${type.constructor.name}`, () => {
       expect(() => type.deserialize(Buffer.from(value, "hex"))).to.throw(error);
+    });
+  }
+});
+
+describe("hashTreeRoot errors", () => {
+  const testCases: {
+    value: string;
+    type: Type<any>;
+    hashTreeRoot: string;
+  }[] = [
+    {
+      value: "0xf77affff03",
+      type: new BitListType({limit: 2048}),
+      hashTreeRoot: "0x499ef8f795abb77b12d2ce58570e6c7660c93575eba6332ad4913f2cd3e21391",
+    },
+  ];
+  for (const { type, value, hashTreeRoot } of testCases) {
+    it(`should correctly hashTreeRoot ${type.constructor.name}`, () => {
+      const v = type.fromJson(value)
+      expect(toHexString(type.hashTreeRoot(v))).to.equal(hashTreeRoot);
     });
   }
 });


### PR DESCRIPTION
See https://discordapp.com/channels/593655374469660673/593655641445367808/730567234719842345
Included testcase, fails before, success now.

The `chunk` method is used in the structural backing case to retrieve the merkle "chunk" at a certain chunk index.
In the bitlist/bitvector structural code, we mistakenly assume the `index` is the byte index, rather than the chunk index.