### PR TITLE
Fix start param validation case

### DIFF
--- a/src/backings/structural/abstract.ts
+++ b/src/backings/structural/abstract.ts
@@ -44,7 +44,7 @@ export class StructuralHandler<T extends object> {
     if (start < 0) {
       throw new Error(`Start param is negative: ${start}`);
     }
-    if (start >= data.length) {
+    if (start > data.length) {
       throw new Error(`Start param: ${start} is greater than length: ${data.length}`);
     }
     if (end < 0) {


### PR DESCRIPTION
Start param should error if it is `>` data.length, not `>=`.