### PR TITLE
Fix bitlist/bitvector validation

### DIFF
--- a/src/backings/structural/list.ts
+++ b/src/backings/structural/list.ts
@@ -23,7 +23,7 @@ export class BasicListStructuralHandler<T extends List<unknown>> extends BasicAr
   }
   validateBytes(data: Uint8Array, start: number, end: number): void {
     super.validateBytes(data, start, end);
-    if ((end - start) / this._type.elementType.size() > this._type.limit) {
+    if (end - start > this.maxSize()) {
       throw new Error("Deserialized list length greater than limit");
     }
   }

--- a/src/backings/structural/vector.ts
+++ b/src/backings/structural/vector.ts
@@ -25,7 +25,7 @@ export class BasicVectorStructuralHandler<T extends Vector<unknown>> extends Bas
   }
   validateBytes(data: Uint8Array, start: number, end: number): void {
     super.validateBytes(data, start, end);
-    if ((end - start) / this._type.elementType.size() !== this._type.length) {
+    if (end - start !== this.size(null)) {
       throw new Error("Incorrect deserialized vector length");
     }
   }


### PR DESCRIPTION
Due to https://github.com/ChainSafe/ssz/issues/49 we missed several issues that resulted in spec test failures.
This resolves the immediate issue, namely the validation for bitlist/bitvector incorrectly assumed the bytelength of the serialized form based on the `size` of the array's elementType. In the bitlist/bitvector case, the elementType is a BooleanType, with size of 1 (byte), wheras in bitlists, booleans are treated specially, and bitpacked.