### PR TITLE
read-only tree iteration

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@chainsafe/as-sha256": "^0.2.0",
-    "@chainsafe/persistent-merkle-tree": "^0.1.3",
+    "@chainsafe/persistent-merkle-tree": "^0.2.0",
     "case": "^1.6.3"
   },
   "devDependencies": {

--- a/src/backings/index.ts
+++ b/src/backings/index.ts
@@ -3,3 +3,4 @@ export * from "./structural";
 export * from "./tree";
 export * from "./byteArray";
 export * from "./backedValue";
+export * from "./readOnlyIterate";

--- a/src/backings/readOnlyIterate.ts
+++ b/src/backings/readOnlyIterate.ts
@@ -1,0 +1,25 @@
+import {ArrayLike} from "../interface";
+
+export function readOnlyForEach<T>(value: ArrayLike<T>, fn: (value: T, index: number) => void): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((value as any).readOnlyForEach) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (value as any).readOnlyForEach(fn);
+  } else {
+    value.forEach(fn);
+  }
+}
+
+export function readOnlyMap<T, U>(value: ArrayLike<T>, fn: (value: T, index: number) => U): U[] {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if ((value as any).readOnlyMap) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return (value as any).readOnlyMap(fn);
+  } else {
+    const result: U[] = [];
+    value.forEach((v: T, index: number): void => {
+      result.push(fn(v, index));
+    });
+    return result;
+  }
+}

--- a/src/backings/readOnlyIterate.ts
+++ b/src/backings/readOnlyIterate.ts
@@ -1,23 +1,27 @@
 import {ArrayLike} from "../interface";
 
-export function readOnlyForEach<T>(value: ArrayLike<T>, fn: (value: T, index: number) => void): void {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if ((value as any).readOnlyForEach) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (value as any).readOnlyForEach(fn);
+export type ForEachFn<T> = (value: T, index: number) => void;
+export type MapFn<T, U> = (value: T, index: number) => U;
+
+export type ReadOnlyIterable<T> = {
+  readOnlyForEach(fn: ForEachFn<T>): void;
+  readOnlyMap<U>(fn: MapFn<T, U>): U[];
+};
+
+export function readOnlyForEach<T>(value: ArrayLike<T> | ReadOnlyIterable<T>, fn: ForEachFn<T>): void {
+  if ((value as ReadOnlyIterable<T>).readOnlyForEach) {
+    (value as ReadOnlyIterable<T>).readOnlyForEach(fn);
   } else {
-    value.forEach(fn);
+    (value as ArrayLike<T>).forEach(fn);
   }
 }
 
-export function readOnlyMap<T, U>(value: ArrayLike<T>, fn: (value: T, index: number) => U): U[] {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  if ((value as any).readOnlyMap) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (value as any).readOnlyMap(fn);
+export function readOnlyMap<T, U>(value: ArrayLike<T> | ReadOnlyIterable<T>, fn: MapFn<T, U>): U[] {
+  if ((value as ReadOnlyIterable<T>).readOnlyMap) {
+    return (value as ReadOnlyIterable<T>).readOnlyMap(fn);
   } else {
     const result: U[] = [];
-    value.forEach((v: T, index: number): void => {
+    (value as ArrayLike<T>).forEach((v: T, index: number): void => {
       result.push(fn(v, index));
     });
     return result;

--- a/src/backings/tree/abstract.ts
+++ b/src/backings/tree/abstract.ts
@@ -240,7 +240,7 @@ export class TreeHandler<T extends object> implements ProxyHandler<T> {
     return this._depth;
   }
   gindexOfChunk(target: Tree, index: number): Gindex {
-    return toGindex(BigInt(index), this.depth());
+    return toGindex(this.depth(), BigInt(index));
   }
   getSubtreeAtChunk(target: Tree, index: number): Tree {
     return target.getSubtree(this.gindexOfChunk(target, index));

--- a/src/backings/tree/array.ts
+++ b/src/backings/tree/array.ts
@@ -161,17 +161,21 @@ export class CompositeArrayTreeHandler<T extends ArrayLike<object>> extends Tree
     if (this._type.elementType.isVariableSize()) {
       let variableIndex = offset + length * 4;
       const fixedSection = new DataView(output.buffer, output.byteOffset + offset, length * 4);
-      for (let i = 0; i < length; i++) {
+      let i = 0;
+      for (const node of target.iterateNodesAtDepth(this.depth(), i, length)) {
         // write offset
         fixedSection.setUint32(i * 4, variableIndex - offset, true);
         // write serialized element to variable section
-        variableIndex = this._type.elementType.tree.toBytes(this.getSubtreeAtChunk(target, i), output, variableIndex);
+        variableIndex = this._type.elementType.tree.toBytes(new Tree(node), output, variableIndex);
+        i++;
       }
       return variableIndex;
     } else {
       let index = offset;
-      for (let i = 0; i < length; i++) {
-        index = this._type.elementType.tree.toBytes(this.getSubtreeAtChunk(target, i), output, index);
+      let i = 0;
+      for (const node of target.iterateNodesAtDepth(this.depth(), i, length)) {
+        index = this._type.elementType.tree.toBytes(new Tree(node), output, index);
+        i++;
       }
       return index;
     }

--- a/src/backings/tree/array.ts
+++ b/src/backings/tree/array.ts
@@ -222,7 +222,7 @@ export class CompositeArrayTreeHandler<T extends ArrayLike<object>> extends Tree
   }
   *[Symbol.iterator](target: Tree): Iterable<PropOfCompositeTreeBacked<T, number>> {
     const elementTreeHandler = this._type.elementType.tree;
-    for (const gindex of iterateAtDepth(BigInt(0), BigInt(this.getLength(target)), this.depth())) {
+    for (const gindex of iterateAtDepth(this.depth(), BigInt(0), BigInt(this.getLength(target)))) {
       yield elementTreeHandler.asTreeBacked(target.getSubtree(gindex)) as PropOfCompositeTreeBacked<T, number>;
     }
   }
@@ -233,7 +233,7 @@ export class CompositeArrayTreeHandler<T extends ArrayLike<object>> extends Tree
     const value = this.asTreeBacked(target);
     const elementTreeHandler = this._type.elementType.tree;
     let i = 0;
-    for (const gindex of iterateAtDepth(BigInt(0), BigInt(this.getLength(target)), this.depth())) {
+    for (const gindex of iterateAtDepth(this.depth(), BigInt(0), BigInt(this.getLength(target)))) {
       const elementValue = elementTreeHandler.asTreeBacked(target.getSubtree(gindex)) as PropOfCompositeTreeBacked<
         T,
         number
@@ -252,7 +252,7 @@ export class CompositeArrayTreeHandler<T extends ArrayLike<object>> extends Tree
     const value = this.asTreeBacked(target);
     const elementTreeHandler = this._type.elementType.tree;
     let i = 0;
-    for (const gindex of iterateAtDepth(BigInt(0), BigInt(this.getLength(target)), this.depth())) {
+    for (const gindex of iterateAtDepth(this.depth(), BigInt(0), BigInt(this.getLength(target)))) {
       const elementValue = elementTreeHandler.asTreeBacked(target.getSubtree(gindex)) as PropOfCompositeTreeBacked<
         T,
         number
@@ -268,7 +268,7 @@ export class CompositeArrayTreeHandler<T extends ArrayLike<object>> extends Tree
     const value = this.asTreeBacked(target);
     const elementTreeHandler = this._type.elementType.tree;
     let i = 0;
-    for (const gindex of iterateAtDepth(BigInt(0), BigInt(this.getLength(target)), this.depth())) {
+    for (const gindex of iterateAtDepth(this.depth(), BigInt(0), BigInt(this.getLength(target)))) {
       const elementValue = elementTreeHandler.asTreeBacked(target.getSubtree(gindex)) as PropOfCompositeTreeBacked<
         T,
         number

--- a/src/backings/tree/array.ts
+++ b/src/backings/tree/array.ts
@@ -42,13 +42,17 @@ export class BasicArrayTreeHandler<T extends ArrayLike<unknown>> extends TreeHan
   }
   toBytes(target: Tree, output: Uint8Array, offset: number): number {
     const size = this.size(target);
+    const fullChunkCount = Math.floor(size / 32);
+    const remainder = size % 32;
     let i = 0;
-    let chunkIndex = 0;
-    for (; i < size - 31; i += 32, chunkIndex += 1) {
-      output.set(this.getRootAtChunk(target, chunkIndex), offset + i);
+    if (fullChunkCount > 0) {
+      for (const node of target.iterateNodesAtDepth(this.depth(), 0, fullChunkCount)) {
+        output.set(node.root, offset + i * 32);
+        i++;
+      }
     }
-    if (i !== size) {
-      output.set(this.getRootAtChunk(target, chunkIndex).slice(0, size - i), offset + i);
+    if (remainder) {
+      output.set(this.getRootAtChunk(target, fullChunkCount).slice(0, remainder), offset + i * 32);
     }
     return offset + size;
   }

--- a/src/backings/tree/bitList.ts
+++ b/src/backings/tree/bitList.ts
@@ -83,4 +83,34 @@ export class BitListTreeHandler extends BasicListTreeHandler<BitList> {
     target.setRoot(chunkGindex, chunk, expand);
     return true;
   }
+  readOnlyForEach(target: Tree, fn: (value: unknown, index: number) => void): void {
+    const length = this.getLength(target);
+    const elementsPerChunk = 256;
+    let i = 0;
+    for (const node of target.iterateNodesAtDepth(this.depth(), 0, Math.ceil(length / elementsPerChunk))) {
+      const chunk = node.root;
+      for (let j = 0; j < elementsPerChunk && i < length; j++) {
+        const byte = chunk[this.getChunkOffset(i)];
+        const elementValue = !!(byte & (1 << this.getBitOffset(i)));
+        fn(elementValue, i);
+        i++;
+      }
+    }
+  }
+  readOnlyMap<T>(target: Tree, fn: (value: unknown, index: number) => T): T[] {
+    const length = this.getLength(target);
+    const elementsPerChunk = 256;
+    const result: T[] = [];
+    let i = 0;
+    for (const node of target.iterateNodesAtDepth(this.depth(), 0, Math.ceil(length / elementsPerChunk))) {
+      const chunk = node.root;
+      for (let j = 0; j < elementsPerChunk && i < length; j++) {
+        const byte = chunk[this.getChunkOffset(i)];
+        const elementValue = !!(byte & (1 << this.getBitOffset(i)));
+        result.push(fn(elementValue, i));
+        i++;
+      }
+    }
+    return result;
+  }
 }

--- a/src/backings/tree/bitVector.ts
+++ b/src/backings/tree/bitVector.ts
@@ -52,4 +52,34 @@ export class BitVectorTreeHandler extends BasicVectorTreeHandler<BitVector> {
     target.setRoot(chunkGindex, chunk);
     return true;
   }
+  readOnlyForEach(target: Tree, fn: (value: unknown, index: number) => void): void {
+    const length = this.getLength(target);
+    const elementsPerChunk = 256;
+    let i = 0;
+    for (const node of target.iterateNodesAtDepth(this.depth(), 0, Math.ceil(length / elementsPerChunk))) {
+      const chunk = node.root;
+      for (let j = 0; j < elementsPerChunk && i < length; j++) {
+        const byte = chunk[this.getChunkOffset(i)];
+        const elementValue = !!(byte & (1 << this.getBitOffset(i)));
+        fn(elementValue, i);
+        i++;
+      }
+    }
+  }
+  readOnlyMap<T>(target: Tree, fn: (value: unknown, index: number) => T): T[] {
+    const length = this.getLength(target);
+    const elementsPerChunk = 256;
+    const result: T[] = [];
+    let i = 0;
+    for (const node of target.iterateNodesAtDepth(this.depth(), 0, Math.ceil(length / elementsPerChunk))) {
+      const chunk = node.root;
+      for (let j = 0; j < elementsPerChunk && i < length; j++) {
+        const byte = chunk[this.getChunkOffset(i)];
+        const elementValue = !!(byte & (1 << this.getBitOffset(i)));
+        result.push(fn(elementValue, i));
+        i++;
+      }
+    }
+    return result;
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -799,10 +799,10 @@
     "@assemblyscript/loader" "^0.9.2"
     buffer "^5.4.3"
 
-"@chainsafe/persistent-merkle-tree@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.1.3.tgz#95d16f5faefc4d75f2861859ec5474f34767a4f7"
-  integrity sha512-ZFu7Zoxjt1A9W5whMVlwWJ+dGMF6+iL99lI9g7kIaG1JbI37M0F4TszO5Fe758e6/XJdGl5SFLi+923JYVB/ow==
+"@chainsafe/persistent-merkle-tree@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.2.0.tgz#2b00ea7e18ec9440af54082abe8a596c7ec1135d"
+  integrity sha512-gOxAuUx0FAH0lZm4jDzUJOiFoIpug+SLnd1cumz1i/EdZlmcFIN0YEdqPq+HhN/4/qWhnJs52bY8pum82KMMaA==
   dependencies:
     "@chainsafe/as-sha256" "^0.2.0"
 


### PR DESCRIPTION
Depends on chainsafe/persistent-merkle-tree#13 and subsequent release

- Update persistent-merkle-tree usage (`toGindex`, `iterateAtDepth` param order change)
- Use `Tree#iterateNodesAtDepth` in tree-backing `toBytes`
- Add `readOnlyForEach` and `readOnlyMap` methods and helper functions