### PR TITLE
Optimize fromStructural, use subtreeFillToContents

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@chainsafe/as-sha256": "^0.2.0",
-    "@chainsafe/persistent-merkle-tree": "^0.2.0",
+    "@chainsafe/persistent-merkle-tree": "^0.2.1",
     "case": "^1.6.3"
   },
   "devDependencies": {

--- a/src/backings/tree/list.ts
+++ b/src/backings/tree/list.ts
@@ -20,6 +20,11 @@ export class BasicListTreeHandler<T extends List<unknown>> extends BasicArrayTre
   defaultBacking(): Tree {
     return new Tree(this.defaultNode());
   }
+  fromStructural(value: T): Tree {
+    const tree = super.fromStructural(value);
+    this.setLength(tree, value.length);
+    return tree;
+  }
   getLength(target: Tree): number {
     return number32Type.fromBytes(target.getRoot(BigInt(3)), 0);
   }
@@ -101,6 +106,11 @@ export class CompositeListTreeHandler<T extends List<object>> extends CompositeA
   }
   defaultBacking(): Tree {
     return new Tree(this.defaultNode());
+  }
+  fromStructural(value: T): Tree {
+    const tree = super.fromStructural(value);
+    this.setLength(tree, value.length);
+    return tree;
   }
   getLength(target: Tree): number {
     return number32Type.fromBytes(target.getRoot(BigInt(3)), 0);

--- a/yarn.lock
+++ b/yarn.lock
@@ -799,10 +799,10 @@
     "@assemblyscript/loader" "^0.9.2"
     buffer "^5.4.3"
 
-"@chainsafe/persistent-merkle-tree@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.2.0.tgz#2b00ea7e18ec9440af54082abe8a596c7ec1135d"
-  integrity sha512-gOxAuUx0FAH0lZm4jDzUJOiFoIpug+SLnd1cumz1i/EdZlmcFIN0YEdqPq+HhN/4/qWhnJs52bY8pum82KMMaA==
+"@chainsafe/persistent-merkle-tree@^0.2.1":
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.2.1.tgz#38eb5fd5772fd256e94639d0621fa606addebab1"
+  integrity sha512-07Hi5QiogeTuwNiZXxg7PQnwNyEqV3ArfITpEloGJ8JVOHxQ2Tha1fo4oNBF54628vTDMcDpMVFGrfnIMsQnxg==
   dependencies:
     "@chainsafe/as-sha256" "^0.2.0"
 


### PR DESCRIPTION
~Depends on https://github.com/ChainSafe/persistent-merkle-tree/pull/15 and subsequent release~

`fromStructural` is the method to convert structural objects to tree objects

Previously, `fromStructural` has the following strategy:
- create a default tree, loop thru the structural values, setting each sub-value to each place in the tree

Now:
- loop thru the structural values, creating an array of leaf nodes, create a tree from the leaf nodes

This new approach is significantly faster, as it avoids navigation thru the tree + rebinding nodes for each sub-value.