### PR TITLE
Add readOnlyEntries

### DIFF
--- a/src/backings/readOnlyIterate.ts
+++ b/src/backings/readOnlyIterate.ts
@@ -1,4 +1,4 @@
-import {ArrayLike} from "../interface";
+import {ArrayLike, ObjectLike} from "../interface";
 
 export type ForEachFn<T> = (value: T, index: number) => void;
 export type MapFn<T, U> = (value: T, index: number) => U;
@@ -6,6 +6,10 @@ export type MapFn<T, U> = (value: T, index: number) => U;
 export type ReadOnlyIterable<T> = {
   readOnlyForEach(fn: ForEachFn<T>): void;
   readOnlyMap<U>(fn: MapFn<T, U>): U[];
+};
+
+export type ReadOnlyObjectIterable<T> = {
+  readOnlyEntries(): [string, T[keyof T]][];
 };
 
 export function readOnlyForEach<T>(value: ArrayLike<T> | ReadOnlyIterable<T>, fn: ForEachFn<T>): void {
@@ -25,5 +29,13 @@ export function readOnlyMap<T, U>(value: ArrayLike<T> | ReadOnlyIterable<T>, fn:
       result.push(fn(v, index));
     });
     return result;
+  }
+}
+
+export function readOnlyEntries<T>(value: ObjectLike | ReadOnlyObjectIterable<T>): [string, T[keyof T]][] {
+  if ((value as ReadOnlyObjectIterable<T>).readOnlyEntries) {
+    return (value as ReadOnlyObjectIterable<T>).readOnlyEntries();
+  } else {
+    return Object.entries(value as ObjectLike);
   }
 }

--- a/src/backings/tree/container.ts
+++ b/src/backings/tree/container.ts
@@ -182,4 +182,20 @@ export class ContainerTreeHandler<T extends ObjectLike> extends TreeHandler<T> {
       return undefined;
     }
   }
+  readOnlyEntries(target: Tree): [string, T[keyof T]][] {
+    const entries: [string, T[keyof T]][] = [];
+    const fields = Object.entries(this._type.fields);
+    let i = 0;
+    for (const node of target.iterateNodesAtDepth(this.depth(), 0, fields.length)) {
+      const [fieldName, fieldType] = fields[i];
+      if (fieldType.isBasic()) {
+        const s = fieldType.size();
+        entries.push([fieldName, fieldType.fromBytes(node.root.slice(0, s), 0)]);
+      } else {
+        entries.push([fieldName, fieldType.tree.asTreeBacked(new Tree(node))]);
+      }
+      i++;
+    }
+    return entries;
+  }
 }


### PR DESCRIPTION
Iterate at depth through a container, expose an `Object.entries`-like interface.