### PR TITLE
Add methods to obtain generalized index of a type

### DIFF
--- a/src/backings/tree/abstract.ts
+++ b/src/backings/tree/abstract.ts
@@ -226,10 +226,6 @@ export class TreeHandler<T extends object> implements ProxyHandler<T> {
   }
 
   // Merkleization
-
-  gindexOfProperty(target: Tree, prop: PropertyKey): Gindex {
-    throw new Error("Not implemented");
-  }
   /**
    * The depth of the merkle tree
    */

--- a/src/types/basic/abstract.ts
+++ b/src/types/basic/abstract.ts
@@ -100,8 +100,8 @@ export class BasicType<T> {
     return this.size();
   }
 
-  getGeneralizedIndex(rootIndex: number, ...path: GIndexPathKeys[]): number {
-    if (path.length !== 0) {
+  getGeneralizedIndex(pathParts: GIndexPathKeys[], rootIndex = 1): number {
+    if (pathParts.length !== 0) {
       throw new Error("Cannot iterate deeper than basic type");
     }
     return rootIndex;

--- a/src/types/basic/abstract.ts
+++ b/src/types/basic/abstract.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import {Json} from "../../interface";
+import {FULL_HASH_LENGTH, GIndexPathKeys} from "../../util/gIndex";
+import {getPowerOfTwoCeil} from "../../util/math";
 
 /**
  * Check if `type` is an instance of `typeSymbol` type
@@ -81,6 +83,28 @@ export class BasicType<T> {
    */
   size(): number {
     throw new Error("Not implemented");
+  }
+
+  /**
+   * Return the number of hashes needed to represent the top-level elements in the given type.
+   * Always 1 for basic types
+   */
+  chunkCount(): number {
+    return 1;
+  }
+
+  /**
+   * Return the number of bytes in a basic type
+   */
+  getItemLength(): number {
+    return this.size();
+  }
+
+  getGeneralizedIndex(rootIndex: number, ...path: GIndexPathKeys[]): number {
+    if (path.length !== 0) {
+      throw new Error("Cannot iterate deeper than basic type");
+    }
+    return rootIndex;
   }
 
   /**

--- a/src/types/composite/abstract.ts
+++ b/src/types/composite/abstract.ts
@@ -3,6 +3,7 @@ import {Json} from "../../interface";
 import {BackedValue, ByteArrayHandler, isBackedValue, StructuralHandler, TreeHandler} from "../../backings";
 import {BasicType} from "../basic";
 import {IJsonOptions} from "../type";
+import {FULL_HASH_LENGTH, GIndexPathKeys} from "../../util/gIndex";
 
 /**
  * A CompositeType is a type containing other types, and is flexible in its representation.
@@ -136,11 +137,44 @@ export class CompositeType<T extends object> {
   // Merkleization
 
   /**
+   * Return the number of bytes in a basic type
+   */
+  getItemLength(): number {
+    return FULL_HASH_LENGTH;
+  }
+
+  /**
    * Return the number of leaf chunks to be merkleized
    */
   chunkCount(): number {
     throw new Error("Not implemented");
   }
+
+  /**
+   * Return three variables:
+   *     (i) the index of the chunk in which the given element of the item is represented;
+   *     (ii) the starting byte position within the chunk;
+   *     (iii) the ending byte position within the chunk.
+   * For example: for a 6-item list of uint64 values, index=2 will return (0, 16, 24), index=5 will return (1, 8, 16)
+   */
+  getItemPosition(indexOrPropertyNAme: number | string): [number, number, number] {
+    throw new Error("Not implemented");
+    // const start = index * this.getItemLength();
+    // return [
+    //   Math.floor(start / FULL_HASH_LENGTH),
+    //   start % FULL_HASH_LENGTH,
+    //   (start % FULL_HASH_LENGTH) + this.getItemLength(),
+    // ];
+  }
+
+  /**
+   * Converts a path (eg. `[7, "foo", 3]` for `x[7].foo[3]`, `[12, "bar", "__len__"]` for
+   * `len(x[12].bar)`) into the generalized index representing its position in the Merkle tree.
+   */
+  getGeneralizedIndex(root = 1, ...paths: GIndexPathKeys[]): number {
+    throw new Error("Not implemented");
+  }
+
   /**
    * Merkleization
    */

--- a/src/types/composite/abstract.ts
+++ b/src/types/composite/abstract.ts
@@ -166,7 +166,7 @@ export class CompositeType<T extends object> {
    * Converts a path (eg. `[7, "foo", 3]` for `x[7].foo[3]`, `[12, "bar", "__len__"]` for
    * `len(x[12].bar)`) into the generalized index representing its position in the Merkle tree.
    */
-  getGeneralizedIndex(root = 1, ...paths: GIndexPathKeys[]): number {
+  getGeneralizedIndex(pathParts: GIndexPathKeys[], rootIndex = 1): number {
     // requires implementation in child classes
     throw new Error("Not implemented");
   }

--- a/src/types/composite/abstract.ts
+++ b/src/types/composite/abstract.ts
@@ -158,13 +158,8 @@ export class CompositeType<T extends object> {
    * For example: for a 6-item list of uint64 values, index=2 will return (0, 16, 24), index=5 will return (1, 8, 16)
    */
   getItemPosition(indexOrPropertyNAme: number | string): [number, number, number] {
+    // requires implementation in child classes
     throw new Error("Not implemented");
-    // const start = index * this.getItemLength();
-    // return [
-    //   Math.floor(start / FULL_HASH_LENGTH),
-    //   start % FULL_HASH_LENGTH,
-    //   (start % FULL_HASH_LENGTH) + this.getItemLength(),
-    // ];
   }
 
   /**
@@ -172,6 +167,7 @@ export class CompositeType<T extends object> {
    * `len(x[12].bar)`) into the generalized index representing its position in the Merkle tree.
    */
   getGeneralizedIndex(root = 1, ...paths: GIndexPathKeys[]): number {
+    // requires implementation in child classes
     throw new Error("Not implemented");
   }
 

--- a/src/types/composite/abstract.ts
+++ b/src/types/composite/abstract.ts
@@ -4,6 +4,7 @@ import {BackedValue, ByteArrayHandler, isBackedValue, StructuralHandler, TreeHan
 import {BasicType} from "../basic";
 import {IJsonOptions} from "../type";
 import {FULL_HASH_LENGTH, GIndexPathKeys} from "../../util/gIndex";
+import { Gindex } from "@chainsafe/persistent-merkle-tree";
 
 /**
  * A CompositeType is a type containing other types, and is flexible in its representation.
@@ -166,7 +167,7 @@ export class CompositeType<T extends object> {
    * Converts a path (eg. `[7, "foo", 3]` for `x[7].foo[3]`, `[12, "bar", "__len__"]` for
    * `len(x[12].bar)`) into the generalized index representing its position in the Merkle tree.
    */
-  getGeneralizedIndex(pathParts: GIndexPathKeys[], rootIndex = 1): number {
+  getGeneralizedIndex(pathParts: GIndexPathKeys[], rootIndex = BigInt(1)): Gindex {
     // requires implementation in child classes
     throw new Error("Not implemented");
   }

--- a/src/types/composite/bitList.ts
+++ b/src/types/composite/bitList.ts
@@ -20,7 +20,8 @@ export class BitListType extends BasicListType<BitList> {
     this.tree = new BitListTreeHandler(this);
     this._typeSymbols.add(BITLIST_TYPE);
   }
+
   chunkCount(): number {
-    return Math.ceil(this.limit / 256);
+    return Math.ceil((this.limit + 255) / 256);
   }
 }

--- a/src/types/composite/bitVector.ts
+++ b/src/types/composite/bitVector.ts
@@ -21,6 +21,6 @@ export class BitVectorType extends BasicVectorType<BitVector> {
     this._typeSymbols.add(BITVECTOR_TYPE);
   }
   chunkCount(): number {
-    return Math.ceil(this.length / 256);
+    return Math.ceil((this.length + 255) / 256);
   }
 }

--- a/src/types/composite/container.ts
+++ b/src/types/composite/container.ts
@@ -59,6 +59,6 @@ export class ContainerType<T extends ObjectLike = ObjectLike> extends CompositeT
     const [pos] = this.getItemPosition(path);
     const baseIndex = 1;
     root = root * baseIndex * getPowerOfTwoCeil(this.chunkCount()) + pos;
-    return this.fields[path].getGeneralizedIndex(root, ...path.slice(1));
+    return this.fields[path].getGeneralizedIndex(root, ...paths.slice(1));
   }
 }

--- a/src/types/composite/container.ts
+++ b/src/types/composite/container.ts
@@ -45,11 +45,11 @@ export class ContainerType<T extends ObjectLike = ObjectLike> extends CompositeT
     return [pos, 0, this.fields[propertyName].getItemLength()];
   }
 
-  getGeneralizedIndex(root = 1, ...paths: GIndexPathKeys[]): number {
-    if (paths.length === 0) {
-      return root;
+  getGeneralizedIndex(pathParts: GIndexPathKeys[], rootIndex = 1): number {
+    if (pathParts.length === 0) {
+      return rootIndex;
     }
-    const path = paths[0];
+    const path = pathParts[0];
     if (typeof path !== "string" || path === GINDEX_LEN_PATH) {
       throw new Error(`Unsupported path ${path} in container`);
     }
@@ -58,7 +58,7 @@ export class ContainerType<T extends ObjectLike = ObjectLike> extends CompositeT
     }
     const [pos] = this.getItemPosition(path);
     const baseIndex = 1;
-    root = root * baseIndex * getPowerOfTwoCeil(this.chunkCount()) + pos;
-    return this.fields[path].getGeneralizedIndex(root, ...paths.slice(1));
+    rootIndex = rootIndex * baseIndex * getPowerOfTwoCeil(this.chunkCount()) + pos;
+    return this.fields[path].getGeneralizedIndex(pathParts.slice(1), rootIndex);
   }
 }

--- a/src/types/composite/container.ts
+++ b/src/types/composite/container.ts
@@ -1,12 +1,14 @@
+import {ContainerByteArrayHandler, ContainerStructuralHandler, ContainerTreeHandler} from "../../backings";
 import {ObjectLike} from "../../interface";
-import {CompositeType} from "./abstract";
+import {GIndexPathKeys, GINDEX_LEN_PATH} from "../../util/gIndex";
+import {getPowerOfTwoCeil} from "../../util/math";
 import {isTypeOf} from "../basic";
 import {Type} from "../type";
-import {ContainerStructuralHandler, ContainerTreeHandler, ContainerByteArrayHandler} from "../../backings";
+import {CompositeType} from "./abstract";
 
-export interface IContainerOptions {
+export interface IContainerOptions<T extends ObjectLike = ObjectLike> {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fields: Record<string, Type<any>>;
+  fields: Record<keyof T, Type<any>>;
 }
 
 export const CONTAINER_TYPE = Symbol.for("ssz/ContainerType");
@@ -14,12 +16,11 @@ export const CONTAINER_TYPE = Symbol.for("ssz/ContainerType");
 export function isContainerType<T extends ObjectLike = ObjectLike>(type: unknown): type is ContainerType<T> {
   return isTypeOf(type, CONTAINER_TYPE);
 }
-
 export class ContainerType<T extends ObjectLike = ObjectLike> extends CompositeType<T> {
   // ES6 ensures key order is chronological
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  fields: Record<string, Type<any>>;
-  constructor(options: IContainerOptions) {
+  fields: Record<keyof T, Type<any>>;
+  constructor(options: IContainerOptions<T>) {
     super();
     this.fields = {...options.fields};
     this.structural = new ContainerStructuralHandler(this);
@@ -27,10 +28,37 @@ export class ContainerType<T extends ObjectLike = ObjectLike> extends CompositeT
     this.byteArray = new ContainerByteArrayHandler(this);
     this._typeSymbols.add(CONTAINER_TYPE);
   }
+
   isVariableSize(): boolean {
     return Object.values(this.fields).some((fieldType) => fieldType.isVariableSize());
   }
+
   chunkCount(): number {
     return Object.keys(this.fields).length;
+  }
+
+  getItemPosition(propertyName: keyof T): [number, number, number] {
+    const pos = Object.keys(this.fields).indexOf(propertyName as string);
+    if (pos === -1) {
+      throw new Error(`Property ${propertyName} doesn't exists on container`);
+    }
+    return [pos, 0, this.fields[propertyName].getItemLength()];
+  }
+
+  getGeneralizedIndex(root = 1, ...paths: GIndexPathKeys[]): number {
+    if (paths.length === 0) {
+      return root;
+    }
+    const path = paths[0];
+    if (typeof path !== "string" || path === GINDEX_LEN_PATH) {
+      throw new Error(`Unsupported path ${path} in container`);
+    }
+    if (!this.fields[path]) {
+      throw new Error(`Property ${path} doesn't exists on container.`);
+    }
+    const [pos] = this.getItemPosition(path);
+    const baseIndex = 1;
+    root = root * baseIndex * getPowerOfTwoCeil(this.chunkCount()) + pos;
+    return this.fields[path].getGeneralizedIndex(root, ...path.slice(1));
   }
 }

--- a/src/types/composite/list.ts
+++ b/src/types/composite/list.ts
@@ -1,16 +1,16 @@
-import {List} from "../../interface";
-import {IArrayOptions, BasicArrayType, CompositeArrayType} from "./array";
-import {isTypeOf, UINT_TYPE} from "../basic";
-import {ArrayElement, FULL_HASH_LENGTH, GIndexPathKeys, GINDEX_LEN_PATH} from "../../util/gIndex";
-import {getPowerOfTwoCeil} from "../../util/math";
 import {
-  BasicListStructuralHandler,
-  CompositeListStructuralHandler,
-  BasicListTreeHandler,
-  CompositeListTreeHandler,
   BasicListByteArrayHandler,
+  BasicListStructuralHandler,
+  BasicListTreeHandler,
   CompositeListByteArrayHandler,
+  CompositeListStructuralHandler,
+  CompositeListTreeHandler,
 } from "../../backings";
+import {List} from "../../interface";
+import {FULL_HASH_LENGTH, GIndexPathKeys, GINDEX_LEN_PATH} from "../../util/gIndex";
+import {getPowerOfTwoCeil} from "../../util/math";
+import {isTypeOf, UINT_TYPE} from "../basic";
+import {BasicArrayType, CompositeArrayType, IArrayOptions} from "./array";
 
 export interface IListOptions extends IArrayOptions {
   limit: number;

--- a/src/types/composite/list.ts
+++ b/src/types/composite/list.ts
@@ -79,10 +79,10 @@ export class BasicListType<T extends List<unknown> = List<unknown>> extends Basi
         throw new Error(`${GINDEX_LEN_PATH} is only supported on ${UINT_TYPE.toString()} array`);
       }
     }
-    if (typeof path !== "number") {
+    if (isNaN(parseInt(path as string))) {
       throw new Error("Not supported path on BasicList");
     }
-    const [pos] = this.getItemPosition(path);
+    const [pos] = this.getItemPosition(parseInt(path as string));
     const baseIndex = 2;
     root = root * baseIndex * getPowerOfTwoCeil(this.chunkCount()) + pos;
     return this.elementType.getGeneralizedIndex(root, ...paths.slice(1));
@@ -120,9 +120,9 @@ export class CompositeListType<T extends List<object> = List<object>> extends Co
     if (!paths.length) {
       return root;
     }
-    const path = paths[0];
-    if (typeof path !== "number") {
-      throw new Error("CompositeArray supports only element index as path");
+    const path = parseInt(paths[0] as string);
+    if (isNaN(path)) {
+      throw new Error("CompositeArray supports only element index as path. Received " + path);
     }
     const [pos] = this.getItemPosition(path);
     const baseIndex = 2;

--- a/src/types/composite/list.ts
+++ b/src/types/composite/list.ts
@@ -1,6 +1,8 @@
 import {List} from "../../interface";
 import {IArrayOptions, BasicArrayType, CompositeArrayType} from "./array";
-import {isTypeOf} from "../basic";
+import {isTypeOf, UINT_TYPE} from "../basic";
+import {ArrayElement, FULL_HASH_LENGTH, GIndexPathKeys, GINDEX_LEN_PATH} from "../../util/gIndex";
+import {getPowerOfTwoCeil} from "../../util/math";
 import {
   BasicListStructuralHandler,
   CompositeListStructuralHandler,
@@ -53,7 +55,37 @@ export class BasicListType<T extends List<unknown> = List<unknown>> extends Basi
     return true;
   }
   chunkCount(): number {
-    return Math.ceil((this.limit * this.elementType.size()) / 32);
+    return Math.ceil((this.limit * this.elementType.getItemLength()) / 32);
+  }
+
+  getItemPosition(index: number): [number, number, number] {
+    const start = index + this.elementType.getItemLength();
+    return [
+      Math.floor(start / FULL_HASH_LENGTH),
+      start % FULL_HASH_LENGTH,
+      (start % FULL_HASH_LENGTH) + this.elementType.getItemLength(),
+    ];
+  }
+
+  getGeneralizedIndex(root = 1, ...paths: GIndexPathKeys[]): number {
+    if (!paths.length) {
+      return root;
+    }
+    const path = paths[0];
+    if (path === GINDEX_LEN_PATH) {
+      if (this.elementType._typeSymbols.has(UINT_TYPE)) {
+        return root * 2 + 1;
+      } else {
+        throw new Error(`${GINDEX_LEN_PATH} is only supported on ${UINT_TYPE.toString()} array`);
+      }
+    }
+    if (typeof path !== "number") {
+      throw new Error("Not supported path on BasicList");
+    }
+    const [pos] = this.getItemPosition(path);
+    const baseIndex = 2;
+    root = root * baseIndex * getPowerOfTwoCeil(this.chunkCount()) + pos;
+    return this.elementType.getGeneralizedIndex(root, ...paths.slice(1));
   }
 }
 
@@ -70,7 +102,31 @@ export class CompositeListType<T extends List<object> = List<object>> extends Co
   isVariableSize(): boolean {
     return true;
   }
+
   chunkCount(): number {
-    return this.limit;
+    return Math.ceil((this.limit * this.elementType.getItemLength()) / 32);
+  }
+
+  getItemPosition(index: number): [number, number, number] {
+    const start = index + this.elementType.getItemLength();
+    return [
+      Math.floor(start / FULL_HASH_LENGTH),
+      start % FULL_HASH_LENGTH,
+      (start % FULL_HASH_LENGTH) + this.elementType.getItemLength(),
+    ];
+  }
+
+  getGeneralizedIndex(root = 1, ...paths: GIndexPathKeys[]): number {
+    if (!paths.length) {
+      return root;
+    }
+    const path = paths[0];
+    if (typeof path !== "number") {
+      throw new Error("CompositeArray supports only element index as path");
+    }
+    const [pos] = this.getItemPosition(path);
+    const baseIndex = 2;
+    root = root * baseIndex * getPowerOfTwoCeil(this.chunkCount()) + pos;
+    return this.elementType.getGeneralizedIndex(root, ...paths.slice(1));
   }
 }

--- a/src/types/composite/list.ts
+++ b/src/types/composite/list.ts
@@ -67,14 +67,14 @@ export class BasicListType<T extends List<unknown> = List<unknown>> extends Basi
     ];
   }
 
-  getGeneralizedIndex(root = 1, ...paths: GIndexPathKeys[]): number {
-    if (!paths.length) {
-      return root;
+  getGeneralizedIndex(pathParts: GIndexPathKeys[], rootIndex = 1): number {
+    if (pathParts.length === 0) {
+      return rootIndex;
     }
-    const path = paths[0];
+    const path = pathParts[0];
     if (path === GINDEX_LEN_PATH) {
       if (this.elementType._typeSymbols.has(UINT_TYPE)) {
-        return root * 2 + 1;
+        return rootIndex * 2 + 1;
       } else {
         throw new Error(`${GINDEX_LEN_PATH} is only supported on ${UINT_TYPE.toString()} array`);
       }
@@ -84,8 +84,8 @@ export class BasicListType<T extends List<unknown> = List<unknown>> extends Basi
     }
     const [pos] = this.getItemPosition(parseInt(path as string));
     const baseIndex = 2;
-    root = root * baseIndex * getPowerOfTwoCeil(this.chunkCount()) + pos;
-    return this.elementType.getGeneralizedIndex(root, ...paths.slice(1));
+    rootIndex = rootIndex * baseIndex * getPowerOfTwoCeil(this.chunkCount()) + pos;
+    return this.elementType.getGeneralizedIndex(pathParts.slice(1), rootIndex);
   }
 }
 
@@ -116,17 +116,17 @@ export class CompositeListType<T extends List<object> = List<object>> extends Co
     ];
   }
 
-  getGeneralizedIndex(root = 1, ...paths: GIndexPathKeys[]): number {
-    if (!paths.length) {
-      return root;
+  getGeneralizedIndex(pathParts: GIndexPathKeys[], rootIndex = 1): number {
+    if (pathParts.length === 0) {
+      return rootIndex;
     }
-    const path = parseInt(paths[0] as string);
+    const path = parseInt(pathParts[0] as string);
     if (isNaN(path)) {
       throw new Error("CompositeArray supports only element index as path. Received " + path);
     }
     const [pos] = this.getItemPosition(path);
     const baseIndex = 2;
-    root = root * baseIndex * getPowerOfTwoCeil(this.chunkCount()) + pos;
-    return this.elementType.getGeneralizedIndex(root, ...paths.slice(1));
+    rootIndex = rootIndex * baseIndex * getPowerOfTwoCeil(this.chunkCount()) + pos;
+    return this.elementType.getGeneralizedIndex(pathParts.slice(1), rootIndex);
   }
 }

--- a/src/types/composite/vector.ts
+++ b/src/types/composite/vector.ts
@@ -1,6 +1,6 @@
 import {Vector} from "../../interface";
 import {IArrayOptions, BasicArrayType, CompositeArrayType} from "./array";
-import {isTypeOf} from "../basic";
+import {isTypeOf, UINT_TYPE} from "../basic";
 import {
   BasicVectorStructuralHandler,
   CompositeVectorStructuralHandler,
@@ -9,6 +9,8 @@ import {
   BasicVectorByteArrayHandler,
   CompositeVectorByteArrayHandler,
 } from "../../backings";
+import {FULL_HASH_LENGTH, GIndexPathKeys, GINDEX_LEN_PATH} from "../../util/gIndex";
+import { getPowerOfTwoCeil } from "../../util/math";
 
 export interface IVectorOptions extends IArrayOptions {
   length: number;
@@ -53,7 +55,37 @@ export class BasicVectorType<T extends Vector<unknown> = Vector<unknown>> extend
     return false;
   }
   chunkCount(): number {
-    return Math.ceil((this.length * this.elementType.size()) / 32);
+    return Math.ceil((this.length * this.elementType.getItemLength() + 31) / 32);
+  }
+
+  getItemPosition(index: number): [number, number, number] {
+    const start = index + this.elementType.getItemLength();
+    return [
+      Math.floor(start / FULL_HASH_LENGTH),
+      start % FULL_HASH_LENGTH,
+      (start % FULL_HASH_LENGTH) + this.elementType.getItemLength(),
+    ];
+  }
+
+  getGeneralizedIndex(root = 1, ...paths: GIndexPathKeys[]): number {
+    if (!paths.length) {
+      return root;
+    }
+    const path = paths[0];
+    if (path === GINDEX_LEN_PATH) {
+      if (this.elementType._typeSymbols.has(UINT_TYPE)) {
+        return root * 2 + 1;
+      } else {
+        throw new Error(`${GINDEX_LEN_PATH} is only supported on ${UINT_TYPE.toString()} array`);
+      }
+    }
+    if (typeof path !== "number") {
+      throw new Error("Not supported path on BasicList");
+    }
+    const [pos] = this.getItemPosition(path);
+    const baseIndex = 2;
+    root = root * baseIndex * getPowerOfTwoCeil(this.chunkCount()) + pos;
+    return this.elementType.getGeneralizedIndex(root, ...paths.slice(1));
   }
 }
 
@@ -71,6 +103,28 @@ export class CompositeVectorType<T extends Vector<object> = Vector<object>> exte
     return this.elementType.isVariableSize();
   }
   chunkCount(): number {
-    return this.length;
+    return Math.ceil((this.length * this.elementType.getItemLength() + 31) / 32);
+  }
+  getItemPosition(index: number): [number, number, number] {
+    const start = index + this.elementType.getItemLength();
+    return [
+      Math.floor(start / FULL_HASH_LENGTH),
+      start % FULL_HASH_LENGTH,
+      (start % FULL_HASH_LENGTH) + this.elementType.getItemLength(),
+    ];
+  }
+
+  getGeneralizedIndex(root = 1, ...paths: GIndexPathKeys[]): number {
+    if (!paths.length) {
+      return root;
+    }
+    const path = paths[0];
+    if (typeof path !== "number") {
+      throw new Error("CompositeArray supports only element index as path");
+    }
+    const [pos] = this.getItemPosition(path);
+    const baseIndex = 2;
+    root = root * baseIndex * getPowerOfTwoCeil(this.chunkCount()) + pos;
+    return this.elementType.getGeneralizedIndex(root, ...paths.slice(1));
   }
 }

--- a/src/types/composite/vector.ts
+++ b/src/types/composite/vector.ts
@@ -10,7 +10,7 @@ import {
   CompositeVectorByteArrayHandler,
 } from "../../backings";
 import {FULL_HASH_LENGTH, GIndexPathKeys, GINDEX_LEN_PATH} from "../../util/gIndex";
-import { getPowerOfTwoCeil } from "../../util/math";
+import {getPowerOfTwoCeil} from "../../util/math";
 
 export interface IVectorOptions extends IArrayOptions {
   length: number;
@@ -67,14 +67,14 @@ export class BasicVectorType<T extends Vector<unknown> = Vector<unknown>> extend
     ];
   }
 
-  getGeneralizedIndex(root = 1, ...paths: GIndexPathKeys[]): number {
-    if (!paths.length) {
-      return root;
+  getGeneralizedIndex(pathParts: GIndexPathKeys[], rootIndex = 1): number {
+    if (pathParts.length == 0) {
+      return rootIndex;
     }
-    const path = paths[0];
+    const path = pathParts[0];
     if (path === GINDEX_LEN_PATH) {
       if (this.elementType._typeSymbols.has(UINT_TYPE)) {
-        return root * 2 + 1;
+        return rootIndex * 2 + 1;
       } else {
         throw new Error(`${GINDEX_LEN_PATH} is only supported on ${UINT_TYPE.toString()} array`);
       }
@@ -84,8 +84,8 @@ export class BasicVectorType<T extends Vector<unknown> = Vector<unknown>> extend
     }
     const [pos] = this.getItemPosition(parseInt(path as string));
     const baseIndex = 2;
-    root = root * baseIndex * getPowerOfTwoCeil(this.chunkCount()) + pos;
-    return this.elementType.getGeneralizedIndex(root, ...paths.slice(1));
+    rootIndex = rootIndex * baseIndex * getPowerOfTwoCeil(this.chunkCount()) + pos;
+    return this.elementType.getGeneralizedIndex(pathParts.slice(1), rootIndex);
   }
 }
 
@@ -114,17 +114,17 @@ export class CompositeVectorType<T extends Vector<object> = Vector<object>> exte
     ];
   }
 
-  getGeneralizedIndex(root = 1, ...paths: GIndexPathKeys[]): number {
-    if (!paths.length) {
-      return root;
+  getGeneralizedIndex(pathParts: GIndexPathKeys[], rootIndex: number): number {
+    if (pathParts.length === 0) {
+      return rootIndex;
     }
-    const path = parseInt(paths[0] as string);
+    const path = parseInt(pathParts[0] as string);
     if (isNaN(path)) {
       throw new Error("CompositeArray supports only element index as path. Received " + path);
     }
     const [pos] = this.getItemPosition(path);
     const baseIndex = 2;
-    root = root * baseIndex * getPowerOfTwoCeil(this.chunkCount()) + pos;
-    return this.elementType.getGeneralizedIndex(root, ...paths.slice(1));
+    rootIndex = rootIndex * baseIndex * getPowerOfTwoCeil(this.chunkCount()) + pos;
+    return this.elementType.getGeneralizedIndex(pathParts.slice(1), rootIndex);
   }
 }

--- a/src/types/composite/vector.ts
+++ b/src/types/composite/vector.ts
@@ -79,10 +79,10 @@ export class BasicVectorType<T extends Vector<unknown> = Vector<unknown>> extend
         throw new Error(`${GINDEX_LEN_PATH} is only supported on ${UINT_TYPE.toString()} array`);
       }
     }
-    if (typeof path !== "number") {
+    if (isNaN(parseInt(path as string))) {
       throw new Error("Not supported path on BasicList");
     }
-    const [pos] = this.getItemPosition(path);
+    const [pos] = this.getItemPosition(parseInt(path as string));
     const baseIndex = 2;
     root = root * baseIndex * getPowerOfTwoCeil(this.chunkCount()) + pos;
     return this.elementType.getGeneralizedIndex(root, ...paths.slice(1));
@@ -118,9 +118,9 @@ export class CompositeVectorType<T extends Vector<object> = Vector<object>> exte
     if (!paths.length) {
       return root;
     }
-    const path = paths[0];
-    if (typeof path !== "number") {
-      throw new Error("CompositeArray supports only element index as path");
+    const path = parseInt(paths[0] as string);
+    if (isNaN(path)) {
+      throw new Error("CompositeArray supports only element index as path. Received " + path);
     }
     const [pos] = this.getItemPosition(path);
     const baseIndex = 2;

--- a/src/util/gIndex.ts
+++ b/src/util/gIndex.ts
@@ -1,0 +1,32 @@
+export const GINDEX_LEN_PATH = "__len__";
+export const FULL_HASH_LENGTH = 32;
+
+type Keys<TRecord> = keyof TRecord;
+
+// Atempt to make Gindex path typesafe
+// Idea is to use conditional type to take all keys from all objects.
+// Trouble is transition container -> array -> container where it's
+// hard to recourse like that to get all keys of all containers
+
+// export type ArrayElement<A> = A extends readonly (infer T)[] ? T : never;
+
+// export type GIndexContainerPathKeys<TRecord extends ObjectLike, TChild = TRecord[keyof TRecord]> =
+//   | Keys<TRecord>
+//   | TChild extends ObjectLike
+//   ? keyof TChild
+//   : never | TChild extends ArrayLike<unknown>
+//   ? GindexArrayPathKeys
+//   : never;
+
+// export type GindexArrayPathKeys<TArray extends ArrayLike<unknown>> =
+//   | typeof GINDEX_LEN_PATH
+//   | number
+//   | ArrayElement<TArray> extends ObjectLike
+//   ? GIndexContainerPathKeys<ArrayElement<TArray>>
+//   : never;
+
+// export type GIndexPathKeys<T extends ObjectLike | ArrayLike<unknown>> = T extends (infer E)[]
+//   ? GindexArrayPathKeys<T>
+//   : GIndexContainerPathKeys<T>;
+
+export type GIndexPathKeys = string | number | typeof GINDEX_LEN_PATH;

--- a/src/util/math.ts
+++ b/src/util/math.ts
@@ -16,3 +16,34 @@ export function nextPowerOf2(n: number): number {
 export function previousPowerOf2(n: number): number {
   return n === 0 ? 1 : Math.pow(2, bitLength(n) - 1);
 }
+
+/**
+ * Get the power of 2 for given input, or the closest higher power of 2 if the input is not a power of 2.
+ * Commonly used for "how many nodes do I need for a bottom tree layer fitting x elements?"
+ * Example: 0->1, 1->1, 2->2, 3->4, 4->4, 5->8, 6->8, 7->8, 8->8, 9->16.
+ */
+export function getPowerOfTwoCeil(x: number): number {
+  if (x <= 1) {
+    return 1;
+  } else if (x === 2) {
+    return 2;
+  } else {
+    return 2 * getPowerOfTwoCeil(Math.floor((x + 1) / 2));
+  }
+}
+
+/**
+ * Get the power of 2 for given input, or the closest lower power of 2 if the input is not a power of 2.
+ * The zero case is a placeholder and not used for math with generalized indices.
+ * Commonly used for "what power of two makes up the root bit of the generalized index?"
+ * Example: 0->1, 1->1, 2->2, 3->2, 4->4, 5->4, 6->4, 7->4, 8->8, 9->8
+ */
+export function getPowerOfTwoFloor(x: number): number {
+  if (x <= 1) {
+    return 1;
+  } else if (x == 2) {
+    return 2;
+  } else {
+    return 2 * getPowerOfTwoFloor(Math.floor(x / 2));
+  }
+}

--- a/test/unit/gindex/index.test.ts
+++ b/test/unit/gindex/index.test.ts
@@ -1,0 +1,20 @@
+import {expect} from "chai";
+import fs from "fs";
+import {join} from "path";
+import * as testTypes from "./types";
+
+describe("generalized static indices", function () {
+  const testCases = fs.readFileSync(join(__dirname, "testCases.txt")).toString().split("\n");
+
+  testCases.forEach((testCase) => {
+    it(testCase, function () {
+      const [type, path, expected] = testCase.split(" ");
+      let pathParts: string[] = [];
+      if (path !== "") {
+        pathParts = path.split("/");
+      }
+      const result = testTypes[type as keyof typeof testTypes].getGeneralizedIndex(1, ...pathParts);
+      expect(result).to.be.equal(parseInt(expected));
+    });
+  });
+});

--- a/test/unit/gindex/testCases.txt
+++ b/test/unit/gindex/testCases.txt
@@ -1,0 +1,16 @@
+TestContainer  1
+TestContainer uint 16
+TestContainer bool 17
+TestContainer bytes32 18
+TestContainer bitlist 19
+TestContainer bitvector 20
+TestContainer basicList 21
+TestContainer basicList/0 336
+TestContainer basicVector 22
+TestContainer basicVector/4 22
+TestContainer complexList 23
+TestContainer complexList/4 740
+TestContainer complexList/4/field 740
+TestContainer complexVector 24
+TestContainer complexVector/4 388
+TestContainer complexVector/4/field 388

--- a/test/unit/gindex/types.ts
+++ b/test/unit/gindex/types.ts
@@ -1,0 +1,28 @@
+import {BigIntUintType} from "../../../src";
+import {ContainerType} from "../../../src/types/composite/container";
+import {BooleanType} from "../../../src/types/basic/boolean";
+import {ByteVectorType} from "../../../src/types/composite/byteVector";
+import {BitListType} from "../../../src/types/composite/bitList";
+import {BitVectorType} from "../../../src/types/composite/bitVector";
+import {ListType} from "../../../src/types/composite/list";
+import {VectorType} from "../../../src/types/composite/vector";
+
+const TestContainer2 = new ContainerType({
+  fields: {
+    field: new BigIntUintType({byteLength: 64}),
+  },
+});
+
+export const TestContainer = new ContainerType({
+  fields: {
+    uint: new BigIntUintType({byteLength: 64}),
+    bool: new BooleanType(),
+    bytes32: new ByteVectorType({length: 32}),
+    bitlist: new BitListType({limit: 10}),
+    bitvector: new BitVectorType({length: 10}),
+    basicList: new ListType({elementType: new BigIntUintType({byteLength: 64}), limit: 30}),
+    basicVector: new VectorType({elementType: new BigIntUintType({byteLength: 64}), length: 30}),
+    complexList: new ListType({elementType: TestContainer2, limit: 10}),
+    complexVector: new VectorType({elementType: TestContainer2, length: 10}),
+  },
+});


### PR DESCRIPTION
As per specified here: https://github.com/ethereum/eth2.0-specs/blob/vbuterin-patch-2/ssz/merkle-proofs.md#ssz-object-to-index

I've changed some existing implementation to align with spec, so I would ask you to pay close attention.
I'm happy to jump on a call if something is unclear or just to go trough the code.

There is a lot of duplicated code since list/vector doesn't have common ancenstor. We could try to address that in separate PR.
Happy to take ideas what's the best way to test this without manually calculating index for every test case 😄 

TODO:
- [ ] tests