### PR TITLE
Remove TreeBacked<T>#gindexOfProperty

### DIFF
--- a/src/backings/tree/abstract.ts
+++ b/src/backings/tree/abstract.ts
@@ -48,10 +48,6 @@ export interface ITreeBacked<T extends object> {
    */
   depth(): number;
   /**
-   * The gindex of a property
-   */
-  gindexOfProperty(prop: PropertyKey): Gindex;
-  /**
    * Merkleization
    */
   hashTreeRoot(): Uint8Array;
@@ -227,7 +223,7 @@ export class TreeHandler<T extends object> implements ProxyHandler<T> {
 
   // Merkleization
 
-  gindexOfProperty(target: Tree, prop: PropertyKey): Gindex {
+  gindexOfProperty(prop: PropertyKey): Gindex {
     throw new Error("Not implemented");
   }
   /**
@@ -239,20 +235,20 @@ export class TreeHandler<T extends object> implements ProxyHandler<T> {
     }
     return this._depth;
   }
-  gindexOfChunk(target: Tree, index: number): Gindex {
+  gindexOfChunk(index: number): Gindex {
     return toGindex(this.depth(), BigInt(index));
   }
   getSubtreeAtChunk(target: Tree, index: number): Tree {
-    return target.getSubtree(this.gindexOfChunk(target, index));
+    return target.getSubtree(this.gindexOfChunk(index));
   }
   setSubtreeAtChunk(target: Tree, index: number, value: Tree, expand = false): void {
-    target.setSubtree(this.gindexOfChunk(target, index), value, expand);
+    target.setSubtree(this.gindexOfChunk(index), value, expand);
   }
   getRootAtChunk(target: Tree, index: number): Uint8Array {
-    return target.getRoot(this.gindexOfChunk(target, index));
+    return target.getRoot(this.gindexOfChunk(index));
   }
   setRootAtChunk(target: Tree, index: number, value: Uint8Array, expand = false): void {
-    target.setRoot(this.gindexOfChunk(target, index), value, expand);
+    target.setRoot(this.gindexOfChunk(index), value, expand);
   }
   /**
    * Merkleization

--- a/src/backings/tree/array.ts
+++ b/src/backings/tree/array.ts
@@ -56,8 +56,8 @@ export class BasicArrayTreeHandler<T extends ArrayLike<unknown>> extends TreeHan
     }
     return offset + size;
   }
-  gindexOfProperty(target: Tree, prop: PropertyKey): Gindex {
-    return this.gindexOfChunk(target, this.getChunkIndex(prop as number));
+  gindexOfProperty(prop: PropertyKey): Gindex {
+    return this.gindexOfChunk(this.getChunkIndex(prop as number));
   }
   getLength(target: Tree): number {
     throw new Error("Not implemented");
@@ -88,7 +88,7 @@ export class BasicArrayTreeHandler<T extends ArrayLike<unknown>> extends TreeHan
     return this.getValueAtIndex(target, index);
   }
   setProperty(target: Tree, property: number, value: T[number], expand = false): boolean {
-    const chunkGindex = this.gindexOfChunk(target, this.getChunkIndex(property));
+    const chunkGindex = this.gindexOfChunk(this.getChunkIndex(property));
     // copy data from old chunk, use new memory to set a new chunk
     const chunk = new Uint8Array(32);
     chunk.set(target.getRoot(chunkGindex));
@@ -220,8 +220,8 @@ export class CompositeArrayTreeHandler<T extends ArrayLike<object>> extends Tree
       return index;
     }
   }
-  gindexOfProperty(target: Tree, prop: PropertyKey): Gindex {
-    return this.gindexOfChunk(target, prop as number);
+  gindexOfProperty(prop: PropertyKey): Gindex {
+    return this.gindexOfChunk(prop as number);
   }
   getLength(target: Tree): number {
     throw new Error("Not implemented");
@@ -247,7 +247,7 @@ export class CompositeArrayTreeHandler<T extends ArrayLike<object>> extends Tree
     return (this.getValueAtChunk(target, index) as unknown) as PropOfCompositeTreeBacked<T, V>;
   }
   setProperty(target: Tree, property: number, value: T[number], expand = false): boolean {
-    const chunkGindex = this.gindexOfChunk(target, property);
+    const chunkGindex = this.gindexOfChunk(property);
     if (isTreeBacked(value)) {
       target.setSubtree(chunkGindex, value.tree());
     } else {

--- a/src/backings/tree/bitList.ts
+++ b/src/backings/tree/bitList.ts
@@ -27,7 +27,7 @@ export class BitListTreeHandler extends BasicListTreeHandler<BitList> {
       throw new Error("Invalid deserialized bitlist, padding bit required");
     }
     const target = super.fromBytes(data, start, end);
-    const lastGindex = this.gindexOfChunk(target, Math.ceil((end - start) / 32) - 1);
+    const lastGindex = this.gindexOfChunk(Math.ceil((end - start) / 32) - 1);
     // copy chunk into new memory
     const lastChunk = new Uint8Array(32);
     lastChunk.set(target.getRoot(lastGindex));
@@ -71,7 +71,7 @@ export class BitListTreeHandler extends BasicListTreeHandler<BitList> {
     return !!(byte & (1 << this.getBitOffset(index)));
   }
   setProperty(target: Tree, property: number, value: boolean, expand = false): boolean {
-    const chunkGindex = this.gindexOfChunk(target, this.getChunkIndex(property));
+    const chunkGindex = this.gindexOfChunk(this.getChunkIndex(property));
     const chunk = new Uint8Array(32);
     chunk.set(target.getRoot(chunkGindex));
     const byteOffset = this.getChunkOffset(property);

--- a/src/backings/tree/bitVector.ts
+++ b/src/backings/tree/bitVector.ts
@@ -40,7 +40,7 @@ export class BitVectorTreeHandler extends BasicVectorTreeHandler<BitVector> {
     return !!(byte & (1 << this.getBitOffset(index)));
   }
   setProperty(target: Tree, property: number, value: boolean): boolean {
-    const chunkGindex = this.gindexOfChunk(target, this.getChunkIndex(property));
+    const chunkGindex = this.gindexOfChunk(this.getChunkIndex(property));
     const chunk = new Uint8Array(32);
     chunk.set(target.getRoot(chunkGindex));
     const byteOffset = this.getChunkOffset(property);

--- a/src/backings/tree/container.ts
+++ b/src/backings/tree/container.ts
@@ -115,12 +115,12 @@ export class ContainerTreeHandler<T extends ObjectLike> extends TreeHandler<T> {
     }
     return variableIndex;
   }
-  gindexOfProperty(target: Tree, prop: PropertyKey): Gindex {
+  gindexOfProperty(prop: PropertyKey): Gindex {
     const chunkIndex = Object.keys(this._type.fields).findIndex((fieldName) => fieldName === prop);
     if (chunkIndex === -1) {
       throw new Error("Invalid container field name");
     }
-    return this.gindexOfChunk(target, chunkIndex);
+    return this.gindexOfChunk(chunkIndex);
   }
   getProperty<V extends keyof T>(target: Tree, property: V): PropOfTreeBacked<T, V> {
     const chunkIndex = Object.keys(this._type.fields).findIndex((fieldName) => fieldName === property);
@@ -140,7 +140,7 @@ export class ContainerTreeHandler<T extends ObjectLike> extends TreeHandler<T> {
     if (chunkIndex === -1) {
       throw new Error("Invalid container field name");
     }
-    const chunkGindex = this.gindexOfChunk(target, chunkIndex);
+    const chunkGindex = this.gindexOfChunk(chunkIndex);
     const fieldType = this._type.fields[property as string];
     if (fieldType.isBasic()) {
       const chunk = new Uint8Array(32);


### PR DESCRIPTION
BREAKING CHANGE:
TreeBacked<T>#gindexOfProperty is removed in favor of
TreeHandler#gindexOfProperty

`gindexOfProperty(target: Tree, property: PropertyKey): Gindex` => 
`gindexOfProperty(property: PropertyKey): Gindex`
Calculating gindices shouldn't rely on the value (the actual tree), since no calculations actually rely on the value.
Instead, just the type information alone is enough to calculate gindices.

Consumers previously using the public method should upgrade like so:
```ts

const value: TreeBacked<T> = ...;

// before

value.gindexOfProperty('foo')

// after

value.type().gindexOfProperty('foo')
```

The gindexOfProperty is very "low level" and likely only needed for proof generation machinery.
In the future, proof generation methods may be added to TreeBacked<T> to provide convenience.