### PR TITLE
Use abstract class Type/BasicType/CompositeType

### DIFF
--- a/src/backings/tree/container.ts
+++ b/src/backings/tree/container.ts
@@ -2,7 +2,7 @@
 import {Node, Tree, subtreeFillToContents, zeroNode, Gindex, LeafNode} from "@chainsafe/persistent-merkle-tree";
 
 import {ObjectLike} from "../../interface";
-import {ContainerType, CompositeType, isBasicType, isCompositeType} from "../../types";
+import {ContainerType, CompositeType, isCompositeType} from "../../types";
 import {isTreeBacked, TreeHandler, PropOfTreeBacked} from "./abstract";
 
 export class ContainerTreeHandler<T extends ObjectLike> extends TreeHandler<T> {

--- a/src/types/basic/abstract.ts
+++ b/src/types/basic/abstract.ts
@@ -1,18 +1,12 @@
+/* eslint-disable @typescript-eslint/member-ordering */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import {Json} from "../../interface";
+import {isTypeOf, Type} from "../type";
 
-/**
- * Check if `type` is an instance of `typeSymbol` type
- *
- * Used by various isFooType functions
- */
-export function isTypeOf(type: unknown, typeSymbol: symbol): boolean {
-  return (
-    type &&
-    (type as BasicType<unknown>)._typeSymbols &&
-    (type as BasicType<unknown>)._typeSymbols.has &&
-    (type as BasicType<unknown>)._typeSymbols.has(typeSymbol)
-  );
+export const BASIC_TYPE = Symbol.for("ssz/BasicType");
+
+export function isBasicType(type: Type<unknown>): type is BasicType<unknown> {
+  return isTypeOf(type, BASIC_TYPE);
 }
 
 /**
@@ -20,34 +14,10 @@ export function isTypeOf(type: unknown, typeSymbol: symbol): boolean {
  *
  * It is serialized as, at maximum, 32 bytes and merkleized as, at maximum, a single chunk
  */
-export class BasicType<T> {
-  /**
-   * Symbols used to track the identity of a type
-   *
-   * Used by various isFooType functions
-   */
-  _typeSymbols: Set<symbol>;
-
+export abstract class BasicType<T> extends Type<T> {
   constructor() {
-    this._typeSymbols = new Set();
-  }
-
-  isBasic(): this is BasicType<T> {
-    return true;
-  }
-
-  /**
-   * Valid value assertion
-   */
-  assertValidValue(value: unknown): asserts value is T {
-    throw new Error("Not implemented");
-  }
-
-  /**
-   * Default constructor
-   */
-  defaultValue(): T {
-    throw new Error("Not implemented");
+    super();
+    this._typeSymbols.add(BASIC_TYPE);
   }
 
   /**
@@ -119,9 +89,7 @@ export class BasicType<T> {
   /**
    * Low-level deserialization
    */
-  fromBytes(data: Uint8Array, offset: number): T {
-    throw new Error("Not implemented");
-  }
+  abstract fromBytes(data: Uint8Array, offset: number): T;
   /**
    * Deserialization
    */
@@ -129,14 +97,6 @@ export class BasicType<T> {
     return this.fromBytes(data, 0);
   }
 
-  /**
-   * Low-level serialization
-   *
-   * Serializes to a pre-allocated Uint8Array
-   */
-  toBytes(value: T, output: Uint8Array, offset: number): number {
-    throw new Error("Not implemented");
-  }
   /**
    * Serialization
    */
@@ -153,19 +113,5 @@ export class BasicType<T> {
     const output = new Uint8Array(32);
     this.toBytes(value, output, 0);
     return output;
-  }
-
-  /**
-   * Convert from JSON-serializable object
-   */
-  fromJson(data: Json): T {
-    throw new Error("Not implemented");
-  }
-
-  /**
-   * Convert to JSON-serializable object
-   */
-  toJson(value: T): Json {
-    throw new Error("Not implemented");
   }
 }

--- a/src/types/basic/abstract.ts
+++ b/src/types/basic/abstract.ts
@@ -1,6 +1,5 @@
 /* eslint-disable @typescript-eslint/member-ordering */
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import {Json} from "../../interface";
 import {isTypeOf, Type} from "../type";
 
 export const BASIC_TYPE = Symbol.for("ssz/BasicType");

--- a/src/types/basic/boolean.ts
+++ b/src/types/basic/boolean.ts
@@ -1,9 +1,10 @@
 import {Json} from "../../interface";
-import {BasicType, isTypeOf} from "./abstract";
+import {isTypeOf, Type} from "../type";
+import {BasicType} from "./abstract";
 
 export const BOOLEAN_TYPE = Symbol.for("ssz/BooleanType");
 
-export function isBooleanType(type: unknown): type is BooleanType {
+export function isBooleanType(type: Type<unknown>): type is BooleanType {
   return isTypeOf(type, BOOLEAN_TYPE);
 }
 

--- a/src/types/basic/uint.ts
+++ b/src/types/basic/uint.ts
@@ -1,5 +1,6 @@
 import {Json} from "../../interface";
-import {BasicType, isTypeOf} from "./abstract";
+import {isTypeOf, Type} from "../type";
+import {BasicType} from "./abstract";
 
 export interface IUintOptions {
   byteLength: number;
@@ -7,12 +8,12 @@ export interface IUintOptions {
 
 export const UINT_TYPE = Symbol.for("ssz/UintType");
 
-export function isUintType<T>(type: unknown): type is UintType<T> {
+export function isUintType<T>(type: Type<unknown>): type is UintType<T> {
   return isTypeOf(type, UINT_TYPE);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export class UintType<T> extends BasicType<T> {
+export abstract class UintType<T> extends BasicType<T> {
   byteLength: number;
   constructor(options: IUintOptions) {
     super();
@@ -26,7 +27,7 @@ export class UintType<T> extends BasicType<T> {
 
 export const NUMBER_UINT_TYPE = Symbol.for("ssz/NumberUintType");
 
-export function isNumberUintType(type: unknown): type is NumberUintType {
+export function isNumberUintType(type: Type<unknown>): type is NumberUintType {
   return isTypeOf(type, NUMBER_UINT_TYPE);
 }
 
@@ -108,7 +109,7 @@ export class NumberUintType extends UintType<number> {
 
 export const BIGINT_UINT_TYPE = Symbol.for("ssz/BigIntUintType");
 
-export function isBigIntUintType(type: unknown): type is BigIntUintType {
+export function isBigIntUintType(type: Type<unknown>): type is BigIntUintType {
   return isTypeOf(type, BIGINT_UINT_TYPE);
 }
 

--- a/src/types/composite/abstract.ts
+++ b/src/types/composite/abstract.ts
@@ -2,7 +2,6 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import {Json} from "../../interface";
 import {BackedValue, ByteArrayHandler, isBackedValue, StructuralHandler, TreeHandler} from "../../backings";
-import {BasicType} from "../basic";
 import {IJsonOptions, isTypeOf, Type} from "../type";
 
 export const COMPOSITE_TYPE = Symbol.for("ssz/CompositeType");

--- a/src/types/composite/abstract.ts
+++ b/src/types/composite/abstract.ts
@@ -1,31 +1,28 @@
+/* eslint-disable @typescript-eslint/member-ordering */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import {Json} from "../../interface";
 import {BackedValue, ByteArrayHandler, isBackedValue, StructuralHandler, TreeHandler} from "../../backings";
 import {BasicType} from "../basic";
-import {IJsonOptions} from "../type";
+import {IJsonOptions, isTypeOf, Type} from "../type";
+
+export const COMPOSITE_TYPE = Symbol.for("ssz/CompositeType");
+
+export function isCompositeType(type: Type<unknown>): type is CompositeType<object> {
+  return isTypeOf(type, COMPOSITE_TYPE);
+}
 
 /**
  * A CompositeType is a type containing other types, and is flexible in its representation.
  *
  */
-export class CompositeType<T extends object> {
+export abstract class CompositeType<T extends object> extends Type<T> {
   structural: StructuralHandler<T>;
   tree: TreeHandler<T>;
   byteArray: ByteArrayHandler<T>;
 
-  /**
-   * Symbols used to track the identity of a type
-   *
-   * Used by various isFooType functions
-   */
-  _typeSymbols: Set<symbol>;
-
   constructor() {
-    this._typeSymbols = new Set();
-  }
-
-  isBasic(): this is BasicType<T> {
-    return false;
+    super();
+    this._typeSymbols.add(COMPOSITE_TYPE);
   }
 
   /**
@@ -67,12 +64,6 @@ export class CompositeType<T extends object> {
   // Serialization / Deserialization
 
   /**
-   * Check if type has a variable number of elements (or subelements)
-   */
-  isVariableSize(): boolean {
-    throw new Error("Not implemented");
-  }
-  /**
    * Serialized byte length
    */
   size(value: BackedValue<T> | T): number {
@@ -101,8 +92,9 @@ export class CompositeType<T extends object> {
    * Low-level deserialization
    */
   fromBytes(data: Uint8Array, start: number, end: number): T {
-    throw new Error("Not implemented");
+    return this.structural.fromBytes(data, start, end);
   }
+
   /**
    * Deserialization
    */
@@ -138,9 +130,8 @@ export class CompositeType<T extends object> {
   /**
    * Return the number of leaf chunks to be merkleized
    */
-  chunkCount(): number {
-    throw new Error("Not implemented");
-  }
+  abstract chunkCount(): number;
+
   /**
    * Merkleization
    */

--- a/src/types/composite/array.ts
+++ b/src/types/composite/array.ts
@@ -8,7 +8,7 @@ export interface IArrayOptions {
   elementType: Type<any>;
 }
 
-export class BasicArrayType<T extends ArrayLike<unknown>> extends CompositeType<T> {
+export abstract class BasicArrayType<T extends ArrayLike<unknown>> extends CompositeType<T> {
   elementType: BasicType<unknown>;
   constructor(options: IArrayOptions) {
     super();
@@ -16,7 +16,7 @@ export class BasicArrayType<T extends ArrayLike<unknown>> extends CompositeType<
   }
 }
 
-export class CompositeArrayType<T extends ArrayLike<unknown>> extends CompositeType<T> {
+export abstract class CompositeArrayType<T extends ArrayLike<unknown>> extends CompositeType<T> {
   elementType: CompositeType<object>;
   constructor(options: IArrayOptions) {
     super();

--- a/src/types/composite/bitList.ts
+++ b/src/types/composite/bitList.ts
@@ -1,6 +1,7 @@
 import {BitList} from "../../interface";
 import {BasicListType} from "./list";
-import {booleanType, isTypeOf} from "../basic";
+import {booleanType} from "../basic";
+import {isTypeOf, Type} from "../type";
 import {BitListStructuralHandler, BitListTreeHandler} from "../../backings";
 
 export interface IBitListOptions {
@@ -9,7 +10,7 @@ export interface IBitListOptions {
 
 export const BITLIST_TYPE = Symbol.for("ssz/BitListType");
 
-export function isBitListType<T extends BitList = BitList>(type: unknown): type is BitListType {
+export function isBitListType<T extends BitList = BitList>(type: Type<unknown>): type is BitListType {
   return isTypeOf(type, BITLIST_TYPE);
 }
 

--- a/src/types/composite/bitVector.ts
+++ b/src/types/composite/bitVector.ts
@@ -1,6 +1,7 @@
 import {BitVector} from "../../interface";
 import {BasicVectorType} from "./vector";
-import {booleanType, isTypeOf} from "../basic";
+import {booleanType} from "../basic";
+import {isTypeOf, Type} from "../type";
 import {BitVectorStructuralHandler, BitVectorTreeHandler} from "../../backings";
 
 export interface IBitVectorOptions {
@@ -9,7 +10,7 @@ export interface IBitVectorOptions {
 
 export const BITVECTOR_TYPE = Symbol.for("ssz/BitVectorType");
 
-export function isBitVectorType<T extends BitVector = BitVector>(type: unknown): type is BitVectorType {
+export function isBitVectorType<T extends BitVector = BitVector>(type: Type<unknown>): type is BitVectorType {
   return isTypeOf(type, BITVECTOR_TYPE);
 }
 

--- a/src/types/composite/byteVector.ts
+++ b/src/types/composite/byteVector.ts
@@ -1,6 +1,7 @@
 import {ByteVector} from "../../interface";
 import {BasicVectorType} from "./vector";
-import {byteType, isTypeOf} from "../basic";
+import {byteType} from "../basic";
+import {isTypeOf, Type} from "../type";
 import {ByteVectorStructuralHandler, ByteVectorTreeHandler} from "../../backings";
 
 export interface IByteVectorOptions {
@@ -9,7 +10,7 @@ export interface IByteVectorOptions {
 
 export const BYTEVECTOR_TYPE = Symbol.for("ssz/ByteVectorType");
 
-export function isByteVectorType<T extends ByteVector = ByteVector>(type: unknown): type is ByteVectorType {
+export function isByteVectorType<T extends ByteVector = ByteVector>(type: Type<unknown>): type is ByteVectorType {
   return isTypeOf(type, BYTEVECTOR_TYPE);
 }
 

--- a/src/types/composite/container.ts
+++ b/src/types/composite/container.ts
@@ -1,7 +1,6 @@
 import {ObjectLike} from "../../interface";
 import {CompositeType} from "./abstract";
-import {isTypeOf} from "../basic";
-import {Type} from "../type";
+import {isTypeOf, Type} from "../type";
 import {ContainerStructuralHandler, ContainerTreeHandler, ContainerByteArrayHandler} from "../../backings";
 
 export interface IContainerOptions {
@@ -11,7 +10,7 @@ export interface IContainerOptions {
 
 export const CONTAINER_TYPE = Symbol.for("ssz/ContainerType");
 
-export function isContainerType<T extends ObjectLike = ObjectLike>(type: unknown): type is ContainerType<T> {
+export function isContainerType<T extends ObjectLike = ObjectLike>(type: Type<unknown>): type is ContainerType<T> {
   return isTypeOf(type, CONTAINER_TYPE);
 }
 

--- a/src/types/composite/list.ts
+++ b/src/types/composite/list.ts
@@ -1,6 +1,7 @@
 import {List} from "../../interface";
 import {IArrayOptions, BasicArrayType, CompositeArrayType} from "./array";
-import {isTypeOf} from "../basic";
+import {isBasicType} from "../basic";
+import {isTypeOf, Type} from "../type";
 import {
   BasicListStructuralHandler,
   CompositeListStructuralHandler,
@@ -24,7 +25,7 @@ type ListTypeConstructor = {
 export const LIST_TYPE = Symbol.for("ssz/ListType");
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isListType<T extends List<any> = List<any>>(type: unknown): type is ListType<T> {
+export function isListType<T extends List<any> = List<any>>(type: Type<unknown>): type is ListType<T> {
   return isTypeOf(type, LIST_TYPE);
 }
 
@@ -32,7 +33,7 @@ export function isListType<T extends List<any> = List<any>>(type: unknown): type
 export const ListType: ListTypeConstructor =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (function ListType<T extends List<any> = List<any>>(options: IListOptions): ListType<T> {
-    if (options.elementType.isBasic()) {
+    if (isBasicType(options.elementType)) {
       return new BasicListType(options);
     } else {
       return new CompositeListType(options);

--- a/src/types/composite/root.ts
+++ b/src/types/composite/root.ts
@@ -1,6 +1,6 @@
-import {isTypeOf} from "../basic";
 import {ByteVectorType} from "./byteVector";
 import {CompositeType} from "./abstract";
+import {isTypeOf, Type} from "../type";
 
 /**
  * Allow for lazily evaulated expandedType thunk
@@ -11,7 +11,7 @@ export interface IRootOptions<T extends object> {
 
 export const ROOT_TYPE = Symbol.for("ssz/RootType");
 
-export function isRootType<T extends object = object>(type: unknown): type is RootType<T> {
+export function isRootType<T extends object = object>(type: Type<unknown>): type is RootType<T> {
   return isTypeOf(type, ROOT_TYPE);
 }
 

--- a/src/types/composite/vector.ts
+++ b/src/types/composite/vector.ts
@@ -1,6 +1,5 @@
 import {Vector} from "../../interface";
 import {IArrayOptions, BasicArrayType, CompositeArrayType} from "./array";
-import {isTypeOf} from "../basic";
 import {
   BasicVectorStructuralHandler,
   CompositeVectorStructuralHandler,
@@ -9,6 +8,8 @@ import {
   BasicVectorByteArrayHandler,
   CompositeVectorByteArrayHandler,
 } from "../../backings";
+import {isBasicType} from "../basic";
+import {isTypeOf, Type} from "../type";
 
 export interface IVectorOptions extends IArrayOptions {
   length: number;
@@ -17,7 +18,7 @@ export interface IVectorOptions extends IArrayOptions {
 export const VECTOR_TYPE = Symbol.for("ssz/VectorType");
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export function isVectorType<T extends Vector<any> = Vector<any>>(type: unknown): type is VectorType<T> {
+export function isVectorType<T extends Vector<any> = Vector<any>>(type: Type<unknown>): type is VectorType<T> {
   return isTypeOf(type, VECTOR_TYPE);
 }
 
@@ -32,7 +33,7 @@ type VectorTypeConstructor = {
 export const VectorType: VectorTypeConstructor =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (function VectorType<T extends Vector<any> = Vector<any>>(options: IVectorOptions): VectorType<T> {
-    if (options.elementType.isBasic()) {
+    if (isBasicType(options.elementType)) {
       return new BasicVectorType(options);
     } else {
       return new CompositeVectorType(options);

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -1,11 +1,114 @@
-import {BasicType} from "./basic";
-import {CompositeType} from "./composite";
-
-/**
- * A Type is either a BasicType or a CompositeType.
- */
-export type Type<T> = BasicType<T> | (T extends object ? CompositeType<T> : never);
-
+import {Json} from "../interface";
 export interface IJsonOptions {
   case: "camel" | "snake";
+}
+
+/**
+ * Check if `type` is an instance of `typeSymbol` type
+ *
+ * Used by various isFooType functions
+ */
+export function isTypeOf(type: Type<unknown>, typeSymbol: symbol): boolean {
+  return type._typeSymbols.has(typeSymbol);
+}
+
+/**
+ * A Type is either a BasicType of a CompositeType
+ */
+export abstract class Type<T> {
+  /**
+   * Symbols used to track the identity of a type
+   *
+   * Used by various isFooType functions
+   */
+  _typeSymbols: Set<symbol>;
+
+  constructor() {
+    this._typeSymbols = new Set();
+  }
+
+  /**
+   * Valid value assertion
+   */
+  abstract assertValidValue(value: unknown): asserts value is T;
+
+  /**
+   * Default constructor
+   */
+  abstract defaultValue(): T;
+
+  /**
+   * Clone / copy
+   */
+  abstract clone(value: T): T;
+
+  /**
+   * Equality
+   */
+  abstract equals(value1: T, value2: T): boolean;
+
+  // Serialization / Deserialization
+
+  /**
+   * Check if type has a variable number of elements (or subelements)
+   *
+   * For basic types, this is always false
+   */
+  abstract isVariableSize(): boolean;
+
+  /**
+   * Serialized byte length
+   */
+  abstract size(value?: T): number;
+
+  /**
+   * Maximal serialized byte length
+   */
+  abstract maxSize(): number;
+
+  /**
+   * Minimal serialized byte length
+   */
+  abstract minSize(): number;
+
+  /**
+   * Low-level deserialization
+   */
+  //abstract fromBytes(data: Uint8Array, offset: number): T;
+
+  /**
+   * Low-level deserialization
+   */
+  abstract fromBytes(data: Uint8Array, start: number, end?: number): T;
+  /**
+   * Deserialization
+   */
+  abstract deserialize(data: Uint8Array): T;
+
+  /**
+   * Low-level serialization
+   *
+   * Serializes to a pre-allocated Uint8Array
+   */
+  abstract toBytes(value: T, output: Uint8Array, offset: number): number;
+
+  /**
+   * Serialization
+   */
+  abstract serialize(value: T): Uint8Array;
+
+  /**
+   * Merkleization
+   */
+  abstract hashTreeRoot(value: T): Uint8Array;
+
+  /**
+   * Convert from JSON-serializable object
+   */
+  abstract fromJson(data: Json, options?: IJsonOptions): T;
+
+  /**
+   * Convert to JSON-serializable object
+   */
+  abstract toJson(value: T, options?: IJsonOptions): Json;
 }


### PR DESCRIPTION
BREAKING CHANGE:
Remove Type#isBasic in favor of isBasicType function

- Make `Type` an abstract class (rather than a type)
- Make `BasicType`, `CompositeType`, , `UintType`, `BasicArrayType`, `CompositeArrayType` abstract
- `Type#isBasic` now no longer works as intended (to coerce the type to a `CompositeType`), so remove it, use `isBasicType`/`isCompositeType` instead

Any consumers that previously used `Type#isBasic` can now use either `isBasicType` or `isCompositeType`
```ts

const t: Type<unknown> = ...;

// before

if (t.isBasic()) {
  ...
} else {
  // t is a CompositeType
  t.tree.defaultValue();
}

// after

if (!isCompositeType(t)) {
  ...
} else {
  // t is a CompositeType
  t.tree.defaultValue();
}
```