### PR TITLE
Improve BigIntUintType.toBytes() to use number bitshifting

### DIFF
--- a/src/types/basic/uint.ts
+++ b/src/types/basic/uint.ts
@@ -139,9 +139,10 @@ export class BigIntUintType extends UintType<bigint> {
     let v = value;
     let groupedBytes = Number(BigInt.asUintN(32, v));
     for (let i = 0; i < this.byteLength; i++) {
-      const byteIndex = i % 4;
-      output[offset + i] = Number((groupedBytes >> (8 * byteIndex)) & 0xff);
-      if ((i + 1) % 4 === 0) {
+      output[offset + i] = Number(groupedBytes & 0xff);
+      if ((i + 1) % 4 !== 0) {
+        groupedBytes >>= 8;
+      } else {
         v >>= BIGINT_4_BYTES;
         groupedBytes = Number(BigInt.asUintN(32, v));
       }

--- a/src/types/basic/uint.ts
+++ b/src/types/basic/uint.ts
@@ -27,6 +27,8 @@ export abstract class UintType<T> extends BasicType<T> {
 
 export const NUMBER_UINT_TYPE = Symbol.for("ssz/NumberUintType");
 
+const BIGINT_4_BYTES = BigInt(32);
+
 export function isNumberUintType(type: Type<unknown>): type is NumberUintType {
   return isTypeOf(type, NUMBER_UINT_TYPE);
 }
@@ -130,23 +132,19 @@ export class BigIntUintType extends UintType<bigint> {
     return BigInt(0);
   }
   toBytes(value: bigint, output: Uint8Array, offset: number): number {
-    // Motivation:
-    //   BigInt bitshifting is more expensive than string manipulation,
-    // but string manipulation is more expensive than number bitshifting.
-    // We would use only number bitshifting if we could,
-    // but Number can only bitshift to 32 bits
-    // Implementation:
-    //   Convert BigInt input to hex string, encoded as big-endian
-    // Iterate through the hex string, 4 bytes (8 characters) at a time, creating a number
-    // (Start from the back of the hex string, in order to convert to little-endian)
-    // With that number, bitshift+mask to get each byte by byte
-    let hexString = value.toString(16);
-    hexString = hexString.padStart(Math.ceil((this.byteLength * 2) / 8) * 8, "0");
-    for (let i = 0, n = 0; i < this.byteLength; i++) {
-      if (i % 4 === 0) {
-        n = Number("0x" + hexString.substring(hexString.length - (8 + i * 2), hexString.length - i * 2));
+    // Motivation
+    // BigInt bit shifting and BigInt allocation is slower compared to number
+    // For every 4 bytes, we extract value to groupedBytes
+    // and do bit shifting on the number
+    let v = value;
+    let groupedBytes = Number(BigInt.asUintN(32, v));
+    for (let i = 0; i < this.byteLength; i++) {
+      const byteIndex = i % 4;
+      output[offset + i] = Number((groupedBytes >> (8 * byteIndex)) & 0xff);
+      if ((i + 1) % 4 === 0) {
+        v >>= BIGINT_4_BYTES;
+        groupedBytes = Number(BigInt.asUintN(32, v));
       }
-      output[offset + i] = (n >> (8 * (i % 4))) & 0xff;
     }
     return offset + this.byteLength;
   }

--- a/test/perf/deserialize.test.ts
+++ b/test/perf/deserialize.test.ts
@@ -8,23 +8,20 @@ describe("deserialize", () => {
     const buffer = ValidatorBalancesType.serialize(value);
     let minTime = Number.MAX_SAFE_INTEGER;
     let maxTime = 0;
-    let average = {duration: 0, count: 0};
     const MAX_TRY = 10000;
+    const from = process.hrtime.bigint();
     for (let i = 0; i < MAX_TRY; i++) {
       const start = Date.now();
       ValidatorBalancesType.deserialize(buffer);
       const duration = Date.now() - start;
-      const totalDuration = average.duration * average.count + duration;
-      const totalCount = average.count + 1;
-      average.count = totalCount;
-      average.duration = totalDuration / totalCount;
       if (duration < minTime) minTime = duration;
       if (duration > maxTime) maxTime = duration;
     }
-    console.log("deserialize minTime:", minTime, "maxTime:", maxTime, "average:", average.duration, "MAX_TRY:", MAX_TRY);
+    const to = process.hrtime.bigint();
+    const average = Number((to - from) / BigInt(MAX_TRY) / BigInt(1000000));
+    console.log("deserialize in ms minTime:", minTime, "maxTime:", maxTime, "average:", average, "MAX_TRY:", MAX_TRY);
     expect(minTime).to.be.lt(85, "Minimal deserialization is not less than 85ms");
     expect(maxTime).to.be.lt(320, "Maximal deserialization is not less than 320ms");
-    expect(average.duration).to.be.lt(100, "Average deserialization is not less than 100ms");
-    expect(average.count).to.be.equal(MAX_TRY);
+    expect(average).to.be.lt(100, "Average deserialization is not less than 100ms");
   });
 });

--- a/test/perf/fromStructural.test.ts
+++ b/test/perf/fromStructural.test.ts
@@ -7,24 +7,21 @@ describe("fromStructural", function () {
     const balances = Array.from({length: 200000}, () => BigInt(31217089836));
     let minTime = Number.MAX_SAFE_INTEGER;
     let maxTime = 0;
-    let average = {duration: 0, count: 0};
     const MAX_TRY = 10000;
+    const from = process.hrtime.bigint();
     for (let i = 0; i < MAX_TRY; i++) {
       const state = BeaconState.tree.defaultValue();
       const start = Date.now();
       state.balances = balances;
       const duration = Date.now() - start;
-      const totalDuration = average.duration * average.count + duration;
-      const totalCount = average.count + 1;
-      average.count = totalCount;
-      average.duration = totalDuration / totalCount;
       if (duration < minTime) minTime = duration;
       if (duration > maxTime) maxTime = duration;
     }
-    console.log("fromStructural minTime:", minTime, "maxTime:", maxTime, "average:", average.duration, "MAX_TRY:", MAX_TRY);
+    const to = process.hrtime.bigint();
+    const average = Number((to - from) / BigInt(MAX_TRY) / BigInt(1000000));
+    console.log("fromStructural in ms minTime:", minTime, "maxTime:", maxTime, "average:", average, "MAX_TRY:", MAX_TRY);
     expect(minTime).to.be.lt(65, "Minimal balances assignment is not less than 65ms");
     expect(maxTime).to.be.lt(390, "Maximal balances assignment is not less than 390ms");
-    expect(average.duration).to.be.lt(81, "Average balances assignment is not less than 81ms");
-    expect(average.count).to.be.equal(MAX_TRY);
+    expect(average).to.be.lt(81, "Average balances assignment is not less than 81ms");
   });
 });

--- a/test/perf/fromStructural.test.ts
+++ b/test/perf/fromStructural.test.ts
@@ -1,0 +1,30 @@
+import { expect } from "chai";
+import { BeaconState } from "./objects";
+
+describe("fromStructural", function () {
+  it("assign balances to BeaconState", function () {
+    this.timeout(0);
+    const balances = Array.from({length: 200000}, () => BigInt(31217089836));
+    let minTime = Number.MAX_SAFE_INTEGER;
+    let maxTime = 0;
+    let average = {duration: 0, count: 0};
+    const MAX_TRY = 10000;
+    for (let i = 0; i < MAX_TRY; i++) {
+      const state = BeaconState.tree.defaultValue();
+      const start = Date.now();
+      state.balances = balances;
+      const duration = Date.now() - start;
+      const totalDuration = average.duration * average.count + duration;
+      const totalCount = average.count + 1;
+      average.count = totalCount;
+      average.duration = totalDuration / totalCount;
+      if (duration < minTime) minTime = duration;
+      if (duration > maxTime) maxTime = duration;
+    }
+    console.log("fromStructural minTime:", minTime, "maxTime:", maxTime, "average:", average.duration, "MAX_TRY:", MAX_TRY);
+    expect(minTime).to.be.lt(65, "Minimal balances assignment is not less than 65ms");
+    expect(maxTime).to.be.lt(390, "Maximal balances assignment is not less than 390ms");
+    expect(average.duration).to.be.lt(81, "Average balances assignment is not less than 81ms");
+    expect(average.count).to.be.equal(MAX_TRY);
+  });
+});

--- a/test/perf/objects.ts
+++ b/test/perf/objects.ts
@@ -1,8 +1,14 @@
-import { BigIntUintType, ListType } from "../../src";
+import { BigIntUintType, ContainerType, ListType } from "../../src";
 
 export const Gwei = new BigIntUintType({byteLength: 8});
 
 export const ValidatorBalances = new ListType({
   elementType: Gwei,
   limit: 200000,
+});
+
+export const BeaconState = new ContainerType({
+  fields: {
+    balances: ValidatorBalances,
+  }
 });

--- a/test/perf/serialize.test.ts
+++ b/test/perf/serialize.test.ts
@@ -7,23 +7,20 @@ describe("serialize", () => {
     const value = Array.from({length: 200000}, () => BigInt(31217089836));
     let minTime = Number.MAX_SAFE_INTEGER;
     let maxTime = 0;
-    let average = {duration: 0, count: 0};
     const MAX_TRY = 10000;
+    const from = process.hrtime.bigint();
     for (let i = 0; i < MAX_TRY; i++) {
       const start = Date.now();
       ValidatorBalancesType.serialize(value);
       const duration = Date.now() - start;
-      const totalDuration = average.duration * average.count + duration;
-      const totalCount = average.count + 1;
-      average.count = totalCount;
-      average.duration = totalDuration / totalCount;
       if (duration < minTime) minTime = duration;
       if (duration > maxTime) maxTime = duration;
     }
-    console.log("serialize minTime:", minTime, "maxTime:", maxTime, "average:", average.duration, "MAX_TRY,", MAX_TRY);
+    const to = process.hrtime.bigint();
+    const average = Number((to - from) / BigInt(MAX_TRY) / BigInt(1000000));
+    console.log("serialize in ms minTime:", minTime, "maxTime:", maxTime, "average:", average, "MAX_TRY:", MAX_TRY);
     expect(minTime).to.be.lt(90, "Minimal serialization is not less than 90ms");
     expect(maxTime).to.be.lt(480, "Maximal serialization is not less than 480ms");
-    expect(average.duration).to.be.lt(100, "Average serialization is not less than 100ms");
-    expect(average.count).to.be.equal(MAX_TRY);
+    expect(average).to.be.lt(100, "Average serialization is not less than 100ms");
   });
 });


### PR DESCRIPTION
resolves #77 

+ Switch back to use number bit shifting to improve performance. Added `fromStructural.test.ts` to prove that and for other improvements in the future if any
+ Leverage `BigInt.asUintN` api and added `BIGINT_4_BYTES` constant to reduce BigInt allocation

Performance statistics for `fromStructural` test:

|Branch|minTime (ms)|maxTime (ms)|average (ms)|
|-------|--------------|--------------|-------------|
|master - 1st|105|678|124.9|
|master - 2nd|104|583|119.32|
|this PR - 1st|62|322|78.00|
|this PR - 2nd|64|376|78.61|