### PR TITLE
Improve convertToTree

### DIFF
--- a/src/types/composite/array.ts
+++ b/src/types/composite/array.ts
@@ -6,6 +6,7 @@ import {BasicType} from "../basic";
 import {CompositeType} from "./abstract";
 import {SszErrorPath} from "../../util/errorPath";
 import {Gindex, iterateAtDepth, LeafNode, Node, subtreeFillToContents, Tree} from "@chainsafe/persistent-merkle-tree";
+import {isTreeBacked} from "../../backings/tree/treeValue";
 
 export interface IArrayOptions {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -99,6 +100,7 @@ export abstract class BasicArrayType<T extends ArrayLike<unknown>> extends Compo
     );
   }
   struct_convertToTree(value: T): Tree {
+    if (isTreeBacked<T>(value)) return value.tree;
     const contents: Node[] = [];
     for (const chunk of this.struct_yieldChunkRoots(value)) {
       contents.push(new LeafNode(chunk));
@@ -379,6 +381,7 @@ export abstract class CompositeArrayType<T extends ArrayLike<unknown>> extends C
     );
   }
   struct_convertToTree(value: T): Tree {
+    if (isTreeBacked<T>(value)) return value.tree;
     const contents: Node[] = [];
     for (const element of value) {
       contents.push(this.elementType.struct_convertToTree(element as CompositeValue).rootNode);

--- a/src/types/composite/container.ts
+++ b/src/types/composite/container.ts
@@ -13,6 +13,7 @@ import {
 } from "@chainsafe/persistent-merkle-tree";
 import {SszErrorPath} from "../../util/errorPath";
 import {toExpectedCase} from "../../util/json";
+import {isTreeBacked} from "../../backings/tree/treeValue";
 
 export interface IContainerOptions {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -220,6 +221,7 @@ export class ContainerType<T extends ObjectLike = ObjectLike> extends CompositeT
     return data;
   }
   struct_convertToTree(value: T): Tree {
+    if (isTreeBacked<T>(value)) return value.tree;
     return new Tree(
       subtreeFillToContents(
         Object.entries(this.fields).map(([fieldName, fieldType]) => {

--- a/src/types/composite/list.ts
+++ b/src/types/composite/list.ts
@@ -5,6 +5,7 @@ import {isBasicType, number32Type} from "../basic";
 import {IJsonOptions, isTypeOf, Type} from "../type";
 import {mixInLength} from "../../util/compat";
 import {BranchNode, Node, Tree, zeroNode} from "@chainsafe/persistent-merkle-tree";
+import {isTreeBacked} from "../../backings/tree/treeValue";
 
 export interface IListOptions extends IArrayOptions {
   limit: number;
@@ -82,6 +83,7 @@ export class BasicListType<T extends List<unknown> = List<unknown>> extends Basi
     return super.struct_convertFromJson(data);
   }
   struct_convertToTree(value: T): Tree {
+    if (isTreeBacked<T>(value)) return value.tree;
     const tree = super.struct_convertToTree(value);
     this.tree_setLength(tree, value.length);
     return tree;
@@ -229,6 +231,7 @@ export class CompositeListType<T extends List<object> = List<object>> extends Co
     return new Tree(this.tree_defaultNode());
   }
   struct_convertToTree(value: T): Tree {
+    if (isTreeBacked<T>(value)) return value.tree;
     const tree = super.struct_convertToTree(value);
     this.tree_setLength(tree, value.length);
     return tree;

--- a/test/perf/convertToTree.test.ts
+++ b/test/perf/convertToTree.test.ts
@@ -1,0 +1,26 @@
+import { expect } from "chai";
+import { CommitteeBits, PendingAttestation } from "./objects";
+
+describe("convertToTree", function () {
+  it("create a new tree from tree backed properties", function () {
+    const bitList = Array.from({length: 128}, () => true);
+    const bitListTree = CommitteeBits.createTreeBackedFromStruct(bitList);
+    const pendingAttestation = {
+      aggregationBits: bitList,
+    };
+    const pendingAttestation2 = {
+      aggregationBits: bitListTree,
+    };
+    const pendingAttestationTree = PendingAttestation.struct_convertToTree(pendingAttestation);
+    const pendingAttestationTree2 = PendingAttestation.struct_convertToTree(pendingAttestation2);
+    expect(pendingAttestationTree.root).to.be.deep.equal(pendingAttestationTree2.root);
+    const MAX_TRY = 1000;
+    const from = process.hrtime.bigint();
+    for (let i = 0; i < MAX_TRY; i++) {
+      PendingAttestation.struct_convertToTree(pendingAttestation2);
+    }
+    const to = process.hrtime.bigint();
+    const timeInMs = Number((to - from) / BigInt(1000000));
+    expect(timeInMs).to.be.lt(20, `convertToTree ${MAX_TRY} times should be less than 20ms`);
+  });
+});

--- a/test/perf/objects.ts
+++ b/test/perf/objects.ts
@@ -1,4 +1,4 @@
-import { BigIntUintType, ContainerType, ListType } from "../../src";
+import { BigIntUintType, BitListType, ContainerType, ListType } from "../../src";
 
 export const Gwei = new BigIntUintType({byteLength: 8});
 
@@ -10,5 +10,17 @@ export const ValidatorBalances = new ListType({
 export const BeaconState = new ContainerType({
   fields: {
     balances: ValidatorBalances,
+  }
+});
+
+const MAX_VALIDATORS_PER_COMMITTEE = 2048;
+
+export const CommitteeBits = new BitListType({
+  limit: MAX_VALIDATORS_PER_COMMITTEE,
+});
+
+export const PendingAttestation = new ContainerType({
+  fields: {
+    aggregationBits: CommitteeBits,
   }
 });


### PR DESCRIPTION
part of https://github.com/ChainSafe/lodestar/issues/2318

**Motivation**

`PendingAttestations` has `aggregationBits` and `data` as TreeBacked values (because they stay inside `attestations` of `TreeBacked<SignedBeaconBlock>`) but it takes so much time to create tree.

**Description**
+ If a value is tree backed, `convertToTree` should return the tree immediately.
+ Reproduce the issue in newly created `convertToTree` performance test.

**Performance test result**
+ master: 368ms
+ this PR: 18ms