### PR TITLE
Add composite type leaves to proof

### DIFF
--- a/src/types/composite/abstract.ts
+++ b/src/types/composite/abstract.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/member-ordering */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import {CompositeValue, Json} from "../../interface";
-import {BackedValue, CompositeArrayTreeValue, createTreeBacked, isBackedValue, Path, TreeBacked} from "../../backings";
+import {BackedValue, createTreeBacked, isBackedValue, Path, TreeBacked} from "../../backings";
 import {IJsonOptions, isTypeOf, Type} from "../type";
 import {
   concatGindices,

--- a/src/types/composite/abstract.ts
+++ b/src/types/composite/abstract.ts
@@ -2,7 +2,7 @@
 /* eslint-disable @typescript-eslint/member-ordering */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import {CompositeValue, Json} from "../../interface";
-import {BackedValue, createTreeBacked, isBackedValue, Path, TreeBacked} from "../../backings";
+import {BackedValue, CompositeArrayTreeValue, createTreeBacked, isBackedValue, Path, TreeBacked} from "../../backings";
 import {IJsonOptions, isTypeOf, Type} from "../type";
 import {
   concatGindices,
@@ -173,7 +173,16 @@ export abstract class CompositeType<T extends CompositeValue> extends Type<T> {
   abstract tree_getPropertyNames(tree: Tree): (string | number)[];
 
   abstract getPropertyGindex(property: PropertyKey): Gindex;
-  getPathGindex(path: Path): Gindex {
+  abstract getPropertyType(property: PropertyKey): Type<unknown> | undefined;
+  abstract tree_getProperty(tree: Tree, property: PropertyKey): Tree | unknown;
+  abstract tree_setProperty(tree: Tree, property: PropertyKey, value: Tree | unknown): boolean;
+  abstract tree_deleteProperty(tree: Tree, property: PropertyKey): boolean;
+  abstract tree_iterateValues(tree: Tree): IterableIterator<Tree | unknown>;
+  abstract tree_readonlyIterateValues(tree: Tree): IterableIterator<Tree | unknown>;
+  /**
+   * Navigate to a subtype & gindex using a path
+   */
+  getPathInfo(path: Path): {gindex: Gindex; type: Type<unknown>} {
     const gindices = [];
     let type = this as CompositeType<CompositeValue>;
     for (const prop of path) {
@@ -183,17 +192,42 @@ export abstract class CompositeType<T extends CompositeValue> extends Type<T> {
       gindices.push(type.getPropertyGindex(prop));
       type = type.getPropertyType(prop) as CompositeType<CompositeValue>;
     }
-    return concatGindices(gindices);
+    return {
+      type,
+      gindex: concatGindices(gindices),
+    };
   }
+  getPathGindex(path: Path): Gindex {
+    return this.getPathInfo(path).gindex;
+  }
+  /**
+   * Get leaf gindices
+   *
+   * Note: This is a recursively called method.
+   * Subtypes recursively call this method until basic types / leaf data is hit.
+   *
+   * @param target Used for variable-length types.
+   * @param root Used to anchor the returned gindices to a non-root gindex.
+   * This is used to augment leaf gindices in recursively-called subtypes relative to the type.
+   * @returns The gindices corresponding to leaf data.
+   */
+  abstract tree_getLeafGindices(target?: Tree, root?: Gindex): Gindex[];
 
-  abstract getPropertyType(property: PropertyKey): Type<unknown> | undefined;
-  abstract tree_getProperty(tree: Tree, property: PropertyKey): Tree | unknown;
-  abstract tree_setProperty(tree: Tree, property: PropertyKey, value: Tree | unknown): boolean;
-  abstract tree_deleteProperty(tree: Tree, property: PropertyKey): boolean;
-  abstract tree_iterateValues(tree: Tree): IterableIterator<Tree | unknown>;
-  abstract tree_readonlyIterateValues(tree: Tree): IterableIterator<Tree | unknown>;
   tree_createProof(target: Tree, paths: Path[]): Proof {
-    const gindices = paths.map((path) => this.getPathGindex(path));
+    const gindices = paths
+      .map((path) => {
+        const {type, gindex} = this.getPathInfo(path);
+        if (!isCompositeType(type)) {
+          return gindex;
+        } else {
+          // if the path subtype is composite, include the gindices of all the leaves
+          return type.tree_getLeafGindices(
+            type.hasVariableSerializedLength() ? target.getSubtree(gindex) : undefined,
+            gindex
+          );
+        }
+      })
+      .flat(1);
     return target.getProof({
       type: ProofType.treeOffset,
       gindices,

--- a/src/types/composite/list.ts
+++ b/src/types/composite/list.ts
@@ -7,6 +7,17 @@ import {mixInLength} from "../../util/compat";
 import {BranchNode, concatGindices, Gindex, Node, Tree, zeroNode} from "@chainsafe/persistent-merkle-tree";
 import {isTreeBacked} from "../../backings/tree/treeValue";
 
+/**
+ * SSZ Lists (variable-length arrays) include the length of the list in the tree
+ * This length is always in the same index in the tree
+ * ```
+ *   1
+ *  / \
+ * 2   3 // <-here
+ * ```
+ */
+export const LENGTH_GINDEX = BigInt(3);
+
 export interface IListOptions extends IArrayOptions {
   limit: number;
 }
@@ -112,13 +123,13 @@ export class BasicListType<T extends List<unknown> = List<unknown>> extends Basi
   }
 
   tree_getLength(target: Tree): number {
-    return number32Type.struct_deserializeFromBytes(target.getRoot(BigInt(3)), 0);
+    return number32Type.struct_deserializeFromBytes(target.getRoot(LENGTH_GINDEX), 0);
   }
 
   tree_setLength(target: Tree, length: number): void {
     const chunk = new Uint8Array(32);
     number32Type.toBytes(length, chunk, 0);
-    target.setRoot(BigInt(3), chunk);
+    target.setRoot(LENGTH_GINDEX, chunk);
   }
 
   tree_deserializeFromBytes(data: Uint8Array, start: number, end: number): Tree {
@@ -201,7 +212,7 @@ export class BasicListType<T extends List<unknown> = List<unknown>> extends Basi
     }
     const gindices = super.tree_getLeafGindices(target, root);
     // include the length chunk
-    gindices.push(concatGindices([root, BigInt(3)]));
+    gindices.push(concatGindices([root, LENGTH_GINDEX]));
     return gindices;
   }
 }
@@ -286,13 +297,13 @@ export class CompositeListType<T extends List<object> = List<object>> extends Co
   }
 
   tree_getLength(target: Tree): number {
-    return number32Type.struct_deserializeFromBytes(target.getRoot(BigInt(3)), 0);
+    return number32Type.struct_deserializeFromBytes(target.getRoot(LENGTH_GINDEX), 0);
   }
 
   tree_setLength(target: Tree, length: number): void {
     const chunk = new Uint8Array(32);
     number32Type.struct_serializeToBytes(length, chunk, 0);
-    target.setRoot(BigInt(3), chunk);
+    target.setRoot(LENGTH_GINDEX, chunk);
   }
 
   tree_deserializeFromBytes(data: Uint8Array, start: number, end: number): Tree {
@@ -391,7 +402,7 @@ export class CompositeListType<T extends List<object> = List<object>> extends Co
     }
     const gindices = super.tree_getLeafGindices(target, root);
     // include the length chunk
-    gindices.push(concatGindices([root, BigInt(3)]));
+    gindices.push(concatGindices([root, LENGTH_GINDEX]));
     return gindices;
   }
 }

--- a/src/types/composite/list.ts
+++ b/src/types/composite/list.ts
@@ -4,7 +4,7 @@ import {IArrayOptions, BasicArrayType, CompositeArrayType} from "./array";
 import {isBasicType, number32Type} from "../basic";
 import {IJsonOptions, isTypeOf, Type} from "../type";
 import {mixInLength} from "../../util/compat";
-import {BranchNode, Node, Tree, zeroNode} from "@chainsafe/persistent-merkle-tree";
+import {BranchNode, concatGindices, Gindex, Node, Tree, zeroNode} from "@chainsafe/persistent-merkle-tree";
 import {isTreeBacked} from "../../backings/tree/treeValue";
 
 export interface IListOptions extends IArrayOptions {
@@ -195,6 +195,15 @@ export class BasicListType<T extends List<unknown> = List<unknown>> extends Basi
   getMaxChunkCount(): number {
     return Math.ceil((this.limit * this.elementType.size()) / 32);
   }
+  tree_getLeafGindices(target?: Tree, root: Gindex = BigInt(1)): Gindex[] {
+    if (!target) {
+      throw new Error("variable type requires tree argument to get leaves");
+    }
+    const gindices = super.tree_getLeafGindices(target, root);
+    // include the length chunk
+    gindices.push(concatGindices([root, BigInt(3)]));
+    return gindices;
+  }
 }
 
 export class CompositeListType<T extends List<object> = List<object>> extends CompositeArrayType<T> {
@@ -375,5 +384,14 @@ export class CompositeListType<T extends List<object> = List<object>> extends Co
     this.tree_setSubtreeAtChunkIndex(target, length - 1, new Tree(zeroNode(0)));
     this.tree_setLength(target, length - 1);
     return value as T[number];
+  }
+  tree_getLeafGindices(target?: Tree, root: Gindex = BigInt(1)): Gindex[] {
+    if (!target) {
+      throw new Error("variable type requires tree argument to get leaves");
+    }
+    const gindices = super.tree_getLeafGindices(target, root);
+    // include the length chunk
+    gindices.push(concatGindices([root, BigInt(3)]));
+    return gindices;
   }
 }

--- a/test/unit/proof.test.ts
+++ b/test/unit/proof.test.ts
@@ -1,0 +1,14 @@
+import { expect } from "chai";
+import { ArrayObject, SimpleObject } from "./objects";
+
+describe("create proof", () => {
+  it("should include all leaves of path to composite type", () => {
+    const arrayObj = ArrayObject.defaultTreeBacked();
+    const simpleObj = SimpleObject.defaultTreeBacked();
+    arrayObj.v.push(simpleObj);
+    const proof = arrayObj.createProof([["v"]]);
+    const arrayObj2 = ArrayObject.createTreeBackedFromProofUnsafe(proof);
+    expect(arrayObj2.v[0].valueOf()).to.deep.equal(arrayObj.v[0].valueOf());
+    expect(arrayObj2.v.valueOf()).to.deep.equal(arrayObj.v.valueOf());
+  });
+});


### PR DESCRIPTION
When creating a proof with a path to a composite type, include all
leaves of the type in the proof.

- Add `CompositeType#tree_getLeafGindices(tree?: Tree, root?: Gindex): Gindex[]`
  - This is where the magic happens. Composite types are recursively traversed to the terminal types to get leaf gindices.
  - The tree is included for 'length' information for variable-length objects. (otherwise we wouldn't know which gindices to include for eg: `state.validators`)
  - A "root" gindex is included to allow for deeply nested types to return gindices relative to the root type
- `CompositeType#createProof` is extended to call `tree_getLeafGindices` when the type at a path is a composite type.