### PR TITLE
Fix BitVector tree_deserializeFromBytes()

### DIFF
--- a/src/types/composite/bitVector.ts
+++ b/src/types/composite/bitVector.ts
@@ -124,7 +124,7 @@ export class BitVectorType extends BasicVectorType<BitVector> {
     const lastByteBitLen = this.length % 8;
     if (lastByteBitLen > 0) {
       const mask = (0xff << lastByteBitLen) & 0xff;
-      if (lastByte & mask > 0) {
+      if ((lastByte & mask) > 0) {
         throw new Error("Invalid deserialized bitvector length");
       }
     }

--- a/src/types/composite/bitVector.ts
+++ b/src/types/composite/bitVector.ts
@@ -119,9 +119,13 @@ export class BitVectorType extends BasicVectorType<BitVector> {
   tree_deserializeFromBytes(data: Uint8Array, start: number, end: number): Tree {
     // mask last byte to ensure it doesn't go over length
     const lastByte = data[end - 1];
-    const mask = (0xff << this.length % 8) & 0xff;
-    if (lastByte & mask) {
-      throw new Error("Invalid deserialized bitvector length");
+    const lastBitLength = this.length % 8;
+    // vector does not take up the whole byte, need to make sure all bits after length are all 0
+    if (lastBitLength) {
+      const mask = (0xff << this.length % 8) & 0xff;
+      if (lastByte & mask) {
+        throw new Error("Invalid deserialized bitvector length");
+      }
     }
     return super.tree_deserializeFromBytes(data, start, end);
   }

--- a/src/types/composite/bitVector.ts
+++ b/src/types/composite/bitVector.ts
@@ -119,11 +119,12 @@ export class BitVectorType extends BasicVectorType<BitVector> {
   tree_deserializeFromBytes(data: Uint8Array, start: number, end: number): Tree {
     // mask last byte to ensure it doesn't go over length
     const lastByte = data[end - 1];
-    const lastBitLength = this.length % 8;
-    // vector does not take up the whole byte, need to make sure all bits after length are all 0
-    if (lastBitLength) {
-      const mask = (0xff << this.length % 8) & 0xff;
-      if (lastByte & mask) {
+    // If the data len fits full bytes this check must be skipped.
+    // Otherwise we must ensure that the extra bits are set to zero.
+    const lastByteBitLen = this.length % 8;
+    if (lastByteBitLen > 0) {
+      const mask = (0xff << lastByteBitLen) & 0xff;
+      if (lastByte & mask > 0) {
         throw new Error("Invalid deserialized bitvector length");
       }
     }

--- a/test/unit/regression.test.ts
+++ b/test/unit/regression.test.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai";
 
-import {VectorType, ByteVectorType, NumberUintType, BitListType, BitVectorType, ListType} from "../../src";
+import {VectorType, ByteVectorType, NumberUintType, BitListType, BitVectorType, ListType, fromHexString} from "../../src";
 
 describe("known issues", () => {
   it("default value of composite vector should be correct", () => {
@@ -30,6 +30,20 @@ describe("known issues", () => {
 
     expect(() => CommitteeBits.createTreeBackedFromStruct(bits)).to.not.throw();
     expect(() => CommitteeBitsVector.createTreeBackedFromStruct(bits)).to.not.throw();
+  });
+
+  it("converts Uint8Array to tree", function () {
+    const CommitteeBits = new BitListType({limit: 32});
+    const CommitteeBitsVector = new BitVectorType({length: 32});
+    const validBytes = fromHexString("0xffffffff");
+
+    expect(() => CommitteeBits.createTreeBackedFromBytes(validBytes)).to.not.throw();
+    expect(() => CommitteeBitsVector.createTreeBackedFromBytes(validBytes)).to.not.throw();
+
+    const invalidBytes = fromHexString("0xffffffffff");
+    const CommitteeBitsVector2 = new BitVectorType({length: 33});
+    // all bits after length should be 0 so this should throw error
+    expect(() => CommitteeBitsVector2.createTreeBackedFromBytes(invalidBytes)).to.throw("Invalid deserialized bitvector length");
   });
 
   it("converts basic vector and list from json", function () {


### PR DESCRIPTION
## Description
+ `BitVector.tree_deserializeFromBytes` has a check to make sure all bits after `length` should be 0, but that should only be for the case vector does not take up the whole byte
+ close #115 