### PR TITLE
Fix benchmark action

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -39,6 +39,4 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # Enable alert commit comment
           comment-on-alert: true
-          # Push and deploy GitHub pages branch automatically
-          auto-push: true
       # Upload the updated cache file for the next job by actions/cache


### PR DESCRIPTION
```
Error: auto-push must be false when external-data-json-path is set since this action reads/writes the given JSON file and never pushes to remote
```