### PR TITLE
Fix benchmark output formatting

### DIFF
--- a/test/perf/utils/runner.ts
+++ b/test/perf/utils/runner.ts
@@ -139,7 +139,7 @@ function formatResultRow({id, averageNs, runsDone, factor}: BenchmarkResult): st
  */
 function formatAsBenchmarkJs(results: BenchmarkResult[]): string {
   return results
-    .map(({id, averageNs, runsDone}) => `${id} x ${1e9 / averageNs} ±0.00% (${runsDone} runs sampled)`)
+    .map(({id, averageNs, runsDone}) => `${id} x ${1e9 / averageNs} ops/sec ±0.00% (${runsDone} runs sampled)`)
     .join("\n");
 }
 


### PR DESCRIPTION
```
Error: No benchmark result was found in /home/runner/work/ssz/ssz/benchmark-output.txt. Benchmark output was 'Simple object binary -> struct x 223264.12145568206 ±0.00% (19164 runs sampled)
```