### PR TITLE
Fix struct_getRootAtChunkIndex for BitVectorType

### DIFF
--- a/src/types/composite/bitVector.ts
+++ b/src/types/composite/bitVector.ts
@@ -5,6 +5,7 @@ import {booleanType} from "../basic";
 import {isTypeOf, Type} from "../type";
 import {fromHexString, toHexString, getByteBits} from "../../util/byteArray";
 import {Tree} from "@chainsafe/persistent-merkle-tree";
+import {BYTES_PER_CHUNK} from "../../util/constants";
 
 export interface IBitVectorOptions {
   length: number;
@@ -90,11 +91,12 @@ export class BitVectorType extends BasicVectorType<BitVector> {
     return offset + byteLength;
   }
 
-  struct_getRootAtChunkIndex(value: BitVector, index: number): Uint8Array {
-    const output = new Uint8Array(32);
-    const byteLength = Math.min(32, this.struct_getByteLength(value) - index);
+  struct_getRootAtChunkIndex(value: BitVector, chunkIndex: number): Uint8Array {
+    const output = new Uint8Array(BYTES_PER_CHUNK);
+    const byteLength = Math.min(BYTES_PER_CHUNK, this.struct_getByteLength(value) - chunkIndex);
+    const byteOffset = chunkIndex * BYTES_PER_CHUNK;
     for (let i = 0; i < byteLength; i++) {
-      output[i] = this.struct_getByte(value, i + index);
+      output[i] = this.struct_getByte(value, i + byteOffset);
     }
     return output;
   }

--- a/test/unit/regression.test.ts
+++ b/test/unit/regression.test.ts
@@ -1,8 +1,20 @@
 import {expect} from "chai";
 
-import {VectorType, ByteVectorType, NumberUintType, BitListType, BitVectorType, ListType, fromHexString} from "../../src";
+import {VectorType, ByteVectorType, NumberUintType, BitListType, BitVectorType, ListType, fromHexString, toHexString} from "../../src";
 
 describe("known issues", () => {
+  it("SyncCommitteeBits hashTreeRoot consistency", function () {
+    const SyncCommitteeBits = new BitVectorType({
+      length: 512,
+    });
+    const biStr = "00001110011100101010100110111001111011110111001110110010101000010010011110000110001101111100100100011011001001010000111010010011100100111010111101110110001000000011011001011000011101010111111011000110000101100111111000110011110010010110101011111110111010101111110010011111101001011110001101111110111001100110110001100010100010101110110010100100001011000101101000011010111010111000100100101000101100001100011001110100100111110011100111001100101001011011111001111010111011000100100000010000000111010010100000000111";
+    const arr = Array.from({length: 512}, (_, i) => biStr.charAt(i) === "0" ? false: true);
+    const rootByStruct = SyncCommitteeBits.hashTreeRoot(arr);
+    const bytes = SyncCommitteeBits.serialize(arr);
+    const rootByTreeBacked = SyncCommitteeBits.createTreeBackedFromBytes(bytes).hashTreeRoot();
+    expect(toHexString(rootByStruct)).to.be.equal(toHexString(rootByTreeBacked), "Inconsistent hashTreeRoot");
+  });
+
   it("default value of composite vector should be correct", () => {
     const Vec = new VectorType({
       elementType: new ByteVectorType({length: 4}),


### PR DESCRIPTION
Close #123 
+ `BitVectorType.struct_getRootAtChunkIndex` accepts a chunk index, not byte index so we have to multiply 32 as byte offset
+ Rename variables accordingly and add unit test