### PR TITLE
Use gindexbitstring whenever possible

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@chainsafe/as-sha256": "^0.2.4",
-    "@chainsafe/persistent-merkle-tree": "^0.3.6",
+    "@chainsafe/persistent-merkle-tree": "^0.3.7",
     "case": "^1.6.3"
   },
   "devDependencies": {

--- a/src/types/composite/abstract.ts
+++ b/src/types/composite/abstract.ts
@@ -7,10 +7,12 @@ import {
   concatGindices,
   countToDepth,
   Gindex,
+  GindexBitstring,
   Node,
   Proof,
   ProofType,
   toGindex,
+  toGindexBitstring,
   Tree,
 } from "@chainsafe/persistent-merkle-tree";
 import {merkleize} from "../../util/compat";
@@ -150,24 +152,29 @@ export abstract class CompositeType<T extends CompositeValue> extends Type<T> {
     }
     return this._chunkDepth;
   }
+
   getGindexAtChunkIndex(index: number): Gindex {
     return toGindex(this.getChunkDepth(), BigInt(index));
   }
 
+  getGindexBitStringAtChunkIndex(index: number): GindexBitstring {
+    return toGindexBitstring(this.getChunkDepth(), index);
+  }
+
   tree_getSubtreeAtChunkIndex(target: Tree, index: number): Tree {
-    return target.getSubtree(this.getGindexAtChunkIndex(index));
+    return target.getSubtree(this.getGindexBitStringAtChunkIndex(index));
   }
 
   tree_setSubtreeAtChunkIndex(target: Tree, index: number, value: Tree, expand = false): void {
-    target.setSubtree(this.getGindexAtChunkIndex(index), value, expand);
+    target.setSubtree(this.getGindexBitStringAtChunkIndex(index), value, expand);
   }
 
   tree_getRootAtChunkIndex(target: Tree, index: number): Uint8Array {
-    return target.getRoot(this.getGindexAtChunkIndex(index));
+    return target.getRoot(this.getGindexBitStringAtChunkIndex(index));
   }
 
   tree_setRootAtChunkIndex(target: Tree, index: number, value: Uint8Array, expand = false): void {
-    target.setRoot(this.getGindexAtChunkIndex(index), value, expand);
+    target.setRoot(this.getGindexBitStringAtChunkIndex(index), value, expand);
   }
 
   abstract struct_getPropertyNames(struct: T): (string | number)[];

--- a/src/types/composite/array.ts
+++ b/src/types/composite/array.ts
@@ -265,12 +265,12 @@ export abstract class BasicArrayType<T extends ArrayLike<unknown>> extends Compo
   }
 
   tree_setValueAtIndex(target: Tree, index: number, value: T[number], expand = false): boolean {
-    const chunkGindex = this.getGindexAtChunkIndex(this.getChunkIndex(index));
+    const chunkGindexBitString = this.getGindexBitStringAtChunkIndex(this.getChunkIndex(index));
     // copy data from old chunk, use new memory to set a new chunk
     const chunk = new Uint8Array(32);
-    chunk.set(target.getRoot(chunkGindex));
+    chunk.set(target.getRoot(chunkGindexBitString));
     this.elementType.struct_serializeToBytes(value, chunk, this.getChunkOffset(index));
-    target.setRoot(chunkGindex, chunk, expand);
+    target.setRoot(chunkGindexBitString, chunk, expand);
     return true;
   }
 

--- a/src/types/composite/bitList.ts
+++ b/src/types/composite/bitList.ts
@@ -146,17 +146,17 @@ export class BitListType extends BasicListType<BitList> {
     }
     // the last byte is > 1, so a padding bit will exist in the last byte and need to be removed
     const target = super.tree_deserializeFromBytes(data, start, end);
-    const lastGindex = this.getGindexAtChunkIndex(Math.ceil((end - start) / 32) - 1);
+    const lastGindexBitString = this.getGindexBitStringAtChunkIndex(Math.ceil((end - start) / 32) - 1);
     // copy chunk into new memory
     const lastChunk = new Uint8Array(32);
-    lastChunk.set(target.getRoot(lastGindex));
+    lastChunk.set(target.getRoot(lastGindexBitString));
     const lastChunkByte = ((end - start) % 32) - 1;
     // mask lastChunkByte
     const lastByteBitLength = lastByte.toString(2).length - 1;
     const length = (end - start - 1) * 8 + lastByteBitLength;
     const mask = 0xff >> (8 - lastByteBitLength);
     lastChunk[lastChunkByte] &= mask;
-    target.setRoot(lastGindex, lastChunk);
+    target.setRoot(lastGindexBitString, lastChunk);
     this.tree_setLength(target, length);
     return target;
   }
@@ -236,16 +236,16 @@ export class BitListType extends BasicListType<BitList> {
   }
 
   tree_setValueAtIndex(target: Tree, property: number, value: boolean, expand = false): boolean {
-    const chunkGindex = this.getGindexAtChunkIndex(this.getChunkIndex(property));
+    const chunkGindexBitString = this.getGindexBitStringAtChunkIndex(this.getChunkIndex(property));
     const chunk = new Uint8Array(32);
-    chunk.set(target.getRoot(chunkGindex));
+    chunk.set(target.getRoot(chunkGindexBitString));
     const byteOffset = this.getChunkOffset(property);
     if (value) {
       chunk[byteOffset] |= 1 << this.getBitOffset(property);
     } else {
       chunk[byteOffset] &= 0xff ^ (1 << this.getBitOffset(property));
     }
-    target.setRoot(chunkGindex, chunk, expand);
+    target.setRoot(chunkGindexBitString, chunk, expand);
     return true;
   }
 

--- a/src/types/composite/bitVector.ts
+++ b/src/types/composite/bitVector.ts
@@ -193,16 +193,16 @@ export class BitVectorType extends BasicVectorType<BitVector> {
   }
 
   tree_setProperty(target: Tree, property: number, value: boolean): boolean {
-    const chunkGindex = this.getGindexAtChunkIndex(this.getChunkIndex(property));
+    const chunkGindexBitString = this.getGindexBitStringAtChunkIndex(this.getChunkIndex(property));
     const chunk = new Uint8Array(32);
-    chunk.set(target.getRoot(chunkGindex));
+    chunk.set(target.getRoot(chunkGindexBitString));
     const byteOffset = this.getChunkOffset(property);
     if (value) {
       chunk[byteOffset] |= 1 << this.getBitOffset(property);
     } else {
       chunk[byteOffset] &= 0xff ^ (1 << this.getBitOffset(property));
     }
-    target.setRoot(chunkGindex, chunk);
+    target.setRoot(chunkGindexBitString, chunk);
     return true;
   }
 

--- a/src/types/composite/union.ts
+++ b/src/types/composite/union.ts
@@ -260,7 +260,7 @@ export class UnionType<T extends Union<unknown>> extends CompositeType<T> {
     return ["value", "selector"];
   }
 
-  getPropertyGindex(property: PropertyKey): bigint {
+  getPropertyGindex(property: PropertyKey): Gindex {
     switch (property) {
       case "value":
         return VALUE_GINDEX;

--- a/yarn.lock
+++ b/yarn.lock
@@ -371,10 +371,10 @@
   dependencies:
     "@chainsafe/as-sha256" "^0.2.2"
 
-"@chainsafe/persistent-merkle-tree@^0.3.6":
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.3.6.tgz#a1b3b9d08e9cdae58304d0729760e5ac986056f5"
-  integrity sha512-fQn/wGBraRqpJsYbVeHEAE38XkPzW6AKqPBDswTVlbTxV4aXkpxajYQVGU+mEJ97Eh5yKm/cEtN4HudlUqUQcQ==
+"@chainsafe/persistent-merkle-tree@^0.3.7":
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.3.7.tgz#d257674fcacf1770e54df1e7e476bb55efcb3ed4"
+  integrity sha512-UXXzvCN8P4eQWCsaTaHRrNa+2sTwY3NB0Vf+uWgM4cU1qf8LOsTU7aU2CeXFAGJag5W/xEQfVGNh463kXTYAgg==
   dependencies:
     "@chainsafe/as-sha256" "^0.2.3"
 


### PR DESCRIPTION
**Motivation**
+ Minor improvement: we want to use `GIndexBitString` whenever possible to avoid BigInt allocation.
+ This depends on https://github.com/ChainSafe/persistent-merkle-tree/pull/45

