### PR TITLE
Use utility function for bigint exponentiation

### DIFF
--- a/src/types/basic/uint.ts
+++ b/src/types/basic/uint.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/camelcase */
 import {Json} from "../../interface";
+import {bigIntPow} from "../../util/bigInt";
 import {isTypeOf, Type} from "../type";
 import {BasicType} from "./abstract";
 
@@ -59,7 +60,7 @@ export class NumberUintType extends UintType<number> {
 
   struct_getMaxBigInt(): BigInt {
     if (this._maxBigInt === undefined) {
-      this._maxBigInt = BigInt(2) ** BigInt(this.byteLength * 8) - BigInt(1);
+      this._maxBigInt = bigIntPow(BigInt(2), BigInt(this.byteLength * 8)) - BigInt(1);
     }
     return this._maxBigInt;
   }

--- a/src/util/bigInt.ts
+++ b/src/util/bigInt.ts
@@ -1,0 +1,11 @@
+export function bigIntPow(base: bigint, exponent: bigint): bigint {
+  if (exponent < 0) {
+    throw new RangeError("Exponent must be positive");
+  }
+
+  let out = BigInt(1);
+  for (; exponent > 0; exponent--) {
+    out *= base;
+  }
+  return out;
+}

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -1,0 +1,15 @@
+import {expect} from "chai";
+import {bigIntPow} from "../../src/util/bigInt";
+
+describe("util / bigIntPow", () => {
+  it("should throw error on negative exponent", () => {
+    expect(() => bigIntPow(BigInt(1), BigInt(-1))).to.throw();
+  });
+  it("should properly exponentiate", () => {
+    for (let x = BigInt(-20); x < 20; x++) {
+      for (let y = BigInt(0); y < 50; y++) {
+        expect(bigIntPow(x, y), `${x} ** ${y}`).to.equal(x ** y);
+      }
+    }
+  });
+});


### PR DESCRIPTION
Downstream libraries may transpile this library to remove the exponentiaiton (`**`) operator.

In the case of exponentiating bigints, the code gets incorrectly transpiled from `BigInt(a) ** BigInt(b)` to `Math.pow(BigInt(a), BigInt(b))`

This PR avoids using `**` with bigints by replacing it with a utility function that does the same.