### PR TITLE
Add getFixedSerializedLength()

### DIFF
--- a/src/types/basic/abstract.ts
+++ b/src/types/basic/abstract.ts
@@ -39,6 +39,10 @@ export abstract class BasicType<T> extends Type<T> {
     return false;
   }
 
+  getFixedSerializedLength(): number {
+    return this.struct_getSerializedLength();
+  }
+
   getMaxSerializedLength(): number {
     return this.struct_getSerializedLength();
   }

--- a/src/types/composite/abstract.ts
+++ b/src/types/composite/abstract.ts
@@ -101,8 +101,10 @@ export abstract class CompositeType<T extends CompositeValue> extends Type<T> {
       throw new Error(`End param: ${end} is greater than length: ${data.length}`);
     }
     const length = end - start;
-    if (!this.hasVariableSerializedLength() && length !== this.struct_getSerializedLength(null)) {
-      throw new Error(`Incorrect data length ${length}, expect ${this.struct_getSerializedLength(null)}`);
+
+    const fixedLen = this.getFixedSerializedLength();
+    if (fixedLen !== null && length !== fixedLen) {
+      throw new Error(`Incorrect data length ${length}, expect ${fixedLen}`);
     }
     if (end - start < this.getMinSerializedLength()) {
       throw new Error(`Data length ${length} is too small, expect at least ${this.getMinSerializedLength()}`);

--- a/src/types/composite/bitVector.ts
+++ b/src/types/composite/bitVector.ts
@@ -28,6 +28,8 @@ export class BitVectorType extends BasicVectorType<BitVector> {
     return this.length;
   }
 
+  // Override all length methods to understand .length as bits not bytes
+
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   struct_getByteLength(value: BitVector): number {
     return Math.ceil(this.length / 8);
@@ -38,12 +40,16 @@ export class BitVectorType extends BasicVectorType<BitVector> {
     return Math.ceil(this.length / 8);
   }
 
+  getFixedSerializedLength(): null | number {
+    return Math.ceil(this.length / 8);
+  }
+
   getMaxSerializedLength(): number {
-    return this.struct_getSerializedLength(null);
+    return Math.ceil(this.length / 8);
   }
 
   getMinSerializedLength(): number {
-    return this.struct_getSerializedLength(null);
+    return Math.ceil(this.length / 8);
   }
 
   struct_getChunkCount(value: BitVector): number {

--- a/src/types/type.ts
+++ b/src/types/type.ts
@@ -78,6 +78,11 @@ export abstract class Type<T> {
   abstract hasVariableSerializedLength(): boolean;
 
   /**
+   * if hasVariableSerializedLength() === true, returns null. Otherwise returns a length value
+   */
+  abstract getFixedSerializedLength(): null | number;
+
+  /**
    * Maximal serialized byte length
    */
   abstract getMaxSerializedLength(): number;


### PR DESCRIPTION
In ssz lib there's a bad type pattern used in

```ts
this.elementType.struct_getSerializedLength(null)
```

since getSerializedLength may or may not require an argument depending on if it is variable length or not.

```ts
if (this.elementType.hasVariableSerializedLength()) {
  // variable stuff
} else {
  return this.elementType.struct_getSerializedLength(null);
}
```

A more typesafe pattern, which requires one less call is

```ts
const fixedLen = this.elementType.getFixedSerializedLength()
if (fixedLen === null) {
  // variable stuff
} else {
  return fixedLen
}
```

where it uses type information to figure out if it's variable length or not.

----

@wemeetagain please review I didn't messed up any of the logic