### PR TITLE
Add alternative to iterator interface

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@chainsafe/as-sha256": "^0.2.4",
-    "@chainsafe/persistent-merkle-tree": "^0.3.5",
+    "@chainsafe/persistent-merkle-tree": "^0.3.6",
     "case": "^1.6.3"
   },
   "devDependencies": {

--- a/src/backings/tree/interface.ts
+++ b/src/backings/tree/interface.ts
@@ -60,4 +60,10 @@ export interface ITreeBacked<T extends CompositeValue> {
   entries(): IterableIterator<[string, ValueOf<T>]>;
   readonlyValues(): IterableIterator<ValueOf<T>>;
   readonlyEntries(): IterableIterator<[string, ValueOf<T>]>;
+
+  keysArray(): string[];
+  valuesArray(): ValueOf<T>[];
+  entriesArray(): [string, ValueOf<T>][];
+  readonlyValuesArray(): ValueOf<T>[];
+  readonlyEntriesArray(): [string, ValueOf<T>][];
 }

--- a/src/types/composite/abstract.ts
+++ b/src/types/composite/abstract.ts
@@ -180,6 +180,8 @@ export abstract class CompositeType<T extends CompositeValue> extends Type<T> {
   abstract tree_deleteProperty(tree: Tree, property: PropertyKey): boolean;
   abstract tree_iterateValues(tree: Tree): IterableIterator<Tree | unknown>;
   abstract tree_readonlyIterateValues(tree: Tree): IterableIterator<Tree | unknown>;
+  abstract tree_getValues(tree: Tree): (Tree | unknown)[];
+  abstract tree_readonlyGetValues(tree: Tree): (Tree | unknown)[];
   /**
    * Navigate to a subtype & gindex using a path
    */

--- a/src/types/composite/bitList.ts
+++ b/src/types/composite/bitList.ts
@@ -213,6 +213,22 @@ export class BitListType extends BasicListType<BitList> {
     }
   }
 
+  tree_getValues(target: Tree): (Tree | unknown)[] {
+    const length = this.tree_getLength(target);
+    const chunkCount = this.tree_getChunkCount(target);
+    const nodes = target.getNodesAtDepth(this.getChunkDepth(), 0, chunkCount);
+    let i = 0;
+    const values = [];
+    for (let nodeIx = 0; nodeIx < nodes.length; nodeIx++) {
+      const chunk = nodes[nodeIx].root;
+      for (let j = 0; j < 256 && i < length; i++, j++) {
+        const byte = chunk[this.getChunkOffset(i)];
+        values.push(!!(byte & (1 << this.getBitOffset(i))));
+      }
+    }
+    return values;
+  }
+
   tree_getValueAtIndex(target: Tree, index: number): boolean {
     const chunk = this.tree_getRootAtChunkIndex(target, this.getChunkIndex(index));
     const byte = chunk[this.getChunkOffset(index)];

--- a/src/types/composite/bitVector.ts
+++ b/src/types/composite/bitVector.ts
@@ -170,6 +170,22 @@ export class BitVectorType extends BasicVectorType<BitVector> {
     }
   }
 
+  tree_getValues(target: Tree): (Tree | unknown)[] {
+    const length = this.tree_getLength(target);
+    const chunkCount = this.tree_getChunkCount(target);
+    const nodes = target.getNodesAtDepth(this.getChunkDepth(), 0, chunkCount);
+    let i = 0;
+    const values = [];
+    for (let nodeIx = 0; nodeIx < nodes.length; nodeIx++) {
+      const chunk = nodes[nodeIx].root;
+      for (let j = 0; j < 256 && i < length; i++, j++) {
+        const byte = chunk[this.getChunkOffset(i)];
+        values.push(!!(byte & (1 << this.getBitOffset(i))));
+      }
+    }
+    return values;
+  }
+
   tree_getValueAtIndex(target: Tree, index: number): boolean {
     const chunk = this.tree_getRootAtChunkIndex(target, this.getChunkIndex(index));
     const byte = chunk[this.getChunkOffset(index)];

--- a/src/types/composite/container.ts
+++ b/src/types/composite/container.ts
@@ -3,6 +3,7 @@ import {CompositeType, isCompositeType} from "./abstract";
 import {IJsonOptions, isTypeOf, Type} from "../type";
 import {
   concatGindices,
+  getGindicesAtDepth,
   Gindex,
   iterateAtDepth,
   LeafNode,
@@ -530,6 +531,37 @@ export class ContainerType<T extends ObjectLike = ObjectLike> extends CompositeT
         yield new Tree(node);
       }
     }
+  }
+
+  tree_getValues(target: Tree): (Tree | unknown)[] {
+    const fieldTypes = Object.values(this.fields);
+    const gindices = getGindicesAtDepth(this.getChunkDepth(), 0, fieldTypes.length);
+    const values = [];
+    for (let i = 0; i < fieldTypes.length; i++) {
+      const fieldType = fieldTypes[i];
+      if (!isCompositeType(fieldType)) {
+        values.push(fieldType.struct_deserializeFromBytes(target.getRoot(gindices[i]), 0));
+      } else {
+        values.push(target.getSubtree(gindices[i]));
+      }
+    }
+    return values;
+  }
+
+  tree_readonlyGetValues(target: Tree): (Tree | unknown)[] {
+    const fieldTypes = Object.values(this.fields);
+    const nodes = target.getNodesAtDepth(this.getChunkDepth(), 0, fieldTypes.length);
+    const values = [];
+    for (let i = 0; i < fieldTypes.length; i++) {
+      const fieldType = fieldTypes[i];
+      const node = nodes[i];
+      if (!isCompositeType(fieldType)) {
+        values.push(fieldType.struct_deserializeFromBytes(node.root, 0));
+      } else {
+        values.push(new Tree(node));
+      }
+    }
+    return values;
   }
 
   hasVariableSerializedLength(): boolean {

--- a/test/perf/iterate.test.ts
+++ b/test/perf/iterate.test.ts
@@ -1,4 +1,14 @@
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
+import {
+  booleanType,
+  ByteVectorType,
+  ContainerType,
+  List,
+  ListType,
+  NumberUintType,
+  ObjectLike,
+  TreeBacked,
+} from "../../src";
 
 describe("iterate", () => {
   setBenchOpts({
@@ -27,3 +37,82 @@ describe("iterate", () => {
     }
   });
 });
+
+describe("readonly values - iterator vs array", () => {
+  setBenchOpts({
+    maxMs: 30 * 1000,
+    minMs: 10 * 1000,
+    runs: 1000,
+  });
+
+  const length = 250_000;
+  const balances = createBalanceList(length);
+
+  itBench("basicListValue.readonlyValues()", () => {
+    for (const balance of balances.readonlyValues()) {
+      balance + 1;
+    }
+  });
+  itBench("basicListValue.readonlyValuesArray()", () => {
+    const balancesArray = balances.readonlyValuesArray();
+    for (let i = 0; i < balancesArray.length; i++) {
+      balancesArray[i] + 1;
+    }
+  });
+
+  const validators = createValidatorList(length);
+
+  itBench("compositeListValue.readonlyValues()", () => {
+    for (const v of validators.readonlyValues()) {
+      v.exitEpoch;
+    }
+  });
+  itBench("compositeListValue.readonlyValuesArray()", () => {
+    const validatorsArray = validators.readonlyValuesArray();
+    for (let i = 0; i < validatorsArray.length; i++) {
+      validatorsArray[i].exitEpoch;
+    }
+  });
+});
+
+function createBalanceList(count: number): TreeBacked<List<number>> {
+  const VALIDATOR_REGISTRY_LIMIT = 1099511627776;
+
+  const balancesList = new ListType({
+    elementType: new NumberUintType({byteLength: 8}),
+    limit: VALIDATOR_REGISTRY_LIMIT,
+  });
+  const balancesStruct = Array.from({length: count}, () => 31217089836);
+  return balancesList.createTreeBackedFromStruct(balancesStruct);
+}
+function createValidatorList(count: number): TreeBacked<List<ObjectLike>> {
+  const VALIDATOR_REGISTRY_LIMIT = 1099511627776;
+
+  const Validator = new ContainerType({
+    fields: {
+      pubkey: new ByteVectorType({length: 48}),
+      withdrawalCredentials: new ByteVectorType({length: 32}),
+      effectiveBalance: new NumberUintType({byteLength: 8}),
+      slashed: booleanType,
+      activationEligibilityEpoch: new NumberUintType({byteLength: 8}),
+      activationEpoch: new NumberUintType({byteLength: 8}),
+      exitEpoch: new NumberUintType({byteLength: 8}),
+      withdrawableEpoch: new NumberUintType({byteLength: 8}),
+    },
+  });
+  const validatorList = new ListType({
+    elementType: Validator,
+    limit: VALIDATOR_REGISTRY_LIMIT,
+  });
+  const validatorsStruct = Array.from({length: count}, () => ({
+    pubkey: new Uint8Array(48),
+    withdrawalCredentials: new Uint8Array(32),
+    effectiveBalance: 31217089836,
+    slashed: false,
+    activationEligibilityEpoch: 31217089836,
+    activationEpoch: 31217089836,
+    exitEpoch: 31217089836,
+    withdrawableEpoch: 31217089836,
+  }));
+  return validatorList.createTreeBackedFromStruct(validatorsStruct);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -371,10 +371,10 @@
   dependencies:
     "@chainsafe/as-sha256" "^0.2.2"
 
-"@chainsafe/persistent-merkle-tree@^0.3.5":
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.3.5.tgz#39ae7e266b8029b4e227b8f46b3757960253d47f"
-  integrity sha512-DOwTdY5q2YVhBBKZj8zZWydGrFNIvLgTPD6Vh3prjiX4Hk1VvLosmtsSGryaYkgFXKWQrPPtKO8RfPuTMmvTyQ==
+"@chainsafe/persistent-merkle-tree@^0.3.6":
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.3.6.tgz#a1b3b9d08e9cdae58304d0729760e5ac986056f5"
+  integrity sha512-fQn/wGBraRqpJsYbVeHEAE38XkPzW6AKqPBDswTVlbTxV4aXkpxajYQVGU+mEJ97Eh5yKm/cEtN4HudlUqUQcQ==
   dependencies:
     "@chainsafe/as-sha256" "^0.2.3"
 


### PR DESCRIPTION
Update persistent-merkle-tree to v0.3.6 - this makes `tree_getValue` much faster, roughly 2x increase
Add `tree_getValues` as a non-iterator alternative to `tree_iterateValues`
Add `tree_readonlyGetValue`  as a non-iterator alternative to `tree_readonlyGetValues`
Expose non-iterator alternatives to `keys`/`values`/`entries` on `TreeBacked`/`TreeValue`