### PR TITLE
Traverse the tree only 1 time for applyDelta flow

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@chainsafe/as-sha256": "^0.2.4",
-    "@chainsafe/persistent-merkle-tree": "^0.3.6",
+    "@chainsafe/persistent-merkle-tree": "^0.3.7",
     "case": "^1.6.3"
   },
   "devDependencies": {

--- a/test/perf/list.test.ts
+++ b/test/perf/list.test.ts
@@ -47,13 +47,26 @@ describe("list", () => {
     }
   });
 
-  // using applyDelta gives 70% - 100% improvement
+  // using applyDelta gives 4x improvement to get and set
+  // 2.7x improvement compared to set only
   itBench("Number64UintType - increase 10 using applyDelta", () => {
     const basicArrayType = tbBalances64.type as Number64ListType;
     const tree = tbBalances64.tree.clone();
     for (let i = 0; i < numBalances; i++) {
       basicArrayType.tree_applyDeltaAtIndex(tree, i, 10);
     }
+  });
+
+  const deltaByIndex = new Map<number, number>();
+  for (let i = 0; i < numBalances; i++) {
+    deltaByIndex.set(i, 10);
+  }
+  // same performance to tree_applyUint64Delta, should be a little faster
+  // if it operates on a subtree with hook
+  itBench("Number64UintType - increase 10 using applyDeltaInBatch", () => {
+    const basicArrayType = tbBalances64.type as Number64ListType;
+    const tree = tbBalances64.tree.clone();
+    basicArrayType.tree_applyDeltaInBatch(tree, deltaByIndex);
   });
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -371,10 +371,10 @@
   dependencies:
     "@chainsafe/as-sha256" "^0.2.2"
 
-"@chainsafe/persistent-merkle-tree@^0.3.6":
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.3.6.tgz#a1b3b9d08e9cdae58304d0729760e5ac986056f5"
-  integrity sha512-fQn/wGBraRqpJsYbVeHEAE38XkPzW6AKqPBDswTVlbTxV4aXkpxajYQVGU+mEJ97Eh5yKm/cEtN4HudlUqUQcQ==
+"@chainsafe/persistent-merkle-tree@^0.3.7":
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.3.7.tgz#d257674fcacf1770e54df1e7e476bb55efcb3ed4"
+  integrity sha512-UXXzvCN8P4eQWCsaTaHRrNa+2sTwY3NB0Vf+uWgM4cU1qf8LOsTU7aU2CeXFAGJag5W/xEQfVGNh463kXTYAgg==
   dependencies:
     "@chainsafe/as-sha256" "^0.2.3"
 


### PR DESCRIPTION
**Motivation**
+ Right now to apply a delta, we have to traverse the tree to get HashObject, calculate new HashObject and set it back at same gindex. It's better if we could traverse the tree only 1 time

**Description**
+ Use the new `setHashObjectFn()` of persistent-merkle-tree
+ Waiting for https://github.com/ChainSafe/persistent-merkle-tree/pull/62 https://github.com/ChainSafe/ssz/pull/159