### PR TITLE
dataview based readwrite num bytes opts

### DIFF
--- a/src/util/numhelper.ts
+++ b/src/util/numhelper.ts
@@ -1,0 +1,156 @@
+export function copyFromBuf32LE(source: Buffer, target: Uint8Array, offset: number): void {
+  //unrolled fast copy
+  target[3 + offset] = source[3];
+  target[2 + offset] = source[2];
+  target[1 + offset] = source[1];
+  target[0 + offset] = source[0];
+}
+
+export function copyToBuf32LE(source: Uint8Array, target: Buffer, offset: number): void {
+  //unrolled fast copy
+  target[3] = source[3 + offset];
+  target[2] = source[2 + offset];
+  target[1] = source[1 + offset];
+  target[0] = source[0 + offset];
+}
+
+export function copyFromBuf64LE(source: Buffer, target: Uint8Array, length: number, offset: number): void {
+  //unrolled fast copy
+  switch (length) {
+    case 8:
+      target[7 + offset] = source[7];
+    /* falls through */
+    case 7:
+      target[6 + offset] = source[6];
+    /* falls through */
+    case 6:
+      target[5 + offset] = source[5];
+    /* falls through */
+    case 5:
+      target[4 + offset] = source[4];
+    /* falls through */
+    case 4:
+      target[3 + offset] = source[3];
+    /* falls through */
+    case 3:
+      target[2 + offset] = source[2];
+    /* falls through */
+    case 2:
+      target[1 + offset] = source[1];
+    /* falls through */
+    case 1:
+      target[0 + offset] = source[0];
+    /* falls through */
+    default:
+  }
+}
+
+export function copyToBuf64LE(source: Uint8Array, target: Buffer, length: number, offset: number): void {
+  switch (
+    length //we need to unroll it for fast computation, buffer copy/looping takes too much time
+  ) {
+    case 8:
+      target[7] = source[7 + offset];
+    /* falls through */
+    case 7:
+      target[6] = source[6 + offset];
+    /* falls through */
+    case 6:
+      target[5] = source[5 + offset];
+    /* falls through */
+    case 5:
+      target[4] = source[4 + offset];
+    /* falls through */
+    case 4:
+      target[3] = source[3 + offset];
+    /* falls through */
+    case 3:
+      target[2] = source[2 + offset];
+    /* falls through */
+    case 2:
+      target[1] = source[1 + offset];
+    /* falls through */
+    case 1:
+      target[0] = source[0 + offset];
+    /* falls through */
+    default:
+  }
+  switch (
+    length //zero the rest
+  ) {
+    case 1:
+      target[1] = 0;
+    /* falls through */
+    case 2:
+      target[2] = 0;
+    /* falls through */
+    case 3:
+      target[3] = 0;
+    /* falls through */
+    case 4:
+      target[4] = 0;
+    /* falls through */
+    case 5:
+      target[5] = 0;
+    /* falls through */
+    case 6:
+      target[6] = 0;
+    /* falls through */
+    case 7:
+      target[7] = 0;
+    /* falls through */
+    default:
+  }
+}
+
+const workingABuf = new ArrayBuffer(8);
+const wbuffer = Buffer.from(workingABuf);
+const wView = new DataView(workingABuf);
+
+const TWO_POWER_32 = 2 ** 32;
+
+export function getBytesFromNumberLE(value: number, result: Uint8Array, length: number, offset: number): void {
+  // let mvalue;
+  length = Math.min(length, 8);
+  wView.setUint32(0, value, true);
+  if (length > 4) {
+    let mvalue = 0;
+    if (value >= TWO_POWER_32) mvalue = Math.floor(value / TWO_POWER_32);
+    wView.setUint32(4, mvalue, true);
+  }
+  copyFromBuf64LE(wbuffer, result, length, offset);
+}
+
+export function getBytesFromNumberLE32(value: number, result: Uint8Array, offset: number): void {
+  // let mvalue;
+  wView.setUint32(0, value, true);
+  copyFromBuf32LE(wbuffer, result, offset);
+}
+
+export function getNumberFromBytesLE(data: Uint8Array, length: number, offset = 0, ignoreUnsafe = true): number {
+  let isbigint = false,
+    combined,
+    left;
+
+  length = Math.min(length, 8);
+  if (!ignoreUnsafe) {
+    if (length > 6)
+      isbigint = data[6] > 31 || data.slice(7, length).reduce((acc, vrow) => acc || vrow > 0, false as boolean);
+
+    if (isbigint) throw new Error("UnSafeInteger");
+  }
+
+  copyToBuf64LE(data, wbuffer, length, offset);
+
+  combined = wView.getUint32(0, true);
+  if (length > 4) {
+    left = wView.getUint32(4, true);
+    if (left > 0) combined = TWO_POWER_32 * left + combined;
+  }
+  return combined;
+}
+
+export function getNumberFromBytesLE32(data: Uint8Array, offset = 0): number {
+  copyToBuf32LE(data, wbuffer, offset);
+  return wView.getUint32(0, true);
+}

--- a/test/perf/uint.test.ts
+++ b/test/perf/uint.test.ts
@@ -51,4 +51,32 @@ describe("Uint64 types", () => {
     }
     expect(tbState.slot).to.be.equal(numLoop);
   });
+
+  const TWO_POWER_32 = 2 ** 32;
+  const numTwoPower32Loop = TWO_POWER_32 + numLoop;
+  itBench(`struct - increase slot from 2**32 to 2**32 + ${numLoop}`, () => {
+    const state: IBeaconState = {
+      slot: TWO_POWER_32,
+    };
+    for (let i = TWO_POWER_32; i < numTwoPower32Loop; i++) {
+      state.slot++;
+    }
+    expect(state.slot).to.be.equal(numTwoPower32Loop);
+  });
+
+  itBench(`NumberUintType - increase slot from 2**32 to 2**32 + ${numLoop}`, () => {
+    const tbState = BeaconState.createTreeBackedFromStruct({slot: TWO_POWER_32});
+    for (let i = TWO_POWER_32; i < numTwoPower32Loop; i++) {
+      tbState.slot++;
+    }
+    expect(tbState.slot).to.be.equal(numTwoPower32Loop);
+  });
+
+  itBench(`Number64UintType - increase slot from 2**32 to 2**32 + ${numLoop}`, () => {
+    const tbState = BeaconState2.createTreeBackedFromStruct({slot: TWO_POWER_32});
+    for (let i = TWO_POWER_32; i < numTwoPower32Loop; i++) {
+      tbState.slot++;
+    }
+    expect(tbState.slot).to.be.equal(numTwoPower32Loop);
+  });
 });

--- a/test/unit/util.test.ts
+++ b/test/unit/util.test.ts
@@ -1,5 +1,7 @@
 import {expect} from "chai";
 import {bigIntPow} from "../../src/util/bigInt";
+import {getNumberFromBytesLE, getBytesFromNumberLE} from "../../src/util/numhelper";
+import {toBigIntLE, toBufferLE} from "bigint-buffer";
 
 describe("util / bigIntPow", () => {
   it("should throw error on negative exponent", () => {
@@ -10,6 +12,16 @@ describe("util / bigIntPow", () => {
       for (let y = BigInt(0); y < 50; y++) {
         expect(bigIntPow(x, y), `${x} ** ${y}`).to.equal(x ** y);
       }
+    }
+  });
+  it("numhelper byte serialization checks", () => {
+    const output = new Uint8Array(108);
+    for (let i = 0; i < 100; i++) {
+      const tnum = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+      getBytesFromNumberLE(tnum, output, (i % 8) + 1, i);
+      const mx = getNumberFromBytesLE(output, (i % 8) + 1, i);
+      const my = Number(toBigIntLE(toBufferLE(BigInt(tnum), (i % 8) + 1)));
+      expect(mx).to.be.equal(my);
     }
   });
 });


### PR DESCRIPTION
This PR replaces the byte extract from uint number via native dataview, which is roughly 2x faster extraction than normal loop. 
when plugged in it gives whopping 80% performace improvement over normal uint byte extraction and a marginal 3-5% improvement in the new uint64 tree backed datatype manipulation.

before: 
![image](https://user-images.githubusercontent.com/76567250/131312867-cf9027d5-9b09-41fc-b785-8becf7c39c52.png)

after:
![image](https://user-images.githubusercontent.com/76567250/131312906-ae715f96-c60a-4af4-b7f5-95faa54a0c79.png)



partially closes #143