### PR TITLE
extending the case transformation in container data fill

### DIFF
--- a/packages/ssz/src/types/composite/container.ts
+++ b/packages/ssz/src/types/composite/container.ts
@@ -248,7 +248,8 @@ export class ContainerType<T extends ObjectLike = ObjectLike> extends CompositeT
     const value = {} as T;
     for (const [fieldName, fieldType] of Object.entries(this.fields)) {
       const expectedCase = options && options.case;
-      const expectedFieldName = toExpectedCase(fieldName, expectedCase);
+      const customCasingMap = options && options.casingMap;
+      const expectedFieldName = toExpectedCase(fieldName, expectedCase, customCasingMap);
       if ((data as Record<string, Json>)[expectedFieldName] === undefined) {
         throw new Error(`Invalid JSON container field: expected field ${expectedFieldName} is undefined`);
       }
@@ -261,8 +262,12 @@ export class ContainerType<T extends ObjectLike = ObjectLike> extends CompositeT
   struct_convertToJson(value: T, options?: IJsonOptions): Json {
     const data = {} as Record<string, Json>;
     const expectedCase = options && options.case;
+    const customCasingMap = options && options.casingMap;
     for (const [fieldName, fieldType] of Object.entries(this.fields)) {
-      data[toExpectedCase(fieldName, expectedCase)] = fieldType.toJson(value[fieldName as keyof T], options);
+      data[toExpectedCase(fieldName, expectedCase, customCasingMap)] = fieldType.toJson(
+        value[fieldName as keyof T],
+        options
+      );
     }
     return data;
   }

--- a/packages/ssz/src/types/type.ts
+++ b/packages/ssz/src/types/type.ts
@@ -2,7 +2,19 @@
 
 import {Json} from "../interface";
 export interface IJsonOptions {
-  case: "camel" | "snake";
+  case:
+    | "lower"
+    | "snake"
+    | "constant"
+    | "camel"
+    | "kebab"
+    | "upper"
+    | "capital"
+    | "header"
+    | "pascal" //Same as squish
+    | "title"
+    | "sentence"
+    | "notransform";
 }
 
 /**

--- a/packages/ssz/src/types/type.ts
+++ b/packages/ssz/src/types/type.ts
@@ -3,17 +3,13 @@
 import {Json} from "../interface";
 export interface IJsonOptions {
   case:
-    | "lower"
     | "snake"
     | "constant"
     | "camel"
-    | "kebab"
-    | "upper"
-    | "capital"
+    | "param"
     | "header"
     | "pascal" //Same as squish
-    | "title"
-    | "sentence"
+    | "dot"
     | "notransform";
 }
 

--- a/packages/ssz/src/types/type.ts
+++ b/packages/ssz/src/types/type.ts
@@ -11,6 +11,7 @@ export interface IJsonOptions {
     | "pascal" //Same as squish
     | "dot"
     | "notransform";
+  casingMap?: Record<string, string>;
 }
 
 /**

--- a/packages/ssz/src/util/json.ts
+++ b/packages/ssz/src/util/json.ts
@@ -1,6 +1,35 @@
 import {IJsonOptions} from "../types";
-import Case from "case";
+import {
+  snakeCase,
+  constantCase,
+  camelCase,
+  paramCase,
+  headerCase,
+  pascalCase,
+  dotCase,
+  camelCaseTransformMerge,
+  pascalCaseTransformMerge,
+} from "change-case";
+
+const splitRegexp = [/([a-z0-9])([A-Z])/g, /([A-Z])([A-Z][a-z])/g, /([a-z,A-Z])([0-9])/g];
 
 export function toExpectedCase(value: string, expectedCase: IJsonOptions["case"] = "camel"): string {
-  return expectedCase === "notransform" ? value : Case[expectedCase](value);
+  switch (expectedCase) {
+    case "snake":
+      return snakeCase(value, {splitRegexp});
+    case "constant":
+      return constantCase(value, {splitRegexp});
+    case "camel":
+      return camelCase(value, {splitRegexp, transform: camelCaseTransformMerge});
+    case "param":
+      return paramCase(value, {splitRegexp});
+    case "header":
+      return headerCase(value, {splitRegexp});
+    case "pascal":
+      return pascalCase(value, {splitRegexp, transform: pascalCaseTransformMerge});
+    case "dot":
+      return dotCase(value, {splitRegexp});
+    default:
+      return value;
+  }
 }

--- a/packages/ssz/src/util/json.ts
+++ b/packages/ssz/src/util/json.ts
@@ -1,13 +1,6 @@
 import {IJsonOptions} from "../types";
 import Case from "case";
 
-export function toExpectedCase(value: string, expectedCase: IJsonOptions["case"] = "camel"): string {
-  switch (expectedCase) {
-    case "camel":
-      return Case.camel(value);
-    case "snake":
-      return Case.snake(value);
-    default:
-      return value;
-  }
+export function toExpectedCase(value: string, expectedCase?: IJsonOptions["case"]): string {
+  return expectedCase && expectedCase != "notransform" && Case[expectedCase] ? Case[expectedCase](value) : value;
 }

--- a/packages/ssz/src/util/json.ts
+++ b/packages/ssz/src/util/json.ts
@@ -2,5 +2,5 @@ import {IJsonOptions} from "../types";
 import Case from "case";
 
 export function toExpectedCase(value: string, expectedCase?: IJsonOptions["case"]): string {
-  return expectedCase && expectedCase != "notransform" && Case[expectedCase] ? Case[expectedCase](value) : value;
+  return expectedCase === "notransform" ? value : Case[expectedCase](value);
 }

--- a/packages/ssz/src/util/json.ts
+++ b/packages/ssz/src/util/json.ts
@@ -1,35 +1,20 @@
 import {IJsonOptions} from "../types";
-import {
-  snakeCase,
-  constantCase,
-  camelCase,
-  paramCase,
-  headerCase,
-  pascalCase,
-  dotCase,
-  camelCaseTransformMerge,
-  pascalCaseTransformMerge,
-} from "change-case";
+import Case from "case";
 
-const splitRegexp = [/([a-z0-9])([A-Z])/g, /([A-Z])([A-Z][a-z])/g, /([a-z,A-Z])([0-9])/g];
-
-export function toExpectedCase(value: string, expectedCase: IJsonOptions["case"] = "camel"): string {
+export function toExpectedCase(
+  value: string,
+  expectedCase: IJsonOptions["case"] = "camel",
+  customCasingMap?: Record<string, string>
+): string {
+  if (customCasingMap && customCasingMap[value]) return customCasingMap[value];
   switch (expectedCase) {
-    case "snake":
-      return snakeCase(value, {splitRegexp});
-    case "constant":
-      return constantCase(value, {splitRegexp});
-    case "camel":
-      return camelCase(value, {splitRegexp, transform: camelCaseTransformMerge});
-    case "param":
-      return paramCase(value, {splitRegexp});
-    case "header":
-      return headerCase(value, {splitRegexp});
-    case "pascal":
-      return pascalCase(value, {splitRegexp, transform: pascalCaseTransformMerge});
-    case "dot":
-      return dotCase(value, {splitRegexp});
-    default:
+    case "notransform":
       return value;
+    case "param":
+      return Case.kebab(value);
+    case "dot":
+      return Case.lower(value, ".", true);
+    default:
+      return Case[expectedCase](value);
   }
 }

--- a/packages/ssz/src/util/json.ts
+++ b/packages/ssz/src/util/json.ts
@@ -1,6 +1,6 @@
 import {IJsonOptions} from "../types";
 import Case from "case";
 
-export function toExpectedCase(value: string, expectedCase?: IJsonOptions["case"]): string {
+export function toExpectedCase(value: string, expectedCase: IJsonOptions["case"] = "camel"): string {
   return expectedCase === "notransform" ? value : Case[expectedCase](value);
 }

--- a/packages/ssz/test/unit/json.test.ts
+++ b/packages/ssz/test/unit/json.test.ts
@@ -1,4 +1,4 @@
-import {CamelCaseFieldObject, ComplexCamelCaseFieldObject} from "./objects";
+import {CamelCaseFieldObject, ComplexCamelCaseFieldObject, NoTransformFieldObject} from "./objects";
 import {expect} from "chai";
 import {CompositeListType} from "../../src/types/composite";
 
@@ -8,6 +8,15 @@ describe("json serialization", function () {
     const json = CamelCaseFieldObject.toJson(test);
     const result = CamelCaseFieldObject.fromJson(json);
     expect(CamelCaseFieldObject.equals(result, test)).to.be.true;
+  });
+
+  it("should deserialize without case transformation", function () {
+    const test = {someValue_RandOM: 4, someOtherValue_1Random2: true};
+    const json = {someValue_RandOM: 4, someOtherValue_1Random2: true};
+    let result = NoTransformFieldObject.fromJson(json, {case: "notransform"});
+    expect(NoTransformFieldObject.equals(test, result)).to.be.true;
+    result = NoTransformFieldObject.fromJson(json); //should do no transform by default
+    expect(NoTransformFieldObject.equals(test, result)).to.be.true;
   });
 
   it("should deserialize from snake case", function () {

--- a/packages/ssz/test/unit/json.test.ts
+++ b/packages/ssz/test/unit/json.test.ts
@@ -25,7 +25,7 @@ describe("json serialization", function () {
 
   it("should deserialize from snake case with numbers", function () {
     const test = {someValueRandOM: 4, someOtherValue1Random2: true};
-    const json = {some_value_rand_om: 4, some_other_value_1_random_2: true};
+    const json = {some_value_rand_o_m: 4, some_other_value1_random2: true};
     const result = RandomTransformFieldObject.fromJson(json, {case: "snake"});
     expect(RandomTransformFieldObject.equals(test, result)).to.be.true;
   });
@@ -38,20 +38,52 @@ describe("json serialization", function () {
   });
 
   it("test eth2 spec slashing fields from snake case", function () {
-    const test = {signedHeader1: 4, signedHeader2: 5, attestation1: true, attestation2: false};
-    const json = {signed_header_1: 4, signed_header_2: 5, attestation_1: true, attestation_2: false};
-    const result = SlashingTransformFieldObject.fromJson(json, {case: "snake"});
+    const test = {eth1Data: 11, signedHeader1: 4, signedHeader2: 5, attestation1: true, attestation2: false};
+    const json = {eth1_data: 11, signed_header_1: 4, signed_header_2: 5, attestation_1: true, attestation_2: false};
+    const result = SlashingTransformFieldObject.fromJson(json, {
+      case: "snake",
+      casingMap: {
+        signedHeader1: "signed_header_1",
+        signedHeader2: "signed_header_2",
+        attestation1: "attestation_1",
+        attestation2: "attestation_2",
+      },
+    });
     expect(SlashingTransformFieldObject.equals(test, result)).to.be.true;
-    const back = SlashingTransformFieldObject.toJson(result, {case: "snake"});
+    const back = SlashingTransformFieldObject.toJson(result, {
+      case: "snake",
+      casingMap: {
+        signedHeader1: "signed_header_1",
+        signedHeader2: "signed_header_2",
+        attestation1: "attestation_1",
+        attestation2: "attestation_2",
+      },
+    });
     expect(back).to.be.deep.equal(json);
   });
 
   it("test eth2 spec slashing fields from constant case ", function () {
-    const test = {signedHeader1: 4, signedHeader2: 5, attestation1: true, attestation2: false};
-    const json = {SIGNED_HEADER_1: 4, SIGNED_HEADER_2: 5, ATTESTATION_1: true, ATTESTATION_2: false};
-    const result = SlashingTransformFieldObject.fromJson(json, {case: "constant"});
+    const test = {eth1Data: 11, signedHeader1: 4, signedHeader2: 5, attestation1: true, attestation2: false};
+    const json = {ETH1_DATA: 11, SIGNED_HEADER_1: 4, SIGNED_HEADER_2: 5, ATTESTATION_1: true, ATTESTATION_2: false};
+    const result = SlashingTransformFieldObject.fromJson(json, {
+      case: "constant",
+      casingMap: {
+        signedHeader1: "SIGNED_HEADER_1",
+        signedHeader2: "SIGNED_HEADER_2",
+        attestation1: "ATTESTATION_1",
+        attestation2: "ATTESTATION_2",
+      },
+    });
     expect(SlashingTransformFieldObject.equals(test, result)).to.be.true;
-    const back = SlashingTransformFieldObject.toJson(result, {case: "constant"});
+    const back = SlashingTransformFieldObject.toJson(result, {
+      case: "constant",
+      casingMap: {
+        signedHeader1: "SIGNED_HEADER_1",
+        signedHeader2: "SIGNED_HEADER_2",
+        attestation1: "ATTESTATION_1",
+        attestation2: "ATTESTATION_2",
+      },
+    });
     expect(back).to.be.deep.equal(json);
   });
 

--- a/packages/ssz/test/unit/json.test.ts
+++ b/packages/ssz/test/unit/json.test.ts
@@ -1,4 +1,10 @@
-import {CamelCaseFieldObject, ComplexCamelCaseFieldObject, NoTransformFieldObject} from "./objects";
+import {
+  CamelCaseFieldObject,
+  ComplexCamelCaseFieldObject,
+  RandomTransformFieldObject,
+  NoTransformFieldObject,
+  SlashingTransformFieldObject,
+} from "./objects";
 import {expect} from "chai";
 import {CompositeListType} from "../../src/types/composite";
 
@@ -13,10 +19,15 @@ describe("json serialization", function () {
   it("should deserialize without case transformation", function () {
     const test = {someValue_RandOM: 4, someOtherValue_1Random2: true};
     const json = {someValue_RandOM: 4, someOtherValue_1Random2: true};
-    let result = NoTransformFieldObject.fromJson(json, {case: "notransform"});
+    const result = NoTransformFieldObject.fromJson(json, {case: "notransform"});
     expect(NoTransformFieldObject.equals(test, result)).to.be.true;
-    result = NoTransformFieldObject.fromJson(json); //should do no transform by default
-    expect(NoTransformFieldObject.equals(test, result)).to.be.true;
+  });
+
+  it("should deserialize from snake case with numbers", function () {
+    const test = {someValueRandOM: 4, someOtherValue1Random2: true};
+    const json = {some_value_rand_om: 4, some_other_value_1_random_2: true};
+    const result = RandomTransformFieldObject.fromJson(json, {case: "snake"});
+    expect(RandomTransformFieldObject.equals(test, result)).to.be.true;
   });
 
   it("should deserialize from snake case", function () {
@@ -24,6 +35,24 @@ describe("json serialization", function () {
     const json = {some_value: 4, some_other_value: true};
     const result = CamelCaseFieldObject.fromJson(json, {case: "snake"});
     expect(CamelCaseFieldObject.equals(test, result)).to.be.true;
+  });
+
+  it("test eth2 spec slashing fields from snake case", function () {
+    const test = {signedHeader1: 4, signedHeader2: 5, attestation1: true, attestation2: false};
+    const json = {signed_header_1: 4, signed_header_2: 5, attestation_1: true, attestation_2: false};
+    const result = SlashingTransformFieldObject.fromJson(json, {case: "snake"});
+    expect(SlashingTransformFieldObject.equals(test, result)).to.be.true;
+    const back = SlashingTransformFieldObject.toJson(result, {case: "snake"});
+    expect(back).to.be.deep.equal(json);
+  });
+
+  it("test eth2 spec slashing fields from constant case ", function () {
+    const test = {signedHeader1: 4, signedHeader2: 5, attestation1: true, attestation2: false};
+    const json = {SIGNED_HEADER_1: 4, SIGNED_HEADER_2: 5, ATTESTATION_1: true, ATTESTATION_2: false};
+    const result = SlashingTransformFieldObject.fromJson(json, {case: "constant"});
+    expect(SlashingTransformFieldObject.equals(test, result)).to.be.true;
+    const back = SlashingTransformFieldObject.toJson(result, {case: "constant"});
+    expect(back).to.be.deep.equal(json);
   });
 
   it("should deserialize array of containers from snake case", function () {

--- a/packages/ssz/test/unit/objects.ts
+++ b/packages/ssz/test/unit/objects.ts
@@ -106,6 +106,7 @@ export const RandomTransformFieldObject = new ContainerType({
 
 export const SlashingTransformFieldObject = new ContainerType({
   fields: {
+    eth1Data: new NumberUintType({byteLength: 4}),
     signedHeader1: new NumberUintType({byteLength: 4}),
     signedHeader2: new NumberUintType({byteLength: 4}),
     attestation1: new BooleanType(),

--- a/packages/ssz/test/unit/objects.ts
+++ b/packages/ssz/test/unit/objects.ts
@@ -97,6 +97,22 @@ export const NoTransformFieldObject = new ContainerType({
   },
 });
 
+export const RandomTransformFieldObject = new ContainerType({
+  fields: {
+    someValueRandOM: new NumberUintType({byteLength: 4}),
+    someOtherValue1Random2: new BooleanType(),
+  },
+});
+
+export const SlashingTransformFieldObject = new ContainerType({
+  fields: {
+    signedHeader1: new NumberUintType({byteLength: 4}),
+    signedHeader2: new NumberUintType({byteLength: 4}),
+    attestation1: new BooleanType(),
+    attestation2: new BooleanType(),
+  },
+});
+
 export const ComplexCamelCaseFieldObject = new ContainerType({
   fields: {
     someValue: new NumberUintType({byteLength: 4}),

--- a/packages/ssz/test/unit/objects.ts
+++ b/packages/ssz/test/unit/objects.ts
@@ -90,6 +90,13 @@ export const CamelCaseFieldObject = new ContainerType({
   },
 });
 
+export const NoTransformFieldObject = new ContainerType({
+  fields: {
+    someValue_RandOM: new NumberUintType({byteLength: 4}),
+    someOtherValue_1Random2: new BooleanType(),
+  },
+});
+
 export const ComplexCamelCaseFieldObject = new ContainerType({
   fields: {
     someValue: new NumberUintType({byteLength: 4}),


### PR DESCRIPTION
extending the case transformation to other cases available in the "case" library in container data fill plus adding a `notransform` option and making no transformation default
plus test case for `notranform`