### PR TITLE
lerna publish based release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,14 @@ jobs:
       - run: yarn install --frozen-lockfile --ignore-optional && yarn build
       - run: yarn build
 
+      - run: git config user.email $(git --no-pager show -s --format='%ae' HEAD)
+      - run: git config user.name $(git --no-pager show -s --format='%an' HEAD)
+
       - name: Publish to npm registry
         run: yarn publish:release
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy Website
         uses: peaceiris/actions-gh-pages@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,33 +6,9 @@ on:
       - "master"
 
 jobs:
-  tag:
-    name: Check and Tag
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Get latest tag
-        id: get-latest-tag
-        uses: actions-ecosystem/action-get-latest-tag@v1
-        with:
-          with_initial_version: false
-      - name: Create tag
-        id: tag
-        uses: butlerlogic/action-autotag@1.1.2
-        with:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          root: "packages/ssz" # lerna doesn't update version root package.json and this action cannot read from lerna.json
-          tag_prefix: "v"
-    outputs:
-      tag: ${{ steps.tag.outputs.tagname }}
-      previous_tag: ${{ steps.get-latest-tag.outputs.tag }}
-
   release:
     name: Publish
     runs-on: ubuntu-latest
-    needs: tag
-    if: needs.tag.outputs.tag != ''
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -45,35 +21,6 @@ jobs:
 
       - run: yarn install --frozen-lockfile --ignore-optional && yarn build
       - run: yarn build
-
-      - name: Generate changelog
-        id: changelog
-        uses: heinrichreimer/github-changelog-generator-action@v2.2
-        with:
-          token: ${{ secrets.GH_PAGES_TOKEN }}
-          issues: "false"
-          pullRequests: "true"
-          prWoLabels: "true"
-          author: "true"
-          usernamesAsGithubLogins: "true"
-          compareLink: "true"
-          filterByMilestone: "false"
-          unreleased: "false"
-          sinceTag: "${{ needs.tag.outputs.previous_tag }}"
-          maxIssues: "0"
-          stripGeneratorNotice: "true"
-          excludeLabels: "meta-excludefromchangelog"
-
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ needs.tag.outputs.tag }}
-          body_path: "CHANGELOG.md"
-          release_name: Release ${{ needs.tag.outputs.tag }}
-          prerelease: false # Note: if prerelease, will be hidden from view in the main page
 
       - name: Publish to npm registry
         run: yarn publish:release


### PR DESCRIPTION
**Motivation**

reverting the changes made to release.yml  in favour of  lerna publish based release workflow which seems to be tagging, creating reease, changelog as well apart from publishing to the npm repos.

This workflow has been tested in the @g11tech/ssz forked repo using `lerna publish patch --yes --no-verify-access --skip-npm` publish command instead of the original `lerna publish from-package --yes --no-verify-access` for testing all aspects of the workflow (except fetching versions and deploying to npm)

attached is the successful run in the forked repo:
![image](https://user-images.githubusercontent.com/76567250/135491929-7ab04ec8-0678-4402-8a95-c608c1d99dd6.png)





<!-- Why does this PR exist? What are the goals of the pull request? -->

**Description**

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #issue_number
#203
**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
