### PR TITLE
declaration time casing map construction if passed expectedCase

### DIFF
--- a/packages/ssz/src/types/composite/container.ts
+++ b/packages/ssz/src/types/composite/container.ts
@@ -23,6 +23,7 @@ export interface IContainerOptions {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   fields: Record<string, Type<any>>;
   casingMap?: Record<string, string>;
+  expectedCase?: IJsonOptions["case"];
 }
 
 export const CONTAINER_TYPE = Symbol.for("ssz/ContainerType");
@@ -51,7 +52,7 @@ export class ContainerType<T extends ObjectLike = ObjectLike> extends CompositeT
   constructor(options: IContainerOptions) {
     super();
     this.fields = {...options.fields};
-    this.casingMap = options.casingMap;
+    this.casingMap = options.casingMap || (options.expectedCase && {});
     this._typeSymbols.add(CONTAINER_TYPE);
     this.fieldInfos = new Map<string, FieldInfo>();
     let chunkIndex = 0;
@@ -62,6 +63,10 @@ export class ContainerType<T extends ObjectLike = ObjectLike> extends CompositeT
         gIndex: this.getGindexAtChunkIndex(chunkIndex),
       });
       chunkIndex++;
+
+      if (options.expectedCase && this.casingMap) {
+        this.casingMap[fieldName] = toExpectedCase(fieldName, options.expectedCase, options.casingMap);
+      }
     }
   }
 

--- a/packages/ssz/test/unit/json.test.ts
+++ b/packages/ssz/test/unit/json.test.ts
@@ -5,6 +5,7 @@ import {
   NoTransformFieldObject,
   SlashingTransformFieldObject,
   WithCasingDeclarationFieldObject,
+  WithCasingMapConstructionFieldObject,
 } from "./objects";
 import {expect} from "chai";
 import {CompositeListType} from "../../src/types/composite";
@@ -98,6 +99,15 @@ describe("json serialization", function () {
         attestation2: "ATTESTATION_2",
       },
     });
+    expect(back).to.be.deep.equal(json);
+  });
+
+  it("test eth2 spec with declaration time casingMap construction", function () {
+    const test = {eth1Data: 11, signedHeader1: 4, signedHeader2: 5, attestation1: true, attestation2: false};
+    const json = {eth1_data: 11, signed_header_1: 4, signed_header_2: 5, attestation_1: true, attestation_2: false};
+    const result = WithCasingMapConstructionFieldObject.fromJson(json);
+    expect(WithCasingMapConstructionFieldObject.equals(test, result)).to.be.true;
+    const back = WithCasingMapConstructionFieldObject.toJson(result);
     expect(back).to.be.deep.equal(json);
   });
 

--- a/packages/ssz/test/unit/objects.ts
+++ b/packages/ssz/test/unit/objects.ts
@@ -130,6 +130,24 @@ export const WithCasingDeclarationFieldObject = new ContainerType({
   },
 });
 
+export const WithCasingMapConstructionFieldObject = new ContainerType({
+  fields: {
+    eth1Data: new NumberUintType({byteLength: 4}),
+    signedHeader1: new NumberUintType({byteLength: 4}),
+    signedHeader2: new NumberUintType({byteLength: 4}),
+    attestation1: new BooleanType(),
+    attestation2: new BooleanType(),
+  },
+  casingMap: {
+    signedHeader1: "signed_header_1",
+    signedHeader2: "signed_header_2",
+    attestation1: "attestation_1",
+    attestation2: "attestation_2",
+  },
+  //for rest of the fields not covered by casingMap, in this case eth1Data which snake casing converstion correctly maps to eth1_data
+  expectedCase: "snake",
+});
+
 export const ComplexCamelCaseFieldObject = new ContainerType({
   fields: {
     someValue: new NumberUintType({byteLength: 4}),


### PR DESCRIPTION
**Motivation**
This PR is to enable the construction of a `casingMap` via an `expectedCase` option when a container type is being created.
It can also extends if a `casingMap` has been provided for the fields not present in `casingMap`.

Use is to only provide any overidings in `casingMap` which can't be handled by the  `case` transformation, but we would still want that all field's `case` matching to be cached in the container declaration time (for speeding up the `toJson/fromJson` calls)
This leads to a much nicer interface and less code crowding.

<!-- Why does this PR exist? What are the goals of the pull request? -->

**Description**
example declaration:
```typescript
export const WithCasingMapConstructionFieldObject = new ContainerType({
  fields: {
    eth1Data: new NumberUintType({byteLength: 4}),
    signedHeader1: new NumberUintType({byteLength: 4}),
    signedHeader2: new NumberUintType({byteLength: 4}),
    attestation1: new BooleanType(),
    attestation2: new BooleanType(),
  },
  casingMap: {
    signedHeader1: "signed_header_1",
    signedHeader2: "signed_header_2",
    attestation1: "attestation_1",
    attestation2: "attestation_2",
  },
  //for rest of the fields not covered by casingMap, in this case eth1Data which snake casing converstion correctly maps to eth1_data
  expectedCase: "snake",
});
```
Here the provided `casingMap` gets extended inside the container type with `eth1Data:eth1_data` using the provided expected case transformation `snake`, so when a object is created using a json that has these fields, it just picks up from this extended `casingMap` :

```typescript
const json = {eth1_data: 11, signed_header_1: 4, signed_header_2: 5, attestation_1: true, attestation_2: false};
const containerObj = WithCasingMapConstructionFieldObject.fromJson(json);
```

<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #issue_number

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
