### PR TITLE
adding ability to add expected case declaration time

### DIFF
--- a/packages/ssz/src/util/json.ts
+++ b/packages/ssz/src/util/json.ts
@@ -6,10 +6,9 @@ export function toExpectedCase(
   expectedCase: IJsonOptions["case"] = "camel",
   customCasingMap?: Record<string, string>
 ): string {
+  if (expectedCase === "notransform") return value;
   if (customCasingMap && customCasingMap[value]) return customCasingMap[value];
   switch (expectedCase) {
-    case "notransform":
-      return value;
     case "param":
       return Case.kebab(value);
     case "dot":

--- a/packages/ssz/test/unit/json.test.ts
+++ b/packages/ssz/test/unit/json.test.ts
@@ -3,6 +3,7 @@ import {
   ComplexCamelCaseFieldObject,
   RandomTransformFieldObject,
   NoTransformFieldObject,
+  NoTransformFieldObjectWithDeclaredExpectedCase,
   SlashingTransformFieldObject,
   WithCasingDeclarationFieldObject,
 } from "./objects";
@@ -22,6 +23,17 @@ describe("json serialization", function () {
     const json = {someValue_RandOM: 4, someOtherValue_1Random2: true};
     const result = NoTransformFieldObject.fromJson(json, {case: "notransform"});
     expect(NoTransformFieldObject.equals(test, result)).to.be.true;
+  });
+
+  it("should deserialize/deserialize without case transformation with notransform declared expectedCase", function () {
+    const test = {someValue_RandOM: 4, someOtherValue_1Random2: true};
+    const json = {someValue_RandOM: 4, someOtherValue_1Random2: true};
+
+    const result = NoTransformFieldObjectWithDeclaredExpectedCase.fromJson(json);
+    expect(NoTransformFieldObjectWithDeclaredExpectedCase.equals(test, result)).to.be.true;
+
+    const back = NoTransformFieldObjectWithDeclaredExpectedCase.toJson(result);
+    expect(back).to.be.deep.equal(json);
   });
 
   it("should deserialize from snake case with numbers", function () {

--- a/packages/ssz/test/unit/objects.ts
+++ b/packages/ssz/test/unit/objects.ts
@@ -97,6 +97,14 @@ export const NoTransformFieldObject = new ContainerType({
   },
 });
 
+export const NoTransformFieldObjectWithDeclaredExpectedCase = new ContainerType({
+  fields: {
+    someValue_RandOM: new NumberUintType({byteLength: 4}),
+    someOtherValue_1Random2: new BooleanType(),
+  },
+  expectedCase: "notransform",
+});
+
 export const RandomTransformFieldObject = new ContainerType({
   fields: {
     someValueRandOM: new NumberUintType({byteLength: 4}),


### PR DESCRIPTION
**Motivation**
This PR adds the ability to specify `expectedCase` when the containertype is being created. this will especially aid in cases where no transformation is expected between container and data fields, skipping any caseMap creation/lookup or any case library based transformation (via passing `expectedCase: "notransform"`,
<!-- Why does this PR exist? What are the goals of the pull request? -->

**Description**
example:
```typescript
export const NoTransformFieldObjectWithDeclaredExpectedCase = new ContainerType({
  fields: {
    someValue_RandOM: new NumberUintType({byteLength: 4}),
    someOtherValue_1Random2: new BooleanType(),
  },
  expectedCase: "notransform",
});
```
usage:
```typescript
const json = {someValue_RandOM: 4, someOtherValue_1Random2: true};
const result = NoTransformFieldObjectWithDeclaredExpectedCase.fromJson(json);
```
<!-- A clear and concise general description of the changes of this PR commits -->

<!-- If applicable, add screenshots to help explain your solution -->

<!-- Link to issues: Resolves #111, Resolves #222 -->
Closes #issue_number
related to PR: https://github.com/ChainSafe/lodestar/pull/3351
**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
