### PR TITLE
Add root readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# @Chainsafe/ssz
+
+> Typescript Simple Serialize (SSZ) libraries
+
+## Intro
+
+This monorepo is part of [ChainSafe's Lodestar](https://lodestar.chainsafe.io) project.
+It contains packages related to [Simple Serialize](https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md).
+
+## Packages
+
+| Package | Version | License | Docs | Description |
+| ------- | ------- | ------- | ---- | ----------- |
+| [@chainsafe/as-sha256](https://github.com/ChainSafe/ssz/tree/master/packages/as-sha256) | [![npm](https://img.shields.io/npm/v/@chainsafe/as-sha256)](https://www.npmjs.com/package/@chainsafe/as-sha256) |  [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | [![documentation](https://img.shields.io/badge/readme-blue)](https://github.com/ChainSafe/ssz/tree/master/packages/as-sha256) | SHA256 optimized for 64 byte input |
+| [@chainsafe/persistent-merkle-tree](https://github.com/ChainSafe/ssz/tree/master/packages/persistent-merkle-tree) | [![npm](https://img.shields.io/npm/v/@chainsafe/persistent-merkle-tree)](https://www.npmjs.com/package/@chainsafe/persistent-merkle-tree) |  [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | [![documentation](https://img.shields.io/badge/readme-blue)](https://github.com/ChainSafe/ssz/tree/master/packages/persistent-merkle-tree) | Merkle tree using structural sharing |
+| [@chainsafe/persistent-ts](https://github.com/ChainSafe/ssz/tree/master/packages/persistent-ts) | [![npm](https://img.shields.io/npm/v/@chainsafe/persistent-ts)](https://www.npmjs.com/package/@chainsafe/persistent-ts) |  [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | [![documentation](https://img.shields.io/badge/readme-blue)](https://github.com/ChainSafe/ssz/tree/master/packages/persistent-ts) | List using structural sharing |
+| [@chainsafe/ssz](https://github.com/ChainSafe/ssz/tree/master/packages/ssz) | [![npm](https://img.shields.io/npm/v/@chainsafe/ssz)](https://www.npmjs.com/package/@chainsafe/ssz) |  [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | [![documentation](https://img.shields.io/badge/readme-blue)](https://github.com/ChainSafe/ssz/tree/master/packages/ssz) | Simple serialize |
+| simpleserialize.com | N/A |  [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0) | [![documentation](https://img.shields.io/badge/readme-blue)](https://github.com/ChainSafe/ssz/tree/master/packages/simpleserialize.com) | Simple serialize demo website |
+


### PR DESCRIPTION
**Motivation**

Currently, there isn't a root README, makes the link https://github.com/chainsafe/ssz uninviting

**Description**

Add a readme linking to sub-packages and linking back to https://lodestar.chainsafe.io