### PR TITLE
Force usage of Uint8Array.prototype.slice

### DIFF
--- a/packages/ssz/src/type/abstract.ts
+++ b/packages/ssz/src/type/abstract.ts
@@ -124,6 +124,13 @@ export abstract class Type<V> {
 
   /** Deserialize binary data to value */
   deserialize(uint8Array: Uint8Array): V {
+    // Buffer.prototype.slice does not copy memory, force use Uint8Array.prototype.slice https://github.com/nodejs/node/issues/28087
+    // - Uint8Array.prototype.slice: Copy memory, safe to mutate
+    // - Buffer.prototype.slice: Does NOT copy memory, mutation affects both views
+    // We could ensure that all Buffer instances are converted to Uint8Array before calling value_deserializeFromBytes
+    // However doing that in a browser friendly way is not easy. Downstream code uses `Uint8Array.prototype.slice.call`
+    // to ensure Buffer.prototype.slice is never used. Unit tests also test non-mutability.
+
     const dataView = new DataView(uint8Array.buffer, uint8Array.byteOffset, uint8Array.byteLength);
     return this.value_deserializeFromBytes({uint8Array, dataView}, 0, uint8Array.length);
   }

--- a/packages/ssz/src/type/bitList.ts
+++ b/packages/ssz/src/type/bitList.ts
@@ -124,13 +124,15 @@ function deserializeUint8ArrayBitListFromBytes(data: Uint8Array, start: number, 
   }
 
   if (lastByte === 1) {
-    const uint8Array = data.slice(start, end - 1);
+    // Buffer.prototype.slice does not copy memory, Enforce Uint8Array usage https://github.com/nodejs/node/issues/28087
+    const uint8Array = Uint8Array.prototype.slice.call(data, start, end - 1);
     const bitLen = (size - 1) * 8;
     return {uint8Array, bitLen};
   }
 
   // the last byte is > 1, so a padding bit will exist in the last byte and need to be removed
-  const uint8Array = data.slice(start, end);
+  // Buffer.prototype.slice does not copy memory, Enforce Uint8Array usage https://github.com/nodejs/node/issues/28087
+  const uint8Array = Uint8Array.prototype.slice.call(data, start, end);
   // mask lastChunkByte
   const lastByteBitLength = lastByte.toString(2).length - 1;
   const bitLen = (size - 1) * 8 + lastByteBitLength;

--- a/packages/ssz/src/type/bitVector.ts
+++ b/packages/ssz/src/type/bitVector.ts
@@ -69,7 +69,8 @@ export class BitVectorType extends BitArrayType {
 
   value_deserializeFromBytes(data: ByteViews, start: number, end: number): BitArray {
     this.assertValidLength(data.uint8Array, start, end);
-    return new BitArray(data.uint8Array.slice(start, end), this.lengthBits);
+    // Buffer.prototype.slice does not copy memory, Enforce Uint8Array usage https://github.com/nodejs/node/issues/28087
+    return new BitArray(Uint8Array.prototype.slice.call(data, start, end), this.lengthBits);
   }
 
   tree_serializedSize(): number {

--- a/packages/ssz/src/type/bitVector.ts
+++ b/packages/ssz/src/type/bitVector.ts
@@ -70,7 +70,7 @@ export class BitVectorType extends BitArrayType {
   value_deserializeFromBytes(data: ByteViews, start: number, end: number): BitArray {
     this.assertValidLength(data.uint8Array, start, end);
     // Buffer.prototype.slice does not copy memory, Enforce Uint8Array usage https://github.com/nodejs/node/issues/28087
-    return new BitArray(Uint8Array.prototype.slice.call(data, start, end), this.lengthBits);
+    return new BitArray(Uint8Array.prototype.slice.call(data.uint8Array, start, end), this.lengthBits);
   }
 
   tree_serializedSize(): number {

--- a/packages/ssz/src/type/byteArray.ts
+++ b/packages/ssz/src/type/byteArray.ts
@@ -1,6 +1,7 @@
 import {concatGindices, Gindex, Node, toGindex, Tree} from "@chainsafe/persistent-merkle-tree";
 import {fromHexString, toHexString, byteArrayEquals} from "../util/byteArray";
 import {splitIntoRootChunks} from "../util/merkleize";
+import {ByteViews} from "./abstract";
 import {CompositeType, LENGTH_GINDEX} from "./composite";
 
 export type ByteArray = Uint8Array;
@@ -54,6 +55,18 @@ export abstract class ByteArrayType extends CompositeType<ByteArray, ByteArray, 
 
   toViewDU(value: ByteArray): ByteArray {
     return value;
+  }
+
+  // Serialization + deserialization (only value is generic)
+
+  value_serializeToBytes(output: ByteViews, offset: number, value: ByteArray): number {
+    output.uint8Array.set(value, offset);
+    return offset + value.length;
+  }
+
+  value_deserializeFromBytes(data: ByteViews, start: number, end: number): ByteArray {
+    this.assertValidSize(end - start);
+    return Uint8Array.prototype.slice.call(data.uint8Array, start, end);
   }
 
   // Merkleization

--- a/packages/ssz/src/type/byteList.ts
+++ b/packages/ssz/src/type/byteList.ts
@@ -50,15 +50,7 @@ export class ByteListType extends ByteArrayType {
     return value.length;
   }
 
-  value_serializeToBytes(output: ByteViews, offset: number, value: ByteArray): number {
-    output.uint8Array.set(value, offset);
-    return offset + value.length;
-  }
-
-  value_deserializeFromBytes(data: ByteViews, start: number, end: number): ByteArray {
-    this.assertValidSize(end - start);
-    return data.uint8Array.slice(start, end);
-  }
+  // value_* inherited from ByteArrayType
 
   tree_serializedSize(node: Node): number {
     return getLengthFromRootNode(node);

--- a/packages/ssz/src/type/byteVector.ts
+++ b/packages/ssz/src/type/byteVector.ts
@@ -52,15 +52,7 @@ export class ByteVectorType extends ByteArrayType {
     return this.fixedSize;
   }
 
-  value_serializeToBytes(output: ByteViews, offset: number, value: ByteVector): number {
-    output.uint8Array.set(value, offset);
-    return offset + this.fixedSize;
-  }
-
-  value_deserializeFromBytes(data: ByteViews, start: number, end: number): ByteVector {
-    this.assertValidSize(end - start);
-    return data.uint8Array.slice(start, end);
-  }
+  // value_* inherited from ByteArrayType
 
   tree_serializedSize(): number {
     return this.fixedSize;

--- a/packages/ssz/src/value/bitArray.ts
+++ b/packages/ssz/src/value/bitArray.ts
@@ -52,7 +52,8 @@ export class BitArray {
 
   clone(): BitArray {
     // TODO: Benchmark if Uint8Array.slice(0) is the fastest way to copy data here
-    return new BitArray(this.uint8Array.slice(0), this.bitLen);
+    // Buffer.prototype.slice does not copy memory, Enforce Uint8Array usage https://github.com/nodejs/node/issues/28087
+    return new BitArray(Uint8Array.prototype.slice.call(this.uint8Array, 0), this.bitLen);
   }
 
   /**

--- a/packages/ssz/test/perf/uintFromBytes.test.ts
+++ b/packages/ssz/test/perf/uintFromBytes.test.ts
@@ -194,12 +194,14 @@ describe("Uint64 deserialize", () => {
     let uint8Array: Uint8Array;
     let uint32Array: Uint32Array;
     let dataView: DataView;
+    let buffer: Buffer;
 
     before("Create random bytes", () => {
       arrayBuffer = new ArrayBuffer(bytesTotal);
       uint8Array = new Uint8Array(arrayBuffer);
       uint32Array = new Uint32Array(arrayBuffer);
       dataView = new DataView(arrayBuffer);
+      buffer = Buffer.from(arrayBuffer);
       for (let i = 0; i < numElements; i++) {
         dataView.setBigUint64(i * 8, BigInt(30e9 + i), true);
       }
@@ -232,8 +234,27 @@ describe("Uint64 deserialize", () => {
     });
 
     itBench(`Copy Uint8Array ${numElements} slice`, () => {
+      uint8Array.slice(0, uint8Array.length);
+    });
+
+    itBench(`Copy Uint8Array ${numElements} Uint8Array.prototype.slice.call`, () => {
+      Uint8Array.prototype.slice.call(uint8Array, 0, uint8Array.length);
+    });
+
+    itBench(`Copy Buffer ${numElements} Uint8Array.prototype.slice.call`, () => {
+      Uint8Array.prototype.slice.call(buffer, 0, uint8Array.length);
+    });
+
+    itBench(`Copy Uint8Array ${numElements} slice + set`, () => {
       const byteLen = uint8Array.length;
-      uint8Array.slice(0, byteLen);
+      const uint8ArrayNew = new Uint8Array(byteLen);
+      uint8ArrayNew.set(uint8Array.slice(0, byteLen));
+    });
+
+    itBench(`Copy Uint8Array ${numElements} subarray + set`, () => {
+      const byteLen = uint8Array.length;
+      const uint8ArrayNew = new Uint8Array(byteLen);
+      uint8ArrayNew.set(uint8Array.subarray(0, byteLen));
     });
 
     itBench(`Copy Uint8Array ${numElements} slice arrayBuffer`, () => {

--- a/packages/ssz/test/spec/runValidTest.ts
+++ b/packages/ssz/test/spec/runValidTest.ts
@@ -86,6 +86,11 @@ export function runValidSszTest(type: Type<unknown>, testData: ValidTestCaseData
     // bytes -> value - deserialize()
     const value = wrapErr(() => type.deserialize(copy(testDataSerialized)), "type.deserialize()");
     assertValue(value, "type.deserialize()");
+
+    // Buffer.prototype.slice does not copy memory, test .deserialize() is mutation safe https://github.com/nodejs/node/issues/28087
+    const bytes = Buffer.from(copy(testDataSerialized));
+    type.deserialize(bytes);
+    expect(toHexString(bytes)).to.equal(testDataSerializedHex, "type.deserialize() mutated input");
   }
 
   // To print the chunk roots of a type value
@@ -159,6 +164,11 @@ export function runValidSszTest(type: Type<unknown>, testData: ValidTestCaseData
 
     const viewDU = type.deserializeToViewDU(copy(testDataSerialized));
     assertNode(type.commitViewDU(viewDU), "deserializeToViewDU");
+
+    // Buffer.prototype.slice does not copy memory, test .deserialize() is mutation safe https://github.com/nodejs/node/issues/28087
+    const bytes = Buffer.from(copy(testDataSerialized));
+    type.deserializeToViewDU(bytes);
+    expect(toHexString(bytes)).to.equal(testDataSerializedHex, "type.deserializeToViewDU() mutated input");
   }
 
   if (isBasicType(type)) {

--- a/packages/ssz/test/unit/uint8Array.test.ts
+++ b/packages/ssz/test/unit/uint8Array.test.ts
@@ -1,7 +1,7 @@
 import {expect} from "chai";
 
-describe("Uint8Array", () => {
-  it("Copy Uint8Array and not mutate", () => {
+describe("Mutability Buffer, Uint8Array", () => {
+  it("Ensure Uint8Array.slice copies memory", () => {
     const len = 64;
     const index = 54;
     const newValue = 1;
@@ -11,6 +11,20 @@ describe("Uint8Array", () => {
     u2[index] = newValue;
 
     expect(u1[index]).to.equal(0, "u1 should have original value");
+    expect(u2[index]).to.equal(newValue, "u2 should have new value");
+  });
+
+  // Buffer.prototype.slice does not copy memory, Enforce Uint8Array usage https://github.com/nodejs/node/issues/28087
+  it("Ensure Buffer does not copy memory", () => {
+    const len = 64;
+    const index = 54;
+    const newValue = 1;
+
+    const u1 = Buffer.alloc(len, 0);
+    const u2 = u1.slice(0);
+    u2[index] = newValue;
+
+    expect(u1[index]).to.equal(newValue, "u1 should have new value");
     expect(u2[index]).to.equal(newValue, "u2 should have new value");
   });
 });


### PR DESCRIPTION
**Motivation**

SSZ expected that all arguments typed as `Uint8Array` as `Uin8Array` but they could get a `Buffer` instance too.

Buffer.prototype.slice does not copy memory, force use Uint8Array.prototype.slice https://github.com/nodejs/node/issues/28087
 - Uint8Array.prototype.slice: Copy memory, safe to mutate
 - Buffer.prototype.slice: Does NOT copy memory, mutation affects both views

We could ensure that all Buffer instances are converted to Uint8Array before calling value_deserializeFromBytes. However doing that in a browser friendly way is not easy. Downstream code uses `Uint8Array.prototype.slice.call` to ensure Buffer.prototype.slice is never used. Unit tests also test non-mutability.

**Description**

Use `Uint8Array.prototype.slice` to ensure the method that copies memory is used. Using this alternative has no performance cost, since it's equivalent, also proof below:

```
      ✓ Copy Uint8Array 100000 slice                                        2863.475 ops/s    349.2260 us/op   x1.424       4897 runs   2.07 s
      ✓ Copy Uint8Array 100000 Uint8Array.prototype.slice.call              4144.614 ops/s    241.2770 us/op   x0.720      11186 runs   2.94 s
      ✓ Copy Buffer 100000 Uint8Array.prototype.slice.call                  4289.471 ops/s    233.1290 us/op   x1.053       7201 runs   2.00 s
```

I've added unit tests that ensure no mutability

Closes https://github.com/ChainSafe/ssz/issues/254