### PR TITLE
Add EF multiproof format

### DIFF
--- a/packages/persistent-merkle-tree/src/proof/efMulti.ts
+++ b/packages/persistent-merkle-tree/src/proof/efMulti.ts
@@ -1,0 +1,103 @@
+import {Gindex} from "../gindex";
+import {BranchNode, LeafNode, Node} from "../node";
+import {Tree} from "../tree";
+import {computeMultiProofBitstrings, SortOrder} from "./util";
+
+/**
+ * Create an EF multiproof
+ *
+ * @param rootNode the root node of the tree
+ * @param gindices generalized indices of leaves to include in the proof
+ */
+export function createEFMultiProof(rootNode: Node, gindices: Gindex[]): [Uint8Array[], Uint8Array[], Gindex[]] {
+  const tree = new Tree(rootNode);
+  const witnessGindices = computeMultiProofBitstrings(
+    gindices.map((gindex) => gindex.toString(2)),
+    false,
+    SortOrder.Decreasing
+  );
+  const leafGindices = gindices.sort((a, b) => (a < b ? 1 : -1));
+  const leaves = leafGindices.map((gindex) => tree.getRoot(gindex));
+  const witnesses = witnessGindices.map((gindex) => tree.getRoot(gindex));
+
+  return [leaves, witnesses, leafGindices];
+}
+
+/**
+ * Recreate a `Node` given a EF multiproof
+ *
+ * @param leaves leaves of a EF multiproof
+ * @param witnesses witnesses of a EF multiproof
+ * @param gindices generalized indices of the leaves
+ */
+export function createNodeFromEFMultiProof(leaves: Uint8Array[], witnesses: Uint8Array[], gindices: Gindex[]): Node {
+  if (leaves.length !== gindices.length) {
+    throw new Error("Leaves length should equal gindices length");
+  }
+
+  const leafBitstrings = gindices.map((gindex) => gindex.toString(2));
+  const witnessBitstrings = computeMultiProofBitstrings(leafBitstrings, false, SortOrder.Decreasing);
+
+  if (witnessBitstrings.length !== witnesses.length) {
+    throw new Error("Witnesses length should equal witnesses gindices length");
+  }
+
+  // Algorithm:
+  // create an object which tracks key-values for each level
+  // pre-load leaves and witnesses into the level object
+  // level by level, starting from the bottom,
+  // find the sibling, create the parent, store it in the next level up
+  // the root is in level 1
+  const maxLevel = Math.max(leafBitstrings[0].length, witnessBitstrings[0].length);
+
+  const levels: Record<number, Record<string, Node>> = Object.fromEntries(
+    Array.from({length: maxLevel}, (_, i) => [i, {}])
+  );
+
+  // preload leaves and witnesses
+  for (let i = 0; i < leafBitstrings.length; i++) {
+    const leafBitstring = leafBitstrings[i];
+    const leaf = leaves[i];
+    levels[leafBitstring.length][leafBitstring] = LeafNode.fromRoot(leaf);
+  }
+  for (let i = 0; i < witnessBitstrings.length; i++) {
+    const witnessBitstring = witnessBitstrings[i];
+    const witness = witnesses[i];
+    levels[witnessBitstring.length][witnessBitstring] = LeafNode.fromRoot(witness);
+  }
+
+  for (let i = maxLevel; i > 1; i--) {
+    const level = levels[i];
+    const parentLevel = levels[i - 1];
+    for (const bitstring of Object.keys(level)) {
+      const node = level[bitstring];
+      // if the node doesn't exist, we've already processed its sibling
+      if (!node) {
+        continue;
+      }
+
+      const isLeft = bitstring[bitstring.length - 1] === "0";
+      const parentBitstring = bitstring.substring(0, bitstring.length - 1);
+      const siblingBitstring = parentBitstring + isLeft ? "1" : "0";
+
+      const siblingNode = level[siblingBitstring];
+      if (!siblingNode) {
+        throw new Error(`Sibling not found: ${siblingBitstring}`);
+      }
+
+      // store the parent node
+      const parentNode = isLeft ? new BranchNode(node, siblingNode) : new BranchNode(siblingNode, node);
+      parentLevel[parentBitstring] = parentNode;
+
+      // delete the used nodes
+      delete level[bitstring];
+      delete level[siblingBitstring];
+    }
+  }
+
+  const root = levels[1]["1"];
+  if (!root) {
+    throw new Error("Internal consistency error: no root found");
+  }
+  return root;
+}

--- a/packages/persistent-merkle-tree/src/proof/single.ts
+++ b/packages/persistent-merkle-tree/src/proof/single.ts
@@ -22,7 +22,7 @@ export function createSingleProof(rootNode: Node, index: Gindex): [Uint8Array, U
 
 export function createNodeFromSingleProof(gindex: Gindex, leaf: Uint8Array, witnesses: Uint8Array[]): Node {
   let node: Node = LeafNode.fromRoot(leaf);
-  const w = witnesses.reverse();
+  const w = witnesses.slice().reverse();
   while (gindex > 1) {
     const sibling = LeafNode.fromRoot(w.pop() as Uint8Array);
     if (gindex % BigInt(2) === BigInt(0)) {

--- a/packages/persistent-merkle-tree/src/proof/util.ts
+++ b/packages/persistent-merkle-tree/src/proof/util.ts
@@ -57,6 +57,41 @@ export function sortInOrderBitstrings(gindices: GindexBitstring[], bitLength: nu
 }
 
 /**
+ * Sort generalized indices in decreasing order
+ */
+export function sortDecreasingBitstrings(gindices: GindexBitstring[]): GindexBitstring[] {
+  if (!gindices.length) {
+    return [];
+  }
+  return gindices.sort((a, b) => {
+    if (a.length < b.length) {
+      return 1;
+    } else if (b.length < a.length) {
+      return -1;
+    }
+    let aPos0 = a.indexOf("0");
+    let bPos0 = b.indexOf("0");
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      if (aPos0 === -1) {
+        return -1;
+      } else if (bPos0 === -1) {
+        return 1;
+      }
+
+      if (aPos0 < bPos0) {
+        return 1;
+      } else if (bPos0 < aPos0) {
+        return -1;
+      }
+
+      aPos0 = a.indexOf("0", aPos0 + 1);
+      bPos0 = b.indexOf("0", bPos0 + 1);
+    }
+  });
+}
+
+/**
  * Filter out parent generalized indices
  */
 export function filterParentBitstrings(gindices: GindexBitstring[]): GindexBitstring[] {
@@ -75,21 +110,32 @@ export function filterParentBitstrings(gindices: GindexBitstring[]): GindexBitst
   return filtered;
 }
 
+export enum SortOrder {
+  InOrder,
+  Decreasing,
+  Unsorted,
+}
+
 /**
  * Return the set of generalized indices required for a multiproof
- * This includes all leaves and any necessary witnesses
+ * This may include all leaves and any necessary witnesses
  * @param gindices leaves to include in proof
- * @returns all generalized indices required for a multiproof (leaves and witnesses), deduplicated and sorted in-order according to the tree
+ * @returns all generalized indices required for a multiproof (leaves and witnesses), deduplicated and sorted
  */
-export function computeMultiProofBitstrings(gindices: GindexBitstring[]): GindexBitstring[] {
-  // Initialize the proof indices with the leaves
-  const proof = new Set<GindexBitstring>(filterParentBitstrings(gindices));
+export function computeMultiProofBitstrings(
+  gindices: GindexBitstring[],
+  includeLeaves = true,
+  sortOrder = SortOrder.InOrder
+): GindexBitstring[] {
+  const leaves = filterParentBitstrings(gindices);
+  // Maybe initialize the proof indices with the leaves
+  const proof = new Set<GindexBitstring>(includeLeaves ? leaves : []);
   const paths = new Set<GindexBitstring>();
   const branches = new Set<GindexBitstring>();
 
   // Collect all path indices and all branch indices
   let maxBitLength = 1;
-  for (const gindex of proof) {
+  for (const gindex of leaves) {
     if (gindex.length > maxBitLength) maxBitLength = gindex.length;
     const {path, branch} = computeProofBitstrings(gindex);
     path.forEach((g) => paths.add(g));
@@ -101,5 +147,12 @@ export function computeMultiProofBitstrings(gindices: GindexBitstring[]): Gindex
   // Add all remaining branches to the leaves
   branches.forEach((g) => proof.add(g));
 
-  return sortInOrderBitstrings(Array.from(proof), maxBitLength);
+  switch (sortOrder) {
+    case SortOrder.InOrder:
+      return sortInOrderBitstrings(Array.from(proof), maxBitLength);
+    case SortOrder.Decreasing:
+      return sortDecreasingBitstrings(Array.from(proof));
+    case SortOrder.Unsorted:
+      return Array.from(proof);
+  }
 }

--- a/packages/persistent-merkle-tree/src/proof/util.ts
+++ b/packages/persistent-merkle-tree/src/proof/util.ts
@@ -95,7 +95,7 @@ export function sortDecreasingBitstrings(gindices: GindexBitstring[]): GindexBit
  * Filter out parent generalized indices
  */
 export function filterParentBitstrings(gindices: GindexBitstring[]): GindexBitstring[] {
-  const sortedBitstrings = gindices.sort((a, b) => a.length - b.length);
+  const sortedBitstrings = gindices.slice().sort((a, b) => a.length - b.length);
   const filtered: GindexBitstring[] = [];
   outer: for (let i = 0; i < sortedBitstrings.length; i++) {
     const bsA = sortedBitstrings[i];

--- a/packages/persistent-merkle-tree/test/unit/proof/index.test.ts
+++ b/packages/persistent-merkle-tree/test/unit/proof/index.test.ts
@@ -12,13 +12,44 @@ function createTree(depth: number, index = 0): Node {
 }
 
 describe("proof equivalence", () => {
-  it("should compute the same root from different proof types", () => {
+  it("should compute the same root from different proof types - single leaf", () => {
     const node = createTree(6);
     const allProofTestCases = Array.from({length: 62}, (_, i) => BigInt(i + 2));
     for (const gindex of allProofTestCases) {
       const singleProof = createProof(node, {type: ProofType.single, gindex});
       const treeOffsetProof = createProof(node, {type: ProofType.treeOffset, gindices: [gindex]});
-      expect(createNodeFromProof(singleProof).root).to.deep.equal(createNodeFromProof(treeOffsetProof).root);
+      const multiProof = createProof(node, {type: ProofType.multi, gindices: [gindex]});
+      expect(node.root).to.deep.equal(createNodeFromProof(singleProof).root);
+      expect(node.root).to.deep.equal(createNodeFromProof(treeOffsetProof).root);
+      expect(node.root).to.deep.equal(createNodeFromProof(multiProof).root);
+    }
+  });
+  it("should compute the same root from different proof types - multiple leaves", function () {
+    this.timeout(2000);
+    const depth = 6;
+    const maxIndex = 2 ** depth;
+    const node = createTree(depth);
+    const allGindices = Array.from({length: maxIndex}, (_, i) => BigInt(i));
+    // Try many combinations of up to 4 leaves
+    // For speed, don't try _every_ combination and only test with leaves in the bottom layer
+    for (let i = 2 ** (depth - 1); i < maxIndex; i++) {
+      for (let j = i + 1; j < maxIndex; j += 2) {
+        for (let k = j + 1; k < maxIndex; k += 3) {
+          for (let l = k + 1; l < maxIndex; l += 4) {
+            const selectedGindices = [allGindices[i], allGindices[j], allGindices[k], allGindices[l]];
+            // try 2, 3, 4 leaves
+            for (let m = 2; m <= 4; m++) {
+              const gindices = selectedGindices.slice(0, m);
+
+              const treeOffsetProof = createProof(node, {type: ProofType.treeOffset, gindices});
+              const multiProof = createProof(node, {type: ProofType.multi, gindices});
+
+              expect(node.root).to.deep.equal(createNodeFromProof(treeOffsetProof).root);
+              expect(node.root).to.deep.equal(createNodeFromProof(multiProof).root);
+            }
+          }
+        }
+      }
     }
   });
 });

--- a/packages/persistent-merkle-tree/test/unit/proof/util.test.ts
+++ b/packages/persistent-merkle-tree/test/unit/proof/util.test.ts
@@ -6,6 +6,7 @@ import {
   sortInOrderBitstrings,
   filterParentBitstrings,
   computeMultiProofBitstrings,
+  sortDecreasingBitstrings,
 } from "../../../src/proof/util";
 
 describe("computeProofGindices", () => {
@@ -101,6 +102,28 @@ describe("computeMultiProofBitstrings", () => {
     for (const {input, output} of testCases) {
       const actual = computeMultiProofBitstrings(input.map((g) => g.toString(2))).map((str) => BigInt("0b" + str));
       expect(actual).to.deep.equal(output);
+    }
+  });
+});
+
+describe("sortDecreasingBitstrings", () => {
+  it("should properly compute known testcases", () => {
+    const length = 40;
+    const testCases = [
+      Array.from({length}, (_, i) => i + 1),
+      Array.from({length}, (_, i) => length - i + 1),
+      Array.from({length}, () => Math.floor(Math.random() * 1000) + 1),
+    ];
+
+    const toBitstring = (i: number): string => i.toString(2);
+
+    for (const testCase of testCases) {
+      const bitstrings = testCase.map(toBitstring);
+
+      const sorted = testCase.sort((a, b) => (a < b ? 1 : -1));
+      const sortedBitstrings = sortDecreasingBitstrings(bitstrings);
+
+      expect(sortedBitstrings).to.be.deep.equal(sorted.map(toBitstring));
     }
   });
 });


### PR DESCRIPTION
**Motivation**

We need to support the multiproof format described in the consensus specs repo:
https://github.com/ethereum/consensus-specs/blob/dev/ssz/merkle-proofs.md

**Description**

Bare minimum to support EF multiproofs

TODO:
- [x] add tests