### PR TITLE
update and publish simpleserialize.com

### DIFF
--- a/packages/simpleserialize.com/CHANGELOG.md
+++ b/packages/simpleserialize.com/CHANGELOG.md
@@ -3,6 +3,158 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.2.0](https://github.com/chainsafe/simpleserialize.com/compare/simpleserialize.com@0.1.0...simpleserialize.com@0.2.0) (2022-05-18)
+
+
+* SSZ v2 (#223) ([9d167b7](https://github.com/chainsafe/simpleserialize.com/commit/9d167b703b1e974ee4943be15710aa9783183986)), closes [#223](https://github.com/chainsafe/simpleserialize.com/issues/223) [#227](https://github.com/chainsafe/simpleserialize.com/issues/227)
+
+
+### BREAKING CHANGES
+
+* complete refactor, see packages/ssz/README.md for details
+
+Initial squashed v2 commit
+
+Replace lodestarTypes
+
+Update tests
+
+Add Union and None types
+
+Update spec tests
+
+Remove old src and lodestar dependencies
+
+Improve JSON parsing for tests
+
+Load YAML with lodestar utils schema
+
+Commit ArrayComposite before getAll
+
+Re-write toJson fromJson test
+
+Fix uint json conversions
+
+Print tree in valid test if requested
+
+Fix hashTreeRoot for ByteList
+
+Add RENDER_ROOTS option
+
+Fix typos
+
+Use numerical sort in array commit
+
+Fix value_serializedSizeArrayComposite
+
+Pass ssz_generic tests
+
+Allow to select tests to run in ssz_static
+
+Fix container bytes offset
+
+Rename fixedLen to fixedSize
+
+Sort deserailization methods
+
+Print json stringified in test
+
+Review logic
+
+Clean up tests
+
+Define JSON casing at constructor time only
+
+Add casing maps for merge types
+
+Update casing in unit tests
+
+Re-organize utils
+
+Fix merge casing
+
+FIx offset calculation
+
+Pass all spec test pre-merge
+
+Bump merge test
+
+Extend timeout for mainnet tests
+
+Pass all unit tests
+
+Return defaultValue in simpleserialize random
+
+Remove @chainsafe/lodestar-spec-test-util dependency
+
+Copy yaml schema from lodestar-utils
+
+Fix benchmark type issues
+
+Skip createProof benchmark
+
+Skip old benchmark without runner
+
+Remove postinstall script
+
+Re-add UintBigint optimization
+
+Fix set_exitEpoch_and_hashTreeRoot benchmark
+
+Add List of Number benchmark
+
+Use DataViews for faster deserialization
+
+Use DataViews for tree serialization too
+
+Update workflows build after install
+
+Update packedNode tests
+
+Review Tree API
+
+Validate length in ByteArrays
+
+FIx benchmarks in persistent-merkle-tree
+
+Simplify LeafNode constructor
+
+Refactor subtreeFillToContents
+
+Run struct <-> tree_backed benchmarks
+
+Update test types
+
+Fix Uint64 DataView benchmarks
+
+Add benchmarks for full state serialization
+
+Use consistent initialization in DataView
+
+Optimize toView for ByteArray
+
+Add clone method for safer ContainerTreeViewDU
+
+Add documentation to all public methods
+
+Update SSZ README
+
+Simplify testTypes
+
+Update persistent-merkle-tree README
+
+Add unit test push x5
+
+Fix heigh typo
+
+Add note Supports index up to Number.MAX_SAFE_INTEGER.
+
+Address PR comments
+
+
+
+
+
 ## [0.1.1](https://github.com/chainsafe/simpleserialize.com/compare/simpleserialize.com@0.1.0...simpleserialize.com@0.1.1) (2021-10-12)
 
 **Note:** Version bump only for package simpleserialize.com

--- a/packages/simpleserialize.com/package.json
+++ b/packages/simpleserialize.com/package.json
@@ -16,8 +16,8 @@
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@babel/types": "^7.14.5",
-    "@chainsafe/lodestar-types": "0.34.0-dev.63",
-    "@chainsafe/ssz": "^0.8.19",
+    "@chainsafe/lodestar-types": "^0.37.0-dev.267dce705c",
+    "@chainsafe/ssz": "^0.9.1",
     "bn.js": "^5.2.0",
     "bulma": "^0.9.3",
     "core-js": "^3.15.2",

--- a/packages/simpleserialize.com/package.json
+++ b/packages/simpleserialize.com/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "simpleserialize.com",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "repository": "https://github.com/chainsafe/simpleserialize.com",
   "author": "Chainsafe Systems",
   "license": "MIT",

--- a/yarn.lock
+++ b/yarn.lock
@@ -85,11 +85,6 @@
   optionalDependencies:
     csv-stringify "^5.3.6"
 
-"@assemblyscript/loader@^0.9.2":
-  version "0.9.4"
-  resolved "https://registry.yarnpkg.com/@assemblyscript/loader/-/loader-0.9.4.tgz#a483c54c1253656bb33babd464e3154a173e1577"
-  integrity sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA==
-
 "@azure/abort-controller@^1.0.0":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@azure/abort-controller/-/abort-controller-1.0.4.tgz#fd3c4d46c8ed67aace42498c8e2270960250eafd"
@@ -1170,14 +1165,6 @@
     "@babel/helper-validator-identifier" "^7.14.9"
     to-fast-properties "^2.0.0"
 
-"@chainsafe/as-sha256@^0.2.3", "@chainsafe/as-sha256@^0.2.4":
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/@chainsafe/as-sha256/-/as-sha256-0.2.4.tgz#17e78d32c71c836160bb55fd79c3daad93d9abf0"
-  integrity sha512-rYfIOaQm0OlFcHdJFUu5VyYOA1HVeQXxOivUsawBjd7WXc3lMQ0bXMfCgN50gPPLWT92G4ioZ0EZz8RnH+YT/g==
-  dependencies:
-    "@assemblyscript/loader" "^0.9.2"
-    buffer "^5.4.3"
-
 "@chainsafe/babel-plugin-inline-binary-import@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@chainsafe/babel-plugin-inline-binary-import/-/babel-plugin-inline-binary-import-1.0.3.tgz#08dde20d91cf5d18f2c253edf32547943a16e409"
@@ -1186,34 +1173,18 @@
     core-js "2.6.10"
     require-resolve "0.0.2"
 
-"@chainsafe/lodestar-params@0.34.0-dev.63+a222e4274e":
-  version "0.34.0-dev.63"
-  resolved "https://registry.yarnpkg.com/@chainsafe/lodestar-params/-/lodestar-params-0.34.0-dev.63.tgz#6f1a4cf91c305e1b9d6efb4995b793b3ffbe79ff"
-  integrity sha512-mtANNPrUF0fsitloDifj3LC/hv/ilMqmTGE68rlqee2f3movtOiu9QxVnSLO5bCUpPwFH1huRvLbBwJRdI6bNA==
+"@chainsafe/lodestar-params@^0.37.0-dev.d7acdcf4a5":
+  version "0.37.0-dev.d7acdcf4a5"
+  resolved "https://registry.yarnpkg.com/@chainsafe/lodestar-params/-/lodestar-params-0.37.0-dev.d7acdcf4a5.tgz#a8d64f34d44c00b46daf93af3be3024f081b61b4"
+  integrity sha512-U2Y2lniB6L1+z8RCHhNXdwto0lQXvEySPxvzk7ykaXEkcfm2TYdMaMoL19JrKNfvEfmx9bX6SoBxljqL6eipnA==
 
-"@chainsafe/lodestar-types@0.34.0-dev.63":
-  version "0.34.0-dev.63"
-  resolved "https://registry.yarnpkg.com/@chainsafe/lodestar-types/-/lodestar-types-0.34.0-dev.63.tgz#dd2faf08eb93c4bd31f10015db5505da6fbc0be6"
-  integrity sha512-9nM+wtFknNkp/OGyssypehOstWk8TxtMesmvcsGwN0rfe6zWt/1NVsAvH5/yMvDrE2NHrMdprgC0QEk3XqLyug==
+"@chainsafe/lodestar-types@^0.37.0-dev.267dce705c":
+  version "0.37.0-dev.d7acdcf4a5"
+  resolved "https://registry.yarnpkg.com/@chainsafe/lodestar-types/-/lodestar-types-0.37.0-dev.d7acdcf4a5.tgz#f07ade41e4fa90bac38f9eadc56b8100366409b5"
+  integrity sha512-zCcTroZr/bDPgLterqfYXFv4RanDC445u0NlXoxzYetSptZkROsGCk8YDDPE8E+UnKGwUVwWyu0Ti67HZ1eaNQ==
   dependencies:
-    "@chainsafe/lodestar-params" "0.34.0-dev.63+a222e4274e"
-    "@chainsafe/ssz" "^0.8.20"
-
-"@chainsafe/persistent-merkle-tree@^0.3.7":
-  version "0.3.7"
-  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.3.7.tgz#d257674fcacf1770e54df1e7e476bb55efcb3ed4"
-  integrity sha512-UXXzvCN8P4eQWCsaTaHRrNa+2sTwY3NB0Vf+uWgM4cU1qf8LOsTU7aU2CeXFAGJag5W/xEQfVGNh463kXTYAgg==
-  dependencies:
-    "@chainsafe/as-sha256" "^0.2.3"
-
-"@chainsafe/ssz@^0.8.19", "@chainsafe/ssz@^0.8.20":
-  version "0.8.20"
-  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.8.20.tgz#2c8e70e173a2540c8e4e0bad7c44fd836b8b256b"
-  integrity sha512-SjD/GqkByWbC5JC2W4cvaFjok6kfZeZDLLzr9k0Kn4sIOZPBfuRTumvV6ihqgn7ItOFpZRXMz0u4DgH+lr28WQ==
-  dependencies:
-    "@chainsafe/as-sha256" "^0.2.4"
-    "@chainsafe/persistent-merkle-tree" "^0.3.7"
-    case "^1.6.3"
+    "@chainsafe/lodestar-params" "^0.37.0-dev.d7acdcf4a5"
+    "@chainsafe/ssz" "^0.9.1"
 
 "@dapplion/benchmark@^0.2.2":
   version "0.2.2"
@@ -3741,14 +3712,6 @@ buffer@4.9.2, buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
-
-buffer@^5.4.3:
-  version "5.7.1"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.7.1.tgz#ba62e7c13133053582197160851a8f648e99eed0"
-  integrity sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==
-  dependencies:
-    base64-js "^1.3.1"
-    ieee754 "^1.1.13"
 
 buffer@^6.0.3:
   version "6.0.3"
@@ -6863,7 +6826,7 @@ ieee754@1.1.13:
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
   integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
 
-ieee754@^1.1.13, ieee754@^1.1.4, ieee754@^1.2.1:
+ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==


### PR DESCRIPTION
**Motivation**
The ssz types in simple serialize are old and error on bellatrix execution types (raised on chainsafe discord ssz troubleshooting)
this push updates the ssz and types package to latest and should resolve issues.