### PR TITLE
Fix ListCompositeType.sliceTo(-1)

### DIFF
--- a/packages/persistent-merkle-tree/src/tree.ts
+++ b/packages/persistent-merkle-tree/src/tree.ts
@@ -643,6 +643,12 @@ export function treeZeroAfterIndex(rootNode: Node, nodesDepth: number, index: nu
   // goRight = (N & mask) == mask
   // ```
 
+  // Degenerate case where tree is zero after a negative index (-1).
+  // All positive indexes are zero, so the entire tree is zero. Return cached zero node as root.
+  if (index < 0) {
+    return zeroNode(nodesDepth);
+  }
+
   /**
    * Contiguous filled stack of parent nodes. It get filled in the first descent
    * Indexed by depthi

--- a/packages/ssz/src/viewDU/listComposite.ts
+++ b/packages/ssz/src/viewDU/listComposite.ts
@@ -39,6 +39,8 @@ export class ListCompositeTreeViewDU<
    * ```
    *
    * To achieve it, rebinds the underlying tree zero-ing all nodes right of `index`.
+   *
+   * Note: Using index = -1, returns an empty list of length 0.
    */
   sliceTo(index: number): this {
     // Commit before getting rootNode to ensure all pending data is in the rootNode

--- a/packages/ssz/test/unit/byType/listComposite/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listComposite/tree.test.ts
@@ -173,16 +173,24 @@ describe("ListCompositeType.sliceTo", () => {
     const listType = new ListCompositeType(ssz.Root, 1024);
     const listView = listType.defaultViewDU();
     const listRoots: string[] = [];
+    const listSerialized: string[] = [];
 
-    for (let i = 0; i < 16; i++) {
-      listView.push(Buffer.alloc(32, i + 1));
-      listRoots.push(toHexString(listView.serialize()));
+    for (let i = -1; i < 16; i++) {
+      // Skip first loop to persist empty case
+      if (i >= 0) {
+        listView.push(Buffer.alloc(32, 0xf + i)); // Avoid 0 case
+      }
+      // Javascript arrays can handle negative indexes (ok for tests)
+      listSerialized[i] = toHexString(listView.serialize());
+      listRoots[i] = toHexString(listView.hashTreeRoot());
     }
 
-    for (let i = 0; i < 16; i++) {
+    // Start at -1 to test the empty case.
+    for (let i = -1; i < 16; i++) {
       const listSlice = listView.sliceTo(i);
       expect(listSlice.length).to.equal(i + 1, `Wrong length at .sliceTo(${i})`);
-      expect(toHexString(listSlice.serialize())).equals(listRoots[i], `Wrong bytes at .sliceTo(${i})`);
+      expect(toHexString(listSlice.serialize())).equals(listSerialized[i], `Wrong serialize at .sliceTo(${i})`);
+      expect(toHexString(listSlice.hashTreeRoot())).equals(listRoots[i], `Wrong root at .sliceTo(${i})`);
     }
   });
 });


### PR DESCRIPTION
**Motivation**

`ListCompositeType.sliceTo(-1)` should return an empty list as it means "set all positive indexes to 0".

The root cause is that `treeZeroAfterIndex` function returns incorrect results if index is less than zero.

**Description**

Add early return in `treeZeroAfterIndex`. All positive indexes are zero, so the entire tree is zero. Return cached zero node as root.