### PR TITLE
Fix typo in UintBigintByteLen

### DIFF
--- a/packages/ssz/src/type/uint.ts
+++ b/packages/ssz/src/type/uint.ts
@@ -257,7 +257,7 @@ export class UintBigintType extends BasicType<bigint> {
     this.maxSize = byteLength;
   }
 
-  static named(byteLength: UintNumberByteLen, opts: Require<UintBigintOpts, "typeName">): UintBigintType {
+  static named(byteLength: UintBigintByteLen, opts: Require<UintBigintOpts, "typeName">): UintBigintType {
     return new (namedClass(UintBigintType, opts.typeName))(byteLength, opts);
   }
 


### PR DESCRIPTION
**Motivation**

named static fn for UintBigintType uses the wrong union

**Description**

- Fix typo in UintBigintByteLen