### PR TITLE
feat: Switch case dependency to internal helper

### DIFF
--- a/packages/ssz/package.json
+++ b/packages/ssz/package.json
@@ -36,8 +36,7 @@
   "types": "lib/index.d.ts",
   "dependencies": {
     "@chainsafe/as-sha256": "^0.3.1",
-    "@chainsafe/persistent-merkle-tree": "^0.4.2",
-    "case": "^1.6.3"
+    "@chainsafe/persistent-merkle-tree": "^0.4.2"
   },
   "devDependencies": {
     "@types/js-yaml": "^4.0.5",

--- a/packages/ssz/src/type/container.ts
+++ b/packages/ssz/src/type/container.ts
@@ -550,12 +550,7 @@ export function precomputeJsonKey<Fields extends Record<string, Type<unknown>>>(
     }
     return keyFromCaseMap as string;
   } else if (jsonCase) {
-    if (jsonCase === "eth2") {
-      const snake = Case.snake(fieldName as string);
-      return snake.replace(/(\d)$/, "_$1");
-    } else {
-      return Case[jsonCase](fieldName as string);
-    }
+    return Case[jsonCase](fieldName as string);
   } else {
     return fieldName as string;
   }

--- a/packages/ssz/src/type/container.ts
+++ b/packages/ssz/src/type/container.ts
@@ -34,7 +34,7 @@ export type ContainerOptions<Fields extends Record<string, unknown>> = {
   getContainerTreeViewDUClass?: typeof getContainerTreeViewDUClass;
 };
 
-type KeyCase =
+export type KeyCase =
   | "eth2"
   | "snake"
   | "constant"

--- a/packages/ssz/src/type/container.ts
+++ b/packages/ssz/src/type/container.ts
@@ -8,7 +8,6 @@ import {
   concatGindices,
   getNode,
 } from "@chainsafe/persistent-merkle-tree";
-import Case from "case";
 import {maxChunksToDepth} from "../util/merkleize";
 import {Require} from "../util/types";
 import {namedClass} from "../util/named";
@@ -21,7 +20,7 @@ import {
   ContainerTreeViewDUType,
   ContainerTreeViewDUTypeConstructor,
 } from "../viewDU/container";
-
+import {Case} from "../util/strings";
 /* eslint-disable @typescript-eslint/member-ordering */
 
 type BytesRange = {start: number; end: number};

--- a/packages/ssz/src/util/strings.ts
+++ b/packages/ssz/src/util/strings.ts
@@ -1,0 +1,29 @@
+// Convert camelCase strings to various other formats  -- assumes input field is camelCase or camel1Case
+export const Case = {
+  snake: (field: string): string =>
+    field
+      .replaceAll(/[^0-z]/g, "")
+      .replaceAll(/[a-z][A-Z]|[0-9][A-Z]/g, (substr) => substr[0] + "_" + substr[1].toLowerCase()),
+  constant: (field: string): string =>
+    field
+      .replaceAll(/[^0-z]/g, "")
+      .replaceAll(/[a-z][A-Z]|[0-9][A-Z]/g, (substr) => substr[0] + "_" + substr[1])
+      .toUpperCase(),
+  pascal: (field: string): string => {
+    const first = field[0].toUpperCase();
+    return (first + field.slice(1)).replaceAll(/[^0-z]/g, "");
+  },
+  camel: (field: string): string => {
+    return field[0].toLowerCase() + field.slice(1);
+  },
+  header: (field: string): string => {
+    const first = field[0].toUpperCase();
+    return (
+      first +
+      field
+        .slice(1)
+        .replaceAll(/[^0-z]/g, "")
+        .replaceAll(/[a-z][A-Z]|[0-9][A-Z]/g, (substr) => substr[0] + "-" + substr[1])
+    );
+  },
+};

--- a/packages/ssz/src/util/strings.ts
+++ b/packages/ssz/src/util/strings.ts
@@ -1,4 +1,5 @@
 // Convert camelCase strings to various other formats  -- assumes input field is camelCase or camel1Case
+
 export const Case = {
   snake: (field: string): string =>
     field
@@ -26,4 +27,5 @@ export const Case = {
         .replaceAll(/[a-z][A-Z]|[0-9][A-Z]/g, (substr) => substr[0] + "-" + substr[1])
     );
   },
+  eth2: (field: string): string => Case.snake(field),
 };

--- a/packages/ssz/src/util/strings.ts
+++ b/packages/ssz/src/util/strings.ts
@@ -27,5 +27,5 @@ export const Case = {
         .replaceAll(/[a-z][A-Z]|[0-9][A-Z]/g, (substr) => substr[0] + "-" + substr[1])
     );
   },
-  eth2: (field: string): string => Case.snake(field),
+  eth2: (field: string): string => Case.snake(field).replace(/(\d)$/, "_$1"),
 };

--- a/packages/ssz/test/unit/strings.test.ts
+++ b/packages/ssz/test/unit/strings.test.ts
@@ -22,4 +22,4 @@ for (const key of keys) {
       });
     }
   });
-};
+}

--- a/packages/ssz/test/unit/strings.test.ts
+++ b/packages/ssz/test/unit/strings.test.ts
@@ -2,20 +2,20 @@ import {expect} from "chai";
 
 import {Case} from "../../src/util/strings";
 import {KeyCase} from "../../src/type/container";
-const testCases = ["fooBar", "foo1Bar", "fooBarBaz", "foo1Bar2Baz"];
+const testCases = ["fooBar", "foo1Bar", "fooBarBaz", "foo1Bar2Baz", "fooBar1"];
 const expectedResults: {[key in KeyCase]: string[]} = {
-  snake: ["foo_bar", "foo1_bar", "foo_bar_baz", "foo1_bar2_baz"],
-  eth2: ["foo_bar", "foo1_bar", "foo_bar_baz", "foo1_bar2_baz"],
-  pascal: ["FooBar", "Foo1Bar", "FooBarBaz", "Foo1Bar2Baz"],
-  camel: ["fooBar", "foo1Bar", "fooBarBaz", "foo1Bar2Baz"],
-  constant: ["FOO_BAR", "FOO1_BAR", "FOO_BAR_BAZ", "FOO1_BAR2_BAZ"],
-  header: ["Foo-Bar", "Foo1-Bar", "Foo-Bar-Baz", "Foo1-Bar2-Baz"],
+  snake: ["foo_bar", "foo1_bar", "foo_bar_baz", "foo1_bar2_baz", "foo_bar1"],
+  eth2: ["foo_bar", "foo1_bar", "foo_bar_baz", "foo1_bar2_baz", "foo_bar_1"],
+  pascal: ["FooBar", "Foo1Bar", "FooBarBaz", "Foo1Bar2Baz", "FooBar1"],
+  camel: ["fooBar", "foo1Bar", "fooBarBaz", "foo1Bar2Baz", "fooBar1"],
+  constant: ["FOO_BAR", "FOO1_BAR", "FOO_BAR_BAZ", "FOO1_BAR2_BAZ", "FOO_BAR1"],
+  header: ["Foo-Bar", "Foo1-Bar", "Foo-Bar-Baz", "Foo1-Bar2-Baz", "Foo-Bar1"],
 };
 
 const keys = Object.keys(expectedResults) as KeyCase[];
 for (const key of keys) {
   describe(`should convert string to ${key} case`, () => {
-    for (let x = 0; x < 4; x++) {
+    for (let x = 0; x < 5; x++) {
       const field: string = Case[key as KeyCase](testCases[x]);
       it(`should convert to ${expectedResults[key as KeyCase][x]}`, () => {
         expect(field).to.equal(expectedResults[key][x]);

--- a/packages/ssz/test/unit/strings.test.ts
+++ b/packages/ssz/test/unit/strings.test.ts
@@ -1,59 +1,25 @@
 import {expect} from "chai";
 
 import {Case} from "../../src/util/strings";
+import {KeyCase} from "../../src/type/container";
+const testCases = ["fooBar", "foo1Bar", "fooBarBaz", "foo1Bar2Baz"];
+const expectedResults: {[key in KeyCase]: string[]} = {
+  snake: ["foo_bar", "foo1_bar", "foo_bar_baz", "foo1_bar2_baz"],
+  eth2: ["foo_bar", "foo1_bar", "foo_bar_baz", "foo1_bar2_baz"],
+  pascal: ["FooBar", "Foo1Bar", "FooBarBaz", "Foo1Bar2Baz"],
+  camel: ["fooBar", "foo1Bar", "fooBarBaz", "foo1Bar2Baz"],
+  constant: ["FOO_BAR", "FOO1_BAR", "FOO_BAR_BAZ", "FOO1_BAR2_BAZ"],
+  header: ["Foo-Bar", "Foo1-Bar", "Foo-Bar-Baz", "Foo1-Bar2-Baz"],
+};
 
-const testCases = ["fooBar", "foo1Bar"];
-describe("should convert strings to snake case", () => {
-  it("should convert to foo_bar", () => {
-    const field = Case.snake(testCases[0]);
-    expect(field).to.equal("foo_bar");
+const keys = Object.keys(expectedResults) as KeyCase[];
+for (const key of keys) {
+  describe(`should convert string to ${key} case`, () => {
+    for (let x = 0; x < 4; x++) {
+      const field: string = Case[key as KeyCase](testCases[x]);
+      it(`should convert to ${expectedResults[key as KeyCase][x]}`, () => {
+        expect(field).to.equal(expectedResults[key][x]);
+      });
+    }
   });
-  it("should convert to foo1_bar", () => {
-    const field = Case.snake(testCases[1]);
-    expect(field).to.equal("foo1_bar");
-  });
-});
-
-describe("should convert strings to pascal case", () => {
-  it("should convert to FooBar", () => {
-    const field = Case.pascal(testCases[0]);
-    expect(field).to.equal("FooBar");
-  });
-  it("should convert to Foo1Bar", () => {
-    const field = Case.pascal(testCases[1]);
-    expect(field).to.equal("Foo1Bar");
-  });
-});
-
-describe("should convert strings to camel case", () => {
-  it("should convert to fooBar", () => {
-    const field = Case.camel(testCases[0]);
-    expect(field).to.equal("fooBar");
-  });
-  it("should convert to foo1Bar", () => {
-    const field = Case.camel(testCases[1]);
-    expect(field).to.equal("foo1Bar");
-  });
-});
-
-describe("should convert strings to constant case", () => {
-  it("should convert to FOO_BAR", () => {
-    const field = Case.constant(testCases[0]);
-    expect(field).to.equal("FOO_BAR");
-  });
-  it("should convert to FOO1_BAR", () => {
-    const field = Case.constant(testCases[1]);
-    expect(field).to.equal("FOO1_BAR");
-  });
-});
-
-describe("should convert strings to header case", () => {
-  it("should convert to Foo-Bar", () => {
-    const field = Case.header(testCases[0]);
-    expect(field).to.equal("Foo-Bar");
-  });
-  it("should convert to Foo1-Bar", () => {
-    const field = Case.header(testCases[1]);
-    expect(field).to.equal("Foo1-Bar");
-  });
-});
+};

--- a/packages/ssz/test/unit/strings.test.ts
+++ b/packages/ssz/test/unit/strings.test.ts
@@ -1,0 +1,59 @@
+import {expect} from "chai";
+
+import {Case} from "../../src/util/strings";
+
+const testCases = ["fooBar", "foo1Bar"];
+describe("should convert strings to snake case", () => {
+  it("should convert to foo_bar", () => {
+    const field = Case.snake(testCases[0]);
+    expect(field).to.equal("foo_bar");
+  });
+  it("should convert to foo1_bar", () => {
+    const field = Case.snake(testCases[1]);
+    expect(field).to.equal("foo1_bar");
+  });
+});
+
+describe("should convert strings to pascal case", () => {
+  it("should convert to FooBar", () => {
+    const field = Case.pascal(testCases[0]);
+    expect(field).to.equal("FooBar");
+  });
+  it("should convert to Foo1Bar", () => {
+    const field = Case.pascal(testCases[1]);
+    expect(field).to.equal("Foo1Bar");
+  });
+});
+
+describe("should convert strings to camel case", () => {
+  it("should convert to fooBar", () => {
+    const field = Case.camel(testCases[0]);
+    expect(field).to.equal("fooBar");
+  });
+  it("should convert to foo1Bar", () => {
+    const field = Case.camel(testCases[1]);
+    expect(field).to.equal("foo1Bar");
+  });
+});
+
+describe("should convert strings to constant case", () => {
+  it("should convert to FOO_BAR", () => {
+    const field = Case.constant(testCases[0]);
+    expect(field).to.equal("FOO_BAR");
+  });
+  it("should convert to FOO1_BAR", () => {
+    const field = Case.constant(testCases[1]);
+    expect(field).to.equal("FOO1_BAR");
+  });
+});
+
+describe("should convert strings to header case", () => {
+  it("should convert to Foo-Bar", () => {
+    const field = Case.header(testCases[0]);
+    expect(field).to.equal("Foo-Bar");
+  });
+  it("should convert to Foo1-Bar", () => {
+    const field = Case.header(testCases[1]);
+    expect(field).to.equal("Foo1-Bar");
+  });
+});


### PR DESCRIPTION
**Motivation**

Removes an external dependency, thus removing the surface area for supply chain atttacks.

**Description**

Replaces `case` dependency that's only used for string manipulation with an internal helper method that accomplishes the same goal.

Run impacted tests.

```sh
cd packages/ssz
npx mocha -- "test/unit/eth2/caseEth2.test.ts" "test/unit/strings.test.ts"
```

