### PR TITLE
chore: use personal token for release-please

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -18,7 +18,7 @@ jobs:
         id: release
         with:
           command: manifest
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{secrets.GH_TOKEN}}
           default-branch: master
           release-type: node
           monorepo-tags: true


### PR DESCRIPTION
**Motivation**

We want the release-please PR to trigger workflows

**Description**

Use a different secret for release-please
See https://github.com/google-github-actions/release-please-action#github-credentials