### PR TITLE
fix: Remove replaceAll with replace(/.../g,... for ES2019 compatibility

### DIFF
--- a/packages/ssz/src/util/strings.ts
+++ b/packages/ssz/src/util/strings.ts
@@ -3,16 +3,16 @@
 export const Case = {
   snake: (field: string): string =>
     field
-      .replaceAll(/[^0-z]/g, "")
-      .replaceAll(/[a-z][A-Z]|[0-9][A-Z]/g, (substr) => substr[0] + "_" + substr[1].toLowerCase()),
+      .replace(/[^0-z]/g, "")
+      .replace(/[a-z][A-Z]|[0-9][A-Z]/g, (substr) => substr[0] + "_" + substr[1].toLowerCase()),
   constant: (field: string): string =>
     field
-      .replaceAll(/[^0-z]/g, "")
-      .replaceAll(/[a-z][A-Z]|[0-9][A-Z]/g, (substr) => substr[0] + "_" + substr[1])
+      .replace(/[^0-z]/g, "")
+      .replace(/[a-z][A-Z]|[0-9][A-Z]/g, (substr) => substr[0] + "_" + substr[1])
       .toUpperCase(),
   pascal: (field: string): string => {
     const first = field[0].toUpperCase();
-    return (first + field.slice(1)).replaceAll(/[^0-z]/g, "");
+    return (first + field.slice(1)).replace(/[^0-z]/g, "");
   },
   camel: (field: string): string => {
     return field[0].toLowerCase() + field.slice(1);
@@ -23,8 +23,8 @@ export const Case = {
       first +
       field
         .slice(1)
-        .replaceAll(/[^0-z]/g, "")
-        .replaceAll(/[a-z][A-Z]|[0-9][A-Z]/g, (substr) => substr[0] + "-" + substr[1])
+        .replace(/[^0-z]/g, "")
+        .replace(/[a-z][A-Z]|[0-9][A-Z]/g, (substr) => substr[0] + "-" + substr[1])
     );
   },
   eth2: (field: string): string => Case.snake(field).replace(/(\d)$/, "_$1"),


### PR DESCRIPTION
fix: Remove replaceAll with replace(/.../g,... for ES2019 comptatibility

see:
 - https://github.com/ethereumjs/ethereumjs-monorepo/issues/2554