### PR TITLE
fix: Use file path imports

### DIFF
--- a/packages/as-sha256/package.json
+++ b/packages/as-sha256/package.json
@@ -13,10 +13,6 @@
     "url": "git+https://github.com/chainsafe/as-sha256.git"
   },
   "main": "lib/index.js",
-  "exports": {
-    ".": "./lib/index.js",
-    "./hashObject": "./lib/hashObject.js"
-  },
   "typesVersions": {
     "*": {
       "*": [

--- a/packages/persistent-merkle-tree/package.json
+++ b/packages/persistent-merkle-tree/package.json
@@ -3,12 +3,6 @@
   "version": "0.6.0",
   "description": "Merkle tree implemented as a persistent datastructure",
   "main": "lib/index.js",
-  "exports": {
-    ".": "./lib/index.js",
-    "./hasher": "./lib/hasher/index.js",
-    "./hasher/as-sha256": "./lib/hasher/as-sha256.js",
-    "./hasher/noble": "./lib/hasher/noble.js"
-  },
   "typesVersions": {
     "*": {
       "*": [

--- a/packages/persistent-merkle-tree/src/hasher/index.ts
+++ b/packages/persistent-merkle-tree/src/hasher/index.ts
@@ -1,7 +1,7 @@
 import {Hasher} from "./types";
 import {hasher as nobleHasher} from "./noble";
 
-export {HashObject} from "@chainsafe/as-sha256/hashObject";
+export {HashObject} from "@chainsafe/as-sha256/lib/hashObject";
 export * from "./types";
 export * from "./util";
 

--- a/packages/persistent-merkle-tree/src/hasher/types.ts
+++ b/packages/persistent-merkle-tree/src/hasher/types.ts
@@ -1,4 +1,4 @@
-import type {HashObject} from "@chainsafe/as-sha256/hashObject";
+import type {HashObject} from "@chainsafe/as-sha256/lib/hashObject";
 
 export type Hasher = {
   /**

--- a/packages/persistent-merkle-tree/src/hasher/util.ts
+++ b/packages/persistent-merkle-tree/src/hasher/util.ts
@@ -1,4 +1,4 @@
-import {byteArrayToHashObject, HashObject, hashObjectToByteArray} from "@chainsafe/as-sha256/hashObject";
+import {byteArrayToHashObject, HashObject, hashObjectToByteArray} from "@chainsafe/as-sha256/lib/hashObject";
 
 export function hashObjectToUint8Array(obj: HashObject): Uint8Array {
   const byteArr = new Uint8Array(32);

--- a/packages/persistent-merkle-tree/src/node.ts
+++ b/packages/persistent-merkle-tree/src/node.ts
@@ -1,4 +1,4 @@
-import {HashObject} from "@chainsafe/as-sha256/hashObject";
+import {HashObject} from "@chainsafe/as-sha256/lib/hashObject";
 import {hashObjectToUint8Array, hasher, uint8ArrayToHashObject} from "./hasher";
 
 const TWO_POWER_32 = 2 ** 32;

--- a/packages/ssz/src/branchNodeStruct.ts
+++ b/packages/ssz/src/branchNodeStruct.ts
@@ -1,4 +1,4 @@
-import {HashObject} from "@chainsafe/as-sha256/hashObject";
+import {HashObject} from "@chainsafe/as-sha256/lib/hashObject";
 import {hashObjectToUint8Array, Node} from "@chainsafe/persistent-merkle-tree";
 
 /**

--- a/packages/ssz/src/util/merkleize.ts
+++ b/packages/ssz/src/util/merkleize.ts
@@ -1,4 +1,4 @@
-import {hasher} from "@chainsafe/persistent-merkle-tree/lib/hasher";
+import {hasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/index";
 import {zeroHash} from "./zeros";
 
 export function hash64(bytes32A: Uint8Array, bytes32B: Uint8Array): Uint8Array {

--- a/packages/ssz/src/util/merkleize.ts
+++ b/packages/ssz/src/util/merkleize.ts
@@ -1,4 +1,4 @@
-import {hasher} from "@chainsafe/persistent-merkle-tree/hasher";
+import {hasher} from "@chainsafe/persistent-merkle-tree/lib/hasher";
 import {zeroHash} from "./zeros";
 
 export function hash64(bytes32A: Uint8Array, bytes32B: Uint8Array): Uint8Array {

--- a/packages/ssz/src/util/zeros.ts
+++ b/packages/ssz/src/util/zeros.ts
@@ -1,4 +1,4 @@
-import {hasher} from "@chainsafe/persistent-merkle-tree/lib/hasher";
+import {hasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/index";
 
 // create array of "zero hashes", successively hashed zero chunks
 const zeroHashes = [new Uint8Array(32)];

--- a/packages/ssz/src/util/zeros.ts
+++ b/packages/ssz/src/util/zeros.ts
@@ -1,4 +1,4 @@
-import {hasher} from "@chainsafe/persistent-merkle-tree/hasher";
+import {hasher} from "@chainsafe/persistent-merkle-tree/lib/hasher";
 
 // create array of "zero hashes", successively hashed zero chunks
 const zeroHashes = [new Uint8Array(32)];

--- a/setHasher.mjs
+++ b/setHasher.mjs
@@ -1,5 +1,5 @@
 // Set the hasher to as-sha256
 // Used to run benchmarks with with visibility into as-sha256 performance, useful for Lodestar
-import {setHasher} from "@chainsafe/persistent-merkle-tree/lib/hasher";
-import {hasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/as-sha256";
+import {setHasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/index.js";
+import {hasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/as-sha256.js";
 setHasher(hasher);

--- a/setHasher.mjs
+++ b/setHasher.mjs
@@ -1,5 +1,5 @@
 // Set the hasher to as-sha256
 // Used to run benchmarks with with visibility into as-sha256 performance, useful for Lodestar
-import {setHasher} from "@chainsafe/persistent-merkle-tree/hasher";
-import {hasher} from "@chainsafe/persistent-merkle-tree/hasher/as-sha256";
+import {setHasher} from "@chainsafe/persistent-merkle-tree/lib/hasher";
+import {hasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/as-sha256";
 setHasher(hasher);


### PR DESCRIPTION
**Motivation**

The goal of this PR is to stop relying on `package.json` `exports`, as it may break older build tools such as Browserify.

**Description**

Uses explicit imports for all imports that were previously using `exports` aliases.

**Steps to test or reproduce**

<!--Steps to reproduce the behavior:
```sh
git checkout <feature_branch>
lodestar beacon --new-flag option1
```
-->
