### PR TITLE
feat: support capella fork on simpleserialize.com

### DIFF
--- a/packages/simpleserialize.com/package.json
+++ b/packages/simpleserialize.com/package.json
@@ -16,8 +16,8 @@
   "dependencies": {
     "@babel/runtime": "^7.14.6",
     "@babel/types": "^7.14.5",
-    "@chainsafe/lodestar-types": "^0.37.0-dev.267dce705c",
     "@chainsafe/ssz": "workspace:^",
+    "@lodestar/types": "^1.7.2",
     "bn.js": "^5.2.0",
     "bulma": "^0.9.3",
     "core-js": "^3.15.2",

--- a/packages/simpleserialize.com/src/components/Footer.tsx
+++ b/packages/simpleserialize.com/src/components/Footer.tsx
@@ -26,8 +26,8 @@ export default function Footer(): JSX.Element {
           </a>
         </div>
         <div>
-          <a className="is-link has-text-grey" href="https://www.npmjs.com/package/@chainsafe/lodestar-types">
-            @chainsafe/lodestar-types {pkg.dependencies["@chainsafe/lodestar-types"]}
+          <a className="is-link has-text-grey" href="https://www.npmjs.com/package/@lodestar/types">
+            @lodestar/types {pkg.dependencies["@lodestar/types"]}
           </a>
         </div>
       </div>

--- a/packages/simpleserialize.com/src/components/Header.tsx
+++ b/packages/simpleserialize.com/src/components/Header.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 
-const SPEC_VERSION = "1.1.9";
+const SPEC_VERSION = "1.3.0";
 
 export default function Header(): JSX.Element {
   return (

--- a/packages/simpleserialize.com/src/components/Input.tsx
+++ b/packages/simpleserialize.com/src/components/Input.tsx
@@ -33,7 +33,7 @@ type State = {
   userHasEditedInput: boolean;
 };
 
-const DEFAULT_FORK = "phase0";
+const DEFAULT_FORK = "capella";
 
 class Input extends React.Component<Props, State> {
   worker: Worker;

--- a/packages/simpleserialize.com/src/types/index.ts
+++ b/packages/simpleserialize.com/src/types/index.ts
@@ -1,5 +1,5 @@
 /**
- * @module types 
+ * @module types
  */
 
-export * from "@chainsafe/lodestar-types"
+export * from "@lodestar/types";

--- a/packages/simpleserialize.com/src/util/types.ts
+++ b/packages/simpleserialize.com/src/util/types.ts
@@ -1,13 +1,26 @@
 import {Type} from "@chainsafe/ssz";
-import {ssz} from "@chainsafe/lodestar-types";
+import {ssz} from "@lodestar/types";
 
-const {phase0, altair, bellatrix, allForks, ...primitive} = ssz;
+const {
+  phase0,
+  altair,
+  bellatrix,
+  capella,
+  deneb,
+  allForks,
+  allForksBlinded,
+  allForksBlobs,
+  allForksExecution,
+  allForksLightClient,
+  ...primitive
+} = ssz;
 
 export const forks = {
   phase0: {...phase0, ...primitive} as Record<string, Type<unknown>>,
   altair: {...phase0, ...altair, ...primitive} as Record<string, Type<unknown>>,
   bellatrix: {...phase0, ...altair, ...bellatrix, ...primitive} as Record<string, Type<unknown>>,
-} as Record<string, Record<string, Type<unknown>>>
+  capella: {...phase0, ...altair, ...bellatrix, ...capella, ...primitive} as Record<string, Type<unknown>>,
+} as Record<string, Record<string, Type<unknown>>>;
 
 export type ForkName = keyof typeof forks;
 

--- a/packages/simpleserialize.com/webpack.config.js
+++ b/packages/simpleserialize.com/webpack.config.js
@@ -21,6 +21,12 @@ const config = {
   module: {
     rules: [
       {
+        test: /\.m?js/,
+        resolve: {
+          fullySpecified: false,
+        },
+      },
+      {
       test: /\.scss$/,
       use: [
           MiniCssExtractPlugin.loader,
@@ -86,6 +92,12 @@ const workerConfig = {
   },
   module: {
     rules: [
+      {
+        test: /\.m?js/,
+        resolve: {
+          fullySpecified: false,
+        },
+      },
       {
         test: /worker?$/,
         loader: 'threads-webpack-plugin',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1647,23 +1647,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@chainsafe/lodestar-params@npm:^0.37.0-dev.d7acdcf4a5":
-  version: 0.37.0-dev.d7acdcf4a5
-  resolution: "@chainsafe/lodestar-params@npm:0.37.0-dev.d7acdcf4a5"
-  checksum: 36021375396414d72b4ba95c587d09528f10b822e51f6332131520c581ae61a57fbf98b9700bdbf64f2d9c6f59b6ee69ac716e4130037c15d96dac143bc0912f
-  languageName: node
-  linkType: hard
-
-"@chainsafe/lodestar-types@npm:^0.37.0-dev.267dce705c":
-  version: 0.37.0-dev.d7acdcf4a5
-  resolution: "@chainsafe/lodestar-types@npm:0.37.0-dev.d7acdcf4a5"
-  dependencies:
-    "@chainsafe/lodestar-params": ^0.37.0-dev.d7acdcf4a5
-    "@chainsafe/ssz": ^0.9.1
-  checksum: 20e8610fe4175b0c27f5adc3bc043666a755d1c6c64a5adfbc7656222de45ef3b345ee4a1cce10d3e36a905e15bd2bd14efad2b2fffce79a127dbd65b6d83482
-  languageName: node
-  linkType: hard
-
 "@chainsafe/persistent-merkle-tree@workspace:^, @chainsafe/persistent-merkle-tree@workspace:packages/persistent-merkle-tree":
   version: 0.0.0-use.local
   resolution: "@chainsafe/persistent-merkle-tree@workspace:packages/persistent-merkle-tree"
@@ -1879,6 +1862,23 @@ __metadata:
   version: 0.1.3
   resolution: "@istanbuljs/schema@npm:0.1.3"
   checksum: 61c5286771676c9ca3eb2bd8a7310a9c063fb6e0e9712225c8471c582d157392c88f5353581c8c9adbe0dff98892317d2fdfc56c3499aa42e0194405206a963a
+  languageName: node
+  linkType: hard
+
+"@lodestar/params@npm:^1.7.2":
+  version: 1.7.2
+  resolution: "@lodestar/params@npm:1.7.2"
+  checksum: 4770e4a5a48c95a7d9314e2838dc612403c04af6fe229d350fc7effe3da1176dd23bf4a50de336264d04d03ef8a7ddd76d032201aebad4e0625d39bf2202c64c
+  languageName: node
+  linkType: hard
+
+"@lodestar/types@npm:^1.7.2":
+  version: 1.7.2
+  resolution: "@lodestar/types@npm:1.7.2"
+  dependencies:
+    "@chainsafe/ssz": ^0.10.1
+    "@lodestar/params": ^1.7.2
+  checksum: 53b4748d82728677f9afd8e4f08d22de230d180f2e1f7aec64ad28769971838a5876f251f149f4a6719d334fa1ad8362cfb2adbd7bc68ce8690106b5c6f93341
   languageName: node
   linkType: hard
 
@@ -11786,8 +11786,8 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.14.6
     "@babel/types": ^7.14.5
-    "@chainsafe/lodestar-types": ^0.37.0-dev.267dce705c
     "@chainsafe/ssz": "workspace:^"
+    "@lodestar/types": ^1.7.2
     "@types/bn.js": ^5.1.0
     "@types/deep-equal": ^1.0.1
     "@types/file-saver": ^2.0.2


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/ssz/issues/320

**Description**

- Add `capella` fork types
- Use `@lodestar/types` package instead of `@chainsafe/lodestar-types`
- Update consensus spec version to 1.3.0
- Set `capella` as default fork instead of `phase0`
- Add webpack config rules to fix build issues
