### PR TITLE
fix: show errors during serialization/deserialization as popup

### DIFF
--- a/packages/simpleserialize.com/src/components/Input.tsx
+++ b/packages/simpleserialize.com/src/components/Input.tsx
@@ -114,9 +114,14 @@ class Input extends React.Component<Props, State> {
     const inputTypeStr = this.getInputType();
     const type = this.types()[this.state.sszTypeName];
     const inputType = inputTypes[inputTypeStr];
-    const parsed = inputType.parse(this.state.input, type);
-    this.props.setOverlay(false);
-    return parsed;
+    try {
+      const parsed = inputType.parse(this.state.input, type);
+      this.props.setOverlay(false);
+      return parsed;
+    } catch (error) {
+      this.handleError(error as Error);
+      throw error;
+    }
   }
 
   async resetWith(inputType: string, sszTypeName: string): Promise<void> {
@@ -170,11 +175,16 @@ class Input extends React.Component<Props, State> {
   setInputType(inputType: string): void {
     const {sszTypeName, value} = this.state;
     const sszType = this.types()[sszTypeName];
-    const input = inputTypes[inputType].dump(value, sszType);
-    if (this.props.serializeModeOn) {
-      this.setState({serializeInputType: inputType, sszTypeName, input});
-    } else {
-      this.setState({deserializeInputType: inputType, sszTypeName, input});
+    try {
+      const input = inputTypes[inputType].dump(value, sszType);
+      if (this.props.serializeModeOn) {
+        this.setState({serializeInputType: inputType, sszTypeName, input});
+      } else {
+        this.setState({deserializeInputType: inputType, sszTypeName, input});
+      }
+    } catch (error) {
+      this.handleError(error as Error);
+      throw error;
     }
   }
 


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/ssz/issues/322

**Description**

Easiest solution I found with high confidence of not breaking something.

It will now also show a error popup instead of just logging to console, the errors are quite technical and might not be that helpful sometimes but at least a user gets notified that something is not right.

![image](https://user-images.githubusercontent.com/38436224/235721283-1ac44a6e-d154-4be7-81f8-15c26b1d07b7.png)

