### PR TITLE
fix: add hasher alias to webpack config to fix build

### DIFF
--- a/packages/simpleserialize.com/webpack.config.js
+++ b/packages/simpleserialize.com/webpack.config.js
@@ -17,6 +17,10 @@ const config = {
   },
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
+    alias: {
+      '@chainsafe/persistent-merkle-tree/lib/hasher/index':
+        '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble',
+    },
   },
   module: {
     rules: [
@@ -76,6 +80,10 @@ const workerConfig = {
   name: "worker",
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
+    alias: {
+      '@chainsafe/persistent-merkle-tree/lib/hasher/index':
+        '../../node_modules/@chainsafe/persistent-merkle-tree/lib/hasher/noble',
+    },
   },
   entry: {
     index: './src/components/worker/index.ts',


### PR DESCRIPTION
**Motivation**

Closes https://github.com/ChainSafe/ssz/issues/324

**Description**

Add alias to webpack config to fix build.

@g11tech I noticed you [added this](https://github.com/ChainSafe/ssz/compare/a7548d9b9fc5ed4315eaca8aebb8db4970e48c7e..c57882e2383e17399bed01e02512631d2f13e55a) in https://github.com/ChainSafe/ssz/pull/318 but it got removed by  a force-push.