### PR TITLE
fix: return correct property gindex for ContainerNodeStructType

### DIFF
--- a/packages/ssz/src/type/containerNodeStruct.ts
+++ b/packages/ssz/src/type/containerNodeStruct.ts
@@ -77,9 +77,6 @@ export class ContainerNodeStructType<Fields extends Record<string, Type<unknown>
 
   // ContainerNodeStructType can only parse proofs that contain all the data.
   // TODO: Support converting a partial tree to a partial value
-  getPropertyGindex(): null {
-    return null;
-  }
 
   // Post process tree to convert regular BranchNode to BranchNodeStruct
   // TODO: Optimize conversions


### PR DESCRIPTION
**Motivation**

While doing gindex calculations on a BeaconState, noticed that there is a 'bug' in getting gindexes for validator entries.

**Description**

Remove the overridden getPropertyGindex that prevents calculation of gindices on a ContainerNodeStructType