### PR TITLE
feat: implement sliceTo() for ListBasicTreeViewDU

### DIFF
--- a/packages/ssz/src/viewDU/listBasic.ts
+++ b/packages/ssz/src/viewDU/listBasic.ts
@@ -42,16 +42,10 @@ export class ListBasicTreeViewDU<ElementType extends BasicType<unknown>> extends
    * Returns a new ListBasicTreeViewDU instance with the values from 0 to `index`.
    * To achieve it, rebinds the underlying tree zero-ing all nodes right of `chunkIindex`.
    * Also set all value right of `index` in the same chunk to 0.
-   *
-   * Note: Using index = -1, returns an empty list of length 0.
    */
   sliceTo(index: number): this {
-    if (index < -1) {
-      throw new Error("Does not support sliceTo() with index less than -1");
-    }
-
-    if (index === -1) {
-      return this.type.defaultViewDU() as this;
+    if (index < 0) {
+      throw new Error(`Does not support sliceTo() with negative index ${index}`);
     }
 
     // Commit before getting rootNode to ensure all pending data is in the rootNode

--- a/packages/ssz/src/viewDU/listBasic.ts
+++ b/packages/ssz/src/viewDU/listBasic.ts
@@ -1,4 +1,11 @@
-import {LeafNode, Node, zeroNode} from "@chainsafe/persistent-merkle-tree";
+import {
+  LeafNode,
+  Node,
+  getNodeAtDepth,
+  setNodesAtDepth,
+  treeZeroAfterIndex,
+  zeroNode,
+} from "@chainsafe/persistent-merkle-tree";
 import {ValueOf} from "../type/abstract";
 import {BasicType} from "../type/basic";
 import {ListBasicType} from "../view/listBasic";
@@ -29,5 +36,35 @@ export class ListBasicTreeViewDU<ElementType extends BasicType<unknown>> extends
     }
 
     this.set(index, value);
+  }
+
+  sliceTo(index: number): this {
+    // Commit before getting rootNode to ensure all pending data is in the rootNode
+    this.commit();
+
+    // All nodes beyond length are already zero
+    // Array of length 2: [X,X,0,0], for index >= 1 no action needed
+    if (index >= this._length - 1) {
+      return this;
+    }
+
+    const rootNode = this._rootNode;
+    const chunkIndex = Math.floor(index / this.type.itemsPerChunk);
+    const nodePrev = (this.nodes[chunkIndex] ?? getNodeAtDepth(rootNode, this.type.depth, chunkIndex)) as LeafNode;
+
+    const nodeChanged = nodePrev.clone();
+    // set remaining items in the same chunk to 0
+    for (let i = index + 1; i < (chunkIndex + 1) * this.type.itemsPerChunk; i++) {
+      this.type.elementType.tree_setToPackedNode(nodeChanged, i, 0);
+    }
+    const chunksNode = this.type.tree_getChunksNode(this._rootNode);
+    let newChunksNode = setNodesAtDepth(chunksNode, this.type.chunkDepth, [chunkIndex], [nodeChanged]);
+    // also do the treeZeroAfterIndex operation on the chunks tree
+    newChunksNode = treeZeroAfterIndex(newChunksNode, this.type.chunkDepth, chunkIndex);
+
+    // Must set new length and commit to tree to restore the same tree at that index
+    const newLength = index + 1;
+    const newRootNode = this.type.tree_setChunksNode(rootNode, newChunksNode, newLength);
+    return this.type.getViewDU(newRootNode) as this;
   }
 }

--- a/packages/ssz/src/viewDU/listBasic.ts
+++ b/packages/ssz/src/viewDU/listBasic.ts
@@ -38,12 +38,26 @@ export class ListBasicTreeViewDU<ElementType extends BasicType<unknown>> extends
     this.set(index, value);
   }
 
+  /**
+   * Returns a new ListBasicTreeViewDU instance with the values from 0 to `index`.
+   * To achieve it, rebinds the underlying tree zero-ing all nodes right of `chunkIindex`.
+   * Also set all value right of `index` in the same chunk to 0.
+   *
+   * Note: Using index = -1, returns an empty list of length 0.
+   */
   sliceTo(index: number): this {
+    if (index < -1) {
+      throw new Error("Does not support sliceTo() with index less than -1");
+    }
+
+    if (index === -1) {
+      return this.type.defaultViewDU() as this;
+    }
+
     // Commit before getting rootNode to ensure all pending data is in the rootNode
     this.commit();
 
     // All nodes beyond length are already zero
-    // Array of length 2: [X,X,0,0], for index >= 1 no action needed
     if (index >= this._length - 1) {
       return this;
     }

--- a/packages/ssz/test/unit/byType/listBasic/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listBasic/tree.test.ts
@@ -219,13 +219,17 @@ describe("ListBasicType.sliceTo", () => {
     const listRoots: string[] = [];
     const listSerialized: string[] = [];
 
-    for (let i = 0; i < 16; i++) {
-      listView.push(i);
+    for (let i = -1; i < 16; i++) {
+      if (i >= 0) {
+        listView.push(i);
+      }
+      // Javascript arrays can handle negative indexes (ok for tests)
       listSerialized[i] = toHexString(listView.serialize());
       listRoots[i] = toHexString(listView.hashTreeRoot());
     }
 
-    for (let i = 0; i < 16; i++) {
+    // Start at -1 to test the empty case.
+    for (let i = -1; i < 16; i++) {
       const listSlice = listView.sliceTo(i);
       expect(listSlice.length).to.equal(i + 1, `Wrong length at .sliceTo(${i})`);
       expect(toHexString(listSlice.serialize())).equals(listSerialized[i], `Wrong serialize at .sliceTo(${i})`);

--- a/packages/ssz/test/unit/byType/listBasic/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listBasic/tree.test.ts
@@ -219,17 +219,13 @@ describe("ListBasicType.sliceTo", () => {
     const listRoots: string[] = [];
     const listSerialized: string[] = [];
 
-    for (let i = -1; i < 16; i++) {
-      if (i >= 0) {
-        listView.push(i);
-      }
-      // Javascript arrays can handle negative indexes (ok for tests)
+    for (let i = 0; i < 16; i++) {
+      listView.push(i);
       listSerialized[i] = toHexString(listView.serialize());
       listRoots[i] = toHexString(listView.hashTreeRoot());
     }
 
-    // Start at -1 to test the empty case.
-    for (let i = -1; i < 16; i++) {
+    for (let i = 0; i < 16; i++) {
       const listSlice = listView.sliceTo(i);
       expect(listSlice.length).to.equal(i + 1, `Wrong length at .sliceTo(${i})`);
       expect(toHexString(listSlice.serialize())).equals(listSerialized[i], `Wrong serialize at .sliceTo(${i})`);

--- a/packages/ssz/test/unit/byType/listBasic/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listBasic/tree.test.ts
@@ -210,3 +210,26 @@ describe("ListBasicType drop caches", () => {
     expect(bytesAfter).to.equal(bytesBefore, "view retained changes");
   });
 });
+
+describe("ListBasicType.sliceTo", () => {
+  // same to BeaconState InactivityScores
+  it("Slice List at multiple length", () => {
+    const listType = new ListBasicType(new UintNumberType(8), 100);
+    const listView = listType.defaultViewDU();
+    const listRoots: string[] = [];
+    const listSerialized: string[] = [];
+
+    for (let i = 0; i < 16; i++) {
+      listView.push(i);
+      listSerialized[i] = toHexString(listView.serialize());
+      listRoots[i] = toHexString(listView.hashTreeRoot());
+    }
+
+    for (let i = 0; i < 16; i++) {
+      const listSlice = listView.sliceTo(i);
+      expect(listSlice.length).to.equal(i + 1, `Wrong length at .sliceTo(${i})`);
+      expect(toHexString(listSlice.serialize())).equals(listSerialized[i], `Wrong serialize at .sliceTo(${i})`);
+      expect(toHexString(listSlice.hashTreeRoot())).equals(listRoots[i], `Wrong root at .sliceTo(${i})`);
+    }
+  });
+});


### PR DESCRIPTION
**Motivation**

- For lodestar, we may want to load beacon state ssz bytes to an existing `ViewDU` object, this is needed to optimize the process in case a field is rarely changed

**Description**

- Add `sliceTo` method to ListBasicTreeViewDU, similar to https://github.com/ChainSafe/ssz/blob/d18ea08177544c82b9a1e7dd09127b4d63a2b2d8/packages/ssz/src/viewDU/listComposite.ts#L45
