### PR TITLE
fix: relax BitArray#intersectValues types

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,11 +21,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - run: corepack enable
       - uses: actions/setup-node@v3
         with:
           cache: yarn
           node-version: 18
-      - run: corepack enable
       - run: yarn --immutable && yarn build
 
       - name: Run benchmarks

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,11 @@ jobs:
         node: [16, 18]
     steps:
       - uses: actions/checkout@v3
+      - run: corepack enable
       - uses: actions/setup-node@v3
         with:
           node-version: ${{matrix.node}}
           cache: yarn
-      - run: corepack enable
       - name: Bootstrap
         run: yarn --immutable
       - name: Build

--- a/packages/ssz/src/value/bitArray.ts
+++ b/packages/ssz/src/value/bitArray.ts
@@ -114,7 +114,7 @@ export class BitArray {
   /**
    * Returns an array with the indexes which have a bit set to true
    */
-  intersectValues<T>(values: T[]): T[] {
+  intersectValues<T>(values: ArrayLike<T>): T[] {
     const yes: T[] = [];
 
     if (values.length !== this.bitLen) {


### PR DESCRIPTION
**Motivation**

- Experimentation in lodestar

**Description**

- `intersectValues` was needlessly strict, requiring an `Array` rather than something merely `ArrayLike`, like a `TypedArray`.