### PR TITLE
fix: fix ci

### DIFF
--- a/.github/workflows/cd-manual.yml
+++ b/.github/workflows/cd-manual.yml
@@ -10,11 +10,11 @@ jobs:
         deployments: write
       steps:
           - uses: actions/checkout@v3
+          - run: corepack enable
           - uses: actions/setup-node@v3
             with:
               cache: yarn
               node-version: '16'
-          - run: corepack enable
           - name: Bootstrap
             run: yarn --immutable
           - name: Build

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -29,6 +29,8 @@ jobs:
       - uses: actions/checkout@v3
         if: ${{ steps.release.outputs.releases_created }}
         
+      - run: corepack enable
+      
       - uses: actions/setup-node@v3
         with:
           cache: 'yarn'
@@ -36,8 +38,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.releases_created }}
 
-      - run: corepack enable
-      
       - run: yarn install --immutable
         if: ${{ steps.release.outputs.releases_created }}
 


### PR DESCRIPTION
**Motivation**

0.14.1 failed to publish https://github.com/ChainSafe/ssz/actions/runs/7852803588/job/21431695079#step:4:23

**Description**

Move `corepack enable` step before `setup-node` step