### PR TITLE
fix: relax other instances of intersectValues

### DIFF
--- a/packages/ssz/src/view/bitArray.ts
+++ b/packages/ssz/src/view/bitArray.ts
@@ -50,7 +50,7 @@ export class BitArrayTreeView extends TreeView<CompositeType<BitArray, unknown, 
   }
 
   /** @see BitArray.intersectValues */
-  intersectValues<T>(values: T[]): T[] {
+  intersectValues<T>(values: ArrayLike<T>): T[] {
     return this.bitArray.intersectValues(values);
   }
 

--- a/packages/ssz/src/viewDU/bitArray.ts
+++ b/packages/ssz/src/viewDU/bitArray.ts
@@ -56,7 +56,7 @@ export class BitArrayTreeViewDU extends TreeViewDU<CompositeType<BitArray, unkno
   }
 
   /** @see BitArray.intersectValues */
-  intersectValues<T>(values: T[]): T[] {
+  intersectValues<T>(values: ArrayLike<T>): T[] {
     return this.bitArray.intersectValues(values);
   }
 


### PR DESCRIPTION
**Motivation**

- follow up from #339 

**Description**

- Relaxes other instances of `intersectValues`