### PR TITLE
feat: add capability to cache merkle roots for lists

### DIFF
--- a/packages/ssz/src/index.ts
+++ b/packages/ssz/src/index.ts
@@ -33,4 +33,4 @@ export {BitArray, getUint8ByteToBitBooleanArray} from "./value/bitArray";
 // Utils
 export {fromHexString, toHexString, byteArrayEquals} from "./util/byteArray";
 
-export {hash64} from "./util/merkleize";
+export {hash64, symbolCachedPermanentRoot} from "./util/merkleize";

--- a/packages/ssz/src/type/array.ts
+++ b/packages/ssz/src/type/array.ts
@@ -23,8 +23,8 @@ export abstract class ArrayType<ElementType extends Type<unknown>, TV, TVDU> ext
   abstract readonly itemsPerChunk: number;
   protected abstract readonly defaultLen: number;
 
-  constructor(readonly elementType: ElementType) {
-    super();
+  constructor(readonly elementType: ElementType, cachePermanentRootStruct?: boolean) {
+    super(cachePermanentRootStruct);
   }
 
   defaultValue(): ValueOf<ElementType>[] {

--- a/packages/ssz/src/type/composite.ts
+++ b/packages/ssz/src/type/composite.ts
@@ -9,7 +9,7 @@ import {
   Tree,
 } from "@chainsafe/persistent-merkle-tree";
 import {byteArrayEquals} from "../util/byteArray";
-import {merkleize} from "../util/merkleize";
+import {merkleize, symbolCachedPermanentRoot, ValueWithCachedPermanentRoot} from "../util/merkleize";
 import {treePostProcessFromProofNode} from "../util/proof/treePostProcessFromProofNode";
 import {Type, ByteViews, JsonPath, JsonPathProp} from "./abstract";
 export {ByteViews};
@@ -36,14 +36,6 @@ export type CompositeViewDU<T extends CompositeType<unknown, unknown, unknown>> 
 
 /** Any CompositeType without any generic arguments */
 export type CompositeTypeAny = CompositeType<unknown, unknown, unknown>;
-
-/** Dedicated property to cache hashTreeRoot of immutable CompositeType values */
-const symbolCachedPermanentRoot = Symbol("ssz_cached_permanent_root");
-
-/** Helper type to cast CompositeType values that may have @see symbolCachedPermanentRoot */
-type ValueWithCachedPermanentRoot = {
-  [symbolCachedPermanentRoot]?: Uint8Array;
-};
 
 /* eslint-disable @typescript-eslint/member-ordering  */
 
@@ -73,7 +65,7 @@ export abstract class CompositeType<V, TV, TVDU> extends Type<V> {
      *
      * WARNING: Must only be used for immutable values. The cached root is never discarded
      */
-    private readonly cachePermanentRootStruct?: boolean
+    protected readonly cachePermanentRootStruct?: boolean
   ) {
     super();
   }

--- a/packages/ssz/src/type/listBasic.ts
+++ b/packages/ssz/src/type/listBasic.ts
@@ -10,7 +10,13 @@ import {
   addLengthNode,
   setChunksNode,
 } from "./arrayBasic";
-import {mixInLength, maxChunksToDepth, splitIntoRootChunks} from "../util/merkleize";
+import {
+  mixInLength,
+  maxChunksToDepth,
+  splitIntoRootChunks,
+  symbolCachedPermanentRoot,
+  ValueWithCachedPermanentRoot,
+} from "../util/merkleize";
 import {Require} from "../util/types";
 import {namedClass} from "../util/named";
 import {ArrayBasicType} from "../view/arrayBasic";
@@ -22,6 +28,7 @@ import {ArrayType} from "./array";
 
 export interface ListBasicOpts {
   typeName?: string;
+  cachePermanentRootStruct?: boolean;
 }
 
 /**
@@ -48,7 +55,7 @@ export class ListBasicType<ElementType extends BasicType<unknown>>
   protected readonly defaultLen = 0;
 
   constructor(readonly elementType: ElementType, readonly limit: number, opts?: ListBasicOpts) {
-    super(elementType);
+    super(elementType, opts?.cachePermanentRootStruct);
 
     if (!elementType.isBasic) throw Error("elementType must be basic");
     if (limit === 0) throw Error("List limit must be > 0");
@@ -144,7 +151,21 @@ export class ListBasicType<ElementType extends BasicType<unknown>>
   // Merkleization
 
   hashTreeRoot(value: ValueOf<ElementType>[]): Uint8Array {
-    return mixInLength(super.hashTreeRoot(value), value.length);
+    // Return cached mutable root if any
+    if (this.cachePermanentRootStruct) {
+      const cachedRoot = (value as ValueWithCachedPermanentRoot)[symbolCachedPermanentRoot];
+      if (cachedRoot) {
+        return cachedRoot;
+      }
+    }
+
+    const root = mixInLength(super.hashTreeRoot(value), value.length);
+
+    if (this.cachePermanentRootStruct) {
+      (value as ValueWithCachedPermanentRoot)[symbolCachedPermanentRoot] = root;
+    }
+
+    return root;
   }
 
   protected getRoots(value: ValueOf<ElementType>[]): Uint8Array[] {

--- a/packages/ssz/src/util/merkleize.ts
+++ b/packages/ssz/src/util/merkleize.ts
@@ -1,6 +1,14 @@
 import {hasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/index";
 import {zeroHash} from "./zeros";
 
+/** Dedicated property to cache hashTreeRoot of immutable CompositeType values */
+export const symbolCachedPermanentRoot = Symbol("ssz_cached_permanent_root");
+
+/** Helper type to cast CompositeType values that may have @see symbolCachedPermanentRoot */
+export type ValueWithCachedPermanentRoot = {
+  [symbolCachedPermanentRoot]?: Uint8Array;
+};
+
 export function hash64(bytes32A: Uint8Array, bytes32B: Uint8Array): Uint8Array {
   return hasher.digest64(bytes32A, bytes32B);
 }


### PR DESCRIPTION
need to cache merkle root of big lists (Transactions), as well as to allow setting the cached root (so needing cached symbol import) so that if we have for e.g. transactionsRoot, that can be set on transactions helping avoid merklelization of it in big blocks