### PR TITLE
feat: improve ViewDU.serialize()

### DIFF
--- a/packages/ssz/src/index.ts
+++ b/packages/ssz/src/index.ts
@@ -21,10 +21,11 @@ export {BitArrayType} from "./type/bitArray";
 export {ByteArrayType} from "./type/byteArray";
 
 // Base type clases
-export {Type, ValueOf, JsonPath} from "./type/abstract";
+export {Type, ValueOf, JsonPath, ByteViews} from "./type/abstract";
 export {BasicType, isBasicType} from "./type/basic";
 export {CompositeType, CompositeTypeAny, CompositeView, CompositeViewDU, isCompositeType} from "./type/composite";
 export {TreeView} from "./view/abstract";
+export {ValueOfFields} from "./view/container";
 export {TreeViewDU} from "./viewDU/abstract";
 
 // Values

--- a/packages/ssz/src/type/arrayBasic.ts
+++ b/packages/ssz/src/type/arrayBasic.ts
@@ -104,12 +104,13 @@ export function tree_serializeToBytesArrayBasic<ElementType extends BasicType<un
   depth: number,
   output: ByteViews,
   offset: number,
-  node: Node
+  node: Node,
+  cachedNodes: Node[] | null = null
 ): number {
   const size = elementType.byteLength * length;
   const chunkCount = Math.ceil(size / 32);
 
-  const nodes = getNodesAtDepth(node, depth, 0, chunkCount);
+  const nodes = cachedNodes ?? getNodesAtDepth(node, depth, 0, chunkCount);
   packedNodeRootsToBytes(output.dataView, offset, size, nodes);
 
   return offset + size;

--- a/packages/ssz/src/type/arrayComposite.ts
+++ b/packages/ssz/src/type/arrayComposite.ts
@@ -151,9 +151,10 @@ export function tree_serializeToBytesArrayComposite<ElementType extends Composit
   depth: number,
   node: Node,
   output: ByteViews,
-  offset: number
+  offset: number,
+  cachedNodes: Node[] | null = null
 ): number {
-  const nodes = getNodesAtDepth(node, depth, 0, length);
+  const nodes = cachedNodes ?? getNodesAtDepth(node, depth, 0, length);
 
   // Variable Length
   // Indices contain offsets, which are indices deeper in the byte array

--- a/packages/ssz/src/type/container.ts
+++ b/packages/ssz/src/type/container.ts
@@ -65,14 +65,14 @@ export class ContainerType<Fields extends Record<string, Type<unknown>>> extends
 
   // Precomputed data for faster serdes
   readonly fieldsEntries: FieldEntry<Fields>[];
+  /** End of fixed section of serialized Container */
+  readonly fixedEnd: number;
   protected readonly fieldsGindex: Record<keyof Fields, Gindex>;
   protected readonly jsonKeyToFieldName: Record<string, keyof Fields>;
   protected readonly isFixedLen: boolean[];
   protected readonly fieldRangesFixedLen: BytesRange[];
   /** Offsets position relative to start of serialized Container. Length may not equal field count. */
   protected readonly variableOffsetsPosition: number[];
-  /** End of fixed section of serialized Container */
-  protected readonly fixedEnd: number;
 
   /** Cached TreeView constuctor with custom prototype for this Type's properties */
   protected readonly TreeView: ContainerTreeViewTypeConstructor<Fields>;

--- a/packages/ssz/src/view/container.ts
+++ b/packages/ssz/src/view/container.ts
@@ -19,6 +19,7 @@ export type ContainerTypeGeneric<Fields extends Record<string, Type<unknown>>> =
 > & {
   readonly fields: Fields;
   readonly fieldsEntries: FieldEntry<Fields>[];
+  readonly fixedEnd: number;
 };
 
 export type ValueOfFields<Fields extends Record<string, Type<unknown>>> = {[K in keyof Fields]: ValueOf<Fields[K]>};

--- a/packages/ssz/src/viewDU/abstract.ts
+++ b/packages/ssz/src/viewDU/abstract.ts
@@ -1,4 +1,4 @@
-import {CompositeType} from "../type/composite";
+import {ByteViews, CompositeType} from "../type/composite";
 import {TreeView} from "../view/abstract";
 
 /* eslint-disable @typescript-eslint/member-ordering  */
@@ -33,6 +33,13 @@ export abstract class TreeViewDU<T extends CompositeType<unknown, unknown, unkno
    */
   protected abstract clearCache(): void;
 
+  /*
+   * By default use type to serialize ViewDU.
+   */
+  serializeToBytes(output: ByteViews, offset: number): number {
+    return this.type.tree_serializeToBytes(output, offset, this.node);
+  }
+
   /**
    * Merkleize view and compute its hashTreeRoot.
    * Commits any pending changes before computing the root.
@@ -51,7 +58,10 @@ export abstract class TreeViewDU<T extends CompositeType<unknown, unknown, unkno
    */
   serialize(): Uint8Array {
     this.commit();
-    return super.serialize();
+    const output = new Uint8Array(this.type.tree_serializedSize(this.node));
+    const dataView = new DataView(output.buffer, output.byteOffset, output.byteLength);
+    this.serializeToBytes({uint8Array: output, dataView}, 0);
+    return output;
   }
 
   /**

--- a/packages/ssz/src/viewDU/arrayComposite.ts
+++ b/packages/ssz/src/viewDU/arrayComposite.ts
@@ -216,7 +216,7 @@ export class ArrayCompositeTreeViewDU<
     }
   }
 
-  private populateAllNodes(): void {
+  protected populateAllNodes(): void {
     // If there's uncommited changes it may break.
     // this.length can be increased but this._rootNode doesn't have that item
     if (this.viewsChanged.size > 0) {

--- a/packages/ssz/src/viewDU/listBasic.ts
+++ b/packages/ssz/src/viewDU/listBasic.ts
@@ -6,10 +6,11 @@ import {
   treeZeroAfterIndex,
   zeroNode,
 } from "@chainsafe/persistent-merkle-tree";
-import {ValueOf} from "../type/abstract";
+import {ByteViews, ValueOf} from "../type/abstract";
 import {BasicType} from "../type/basic";
 import {ListBasicType} from "../view/listBasic";
 import {ArrayBasicTreeViewDU, ArrayBasicTreeViewDUCache} from "./arrayBasic";
+import {tree_serializeToBytesArrayBasic} from "../type/arrayBasic";
 
 export class ListBasicTreeViewDU<ElementType extends BasicType<unknown>> extends ArrayBasicTreeViewDU<ElementType> {
   constructor(readonly type: ListBasicType<ElementType>, protected _rootNode: Node, cache?: ArrayBasicTreeViewDUCache) {
@@ -77,5 +78,23 @@ export class ListBasicTreeViewDU<ElementType extends BasicType<unknown>> extends
     const newLength = index + 1;
     const newRootNode = this.type.tree_setChunksNode(rootNode, newChunksNode, newLength);
     return this.type.getViewDU(newRootNode) as this;
+  }
+
+  /**
+   * Same method to `type/listBasic.ts` leveraging cached nodes.
+   */
+  serializeToBytes(output: ByteViews, offset: number): number {
+    this.commit();
+    const {nodes, nodesPopulated} = this.cache;
+    const chunksNode = this.type.tree_getChunksNode(this._rootNode);
+    return tree_serializeToBytesArrayBasic(
+      this.type.elementType,
+      this._length,
+      this.type.chunkDepth,
+      output,
+      offset,
+      chunksNode,
+      nodesPopulated ? nodes : null
+    );
   }
 }

--- a/packages/ssz/test/spec/runValidTest.ts
+++ b/packages/ssz/test/spec/runValidTest.ts
@@ -5,6 +5,7 @@ import {fromHexString, toHexString} from "../../src/util/byteArray";
 import {CompositeType, isCompositeType} from "../../src/type/composite";
 import {isBasicType} from "../../src/type/basic";
 import {wrapErr} from "../utils/error";
+import {TreeViewDU} from "../../src";
 
 type ValidTestCaseData = {
   root: string;
@@ -169,6 +170,9 @@ export function runValidSszTest(type: Type<unknown>, testData: ValidTestCaseData
     const bytes = Buffer.from(copy(testDataSerialized));
     type.deserializeToViewDU(bytes);
     expect(toHexString(bytes)).to.equal(testDataSerializedHex, "type.deserializeToViewDU() mutated input");
+    if (viewDU instanceof TreeViewDU) {
+      assertBytes(viewDU.serialize(), "viewDU.serialize");
+    }
   }
 
   if (isBasicType(type)) {


### PR DESCRIPTION
**Motivation**

- ViewDU has cached nodes, however when we serialize we go through the respective type and it loads all nodes again, see https://github.com/ChainSafe/ssz/blob/6220d320b004ea80bd30925487ac0f3299295528/packages/ssz/src/type/container.ts#L233
- This is to improve `state.serialize()` in lodestar: right after we get through state transition, we always have cached nodes inside

**Description**
Define `serialize()` in ViewDU to go through the new `serializeToBytes()` method instead of its respective type class

- Add `serializeToBytes()` method to TreeViewDU, by default it'll delegate to respective type class
- The container ViewDU `serializeToBytes()` will recursively call respective `serializeToBytes` of internal ViewDU properties
- For `listComposite` and `listBasic` ViewDUs, they'll use use cached nodes if possible
- Also export some util types so that lodestar can consume

**Test**
New `serialize()` implementation in ViewDU is scanned through spec tests