### PR TITLE
feat: new type for list of uint64

### DIFF
--- a/packages/ssz/src/type/listUintNum64.ts
+++ b/packages/ssz/src/type/listUintNum64.ts
@@ -1,0 +1,49 @@
+import {LeafNode, Node, packedUintNum64sToLeafNodes, subtreeFillToContents} from "@chainsafe/persistent-merkle-tree";
+
+import {ListBasicTreeViewDU} from "../viewDU/listBasic";
+import {ListBasicOpts, ListBasicType} from "./listBasic";
+import {UintNumberType} from "./uint";
+import {addLengthNode} from "./arrayBasic";
+
+/**
+ * Specific implementation of ListBasicType for UintNumberType with some optimizations.
+ */
+export class ListUintNum64Type extends ListBasicType<UintNumberType> {
+  constructor(limit: number, opts?: ListBasicOpts) {
+    super(new UintNumberType(8), limit, opts);
+  }
+
+  /**
+   * Return a ListBasicTreeViewDU with nodes populated
+   */
+  toViewDU(value: number[]): ListBasicTreeViewDU<UintNumberType> {
+    // no need to serialize and deserialize like in the abstract class
+    const {treeNode, leafNodes} = this.packedUintNum64sToNode(value);
+    // cache leaf nodes in the ViewDU
+    return this.getViewDU(treeNode, {
+      nodes: leafNodes,
+      length: value.length,
+      nodesPopulated: true,
+    });
+  }
+
+  /**
+   * No need to serialize and deserialize like in the abstract class
+   */
+  value_toTree(value: number[]): Node {
+    const {treeNode} = this.packedUintNum64sToNode(value);
+    return treeNode;
+  }
+
+  private packedUintNum64sToNode(value: number[]): {treeNode: Node; leafNodes: LeafNode[]} {
+    if (value.length > this.limit) {
+      throw new Error(`Exceeds limit: ${value.length} > ${this.limit}`);
+    }
+
+    const leafNodes = packedUintNum64sToLeafNodes(value);
+    // subtreeFillToContents mutates the leafNodes array
+    const rootNode = subtreeFillToContents([...leafNodes], this.chunkDepth);
+    const treeNode = addLengthNode(rootNode, value.length);
+    return {treeNode, leafNodes};
+  }
+}

--- a/packages/ssz/test/lodestarTypes/phase0/sszTypes.ts
+++ b/packages/ssz/test/lodestarTypes/phase0/sszTypes.ts
@@ -8,6 +8,7 @@ import {
   VectorBasicType,
   VectorCompositeType,
 } from "../../../src";
+import {ListUintNum64Type} from "../../../src/type/listUintNum64";
 import {
   preset,
   MAX_REQUEST_BLOCKS,
@@ -250,7 +251,7 @@ export const Validator = ValidatorNodeStruct;
 
 // Export as stand-alone for direct tree optimizations
 export const Validators = new ListCompositeType(ValidatorNodeStruct, VALIDATOR_REGISTRY_LIMIT);
-export const Balances = new ListBasicType(UintNum64, VALIDATOR_REGISTRY_LIMIT);
+export const Balances = new ListUintNum64Type(VALIDATOR_REGISTRY_LIMIT);
 export const RandaoMixes = new VectorCompositeType(Bytes32, EPOCHS_PER_HISTORICAL_VECTOR);
 export const Slashings = new VectorBasicType(Gwei, EPOCHS_PER_SLASHINGS_VECTOR);
 export const JustificationBits = new BitVectorType(JUSTIFICATION_BITS_LENGTH);


### PR DESCRIPTION
**Motivation**

- Improve performance of `ListBasicType<UintNumberType<8>>.toViewDU()` (`balances` type in lodestar), the performance issue was noted here https://github.com/ChainSafe/ssz/blob/14c4457026a9fbea5bfe5c66580f7c8a8bee790a/packages/ssz/src/type/abstract.ts#L96
- Cache the created leaf nodes when calling that function and populate them to resulting ViewDU object, see https://github.com/ChainSafe/lodestar/issues/6520

**Description**

- New `ListUintNum64Type` class and overwrite `toViewDU()` function:
  - create nodes directly from `number[]` instead of having to `serialize()/deserialize()` implementation in the parent abstract class
  - use the created LeftNodes to populate the final ViewDU object


part of https://github.com/ChainSafe/lodestar/issues/6520
