### PR TITLE
fix: export ListUintNum64Type

### DIFF
--- a/packages/persistent-merkle-tree/README.md
+++ b/packages/persistent-merkle-tree/README.md
@@ -21,7 +21,8 @@ const branch = new BranchNode(leaf, otherLeaf);
 
 // The `root` property returns the merkle root of a Node
 
-const r: Uint8Array = branch.root; // == hash(leaf.root, otherLeaf.root));
+// this is equal to `hash(leaf.root, otherLeaf.root));`
+const r: Uint8Array = branch.root;
 
 // The `isLeaf` method returns true if the Node is a LeafNode
 

--- a/packages/ssz/src/index.ts
+++ b/packages/ssz/src/index.ts
@@ -14,6 +14,7 @@ export {UnionType} from "./type/union";
 export {OptionalType} from "./type/optional";
 export {VectorBasicType} from "./type/vectorBasic";
 export {VectorCompositeType} from "./type/vectorComposite";
+export {ListUintNum64Type} from "./type/listUintNum64";
 
 // Base types
 export {ArrayType} from "./type/array";


### PR DESCRIPTION
**Motivation**

- The release of ssz v0.15.0 and `persistent-merkle-tree` v0.7.0 were not successful with this CI so need to release new version  https://github.com/ChainSafe/ssz/actions/runs/8258360670/job/22590459475

**Description**
- Fix ssz: export new `ListUintNum64Type` type from #352
- Modify persistent-merkle-tree readme in order to trigger new release