### PR TITLE
feat: Add deneb to simpleserialize.com

### DIFF
--- a/packages/simpleserialize.com/package.json
+++ b/packages/simpleserialize.com/package.json
@@ -17,7 +17,7 @@
     "@babel/runtime": "^7.14.6",
     "@babel/types": "^7.14.5",
     "@chainsafe/ssz": "workspace:^",
-    "@lodestar/types": "^1.7.2",
+    "@lodestar/types": "^1.14.0",
     "bn.js": "^5.2.0",
     "bulma": "^0.9.3",
     "core-js": "^3.15.2",

--- a/packages/simpleserialize.com/src/components/Header.tsx
+++ b/packages/simpleserialize.com/src/components/Header.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 
-const SPEC_VERSION = "1.3.0";
+const SPEC_VERSION = "1.4.0";
 
 export default function Header(): JSX.Element {
   return (

--- a/packages/simpleserialize.com/src/components/Input.tsx
+++ b/packages/simpleserialize.com/src/components/Input.tsx
@@ -33,7 +33,7 @@ type State = {
   userHasEditedInput: boolean;
 };
 
-const DEFAULT_FORK = "capella";
+const DEFAULT_FORK = "deneb";
 
 class Input extends React.Component<Props, State> {
   worker: Worker;

--- a/packages/simpleserialize.com/src/util/types.ts
+++ b/packages/simpleserialize.com/src/util/types.ts
@@ -28,6 +28,7 @@ phase0 = patchSszTypes(phase0);
 altair = patchSszTypes(altair);
 bellatrix = patchSszTypes(bellatrix);
 capella = patchSszTypes(capella);
+deneb = patchSszTypes(deneb);
 primitive = patchSszTypes(primitive);
 
 export const forks = {
@@ -35,6 +36,7 @@ export const forks = {
   altair: {...phase0, ...altair, ...primitive},
   bellatrix: {...phase0, ...altair, ...bellatrix, ...primitive},
   capella: {...phase0, ...altair, ...bellatrix, ...capella, ...primitive},
+  deneb: {...phase0, ...altair, ...bellatrix, ...capella, ...deneb, ...primitive},
 } as Record<string, Record<string, Type<unknown>>>;
 
 export type ForkName = keyof typeof forks;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1826,20 +1826,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lodestar/params@npm:^1.7.2":
-  version: 1.7.2
-  resolution: "@lodestar/params@npm:1.7.2"
-  checksum: 4770e4a5a48c95a7d9314e2838dc612403c04af6fe229d350fc7effe3da1176dd23bf4a50de336264d04d03ef8a7ddd76d032201aebad4e0625d39bf2202c64c
+"@lodestar/params@npm:^1.17.0":
+  version: 1.17.0
+  resolution: "@lodestar/params@npm:1.17.0"
+  checksum: dddf3359d0fdafa5a021528fdd79338541a970044250ab21bc36db784e47a2011e09481b9e033294621d324bcda27a8b20aba41b603a93f7a0903c0e8d459e23
   languageName: node
   linkType: hard
 
-"@lodestar/types@npm:^1.7.2":
-  version: 1.7.2
-  resolution: "@lodestar/types@npm:1.7.2"
+"@lodestar/types@npm:^1.14.0":
+  version: 1.17.0
+  resolution: "@lodestar/types@npm:1.17.0"
   dependencies:
-    "@chainsafe/ssz": ^0.10.1
-    "@lodestar/params": ^1.7.2
-  checksum: 53b4748d82728677f9afd8e4f08d22de230d180f2e1f7aec64ad28769971838a5876f251f149f4a6719d334fa1ad8362cfb2adbd7bc68ce8690106b5c6f93341
+    "@chainsafe/ssz": ^0.14.3
+    "@lodestar/params": ^1.17.0
+    ethereum-cryptography: ^2.0.0
+  checksum: ff0a2be0fcf8ac664849137a2eac66df2db6eb0f99c70fd1c1f1cb4470ff4abec91afd3d0121ab64af97e14584a251168461d8d689818fce0d246774d1fcfd71
   languageName: node
   linkType: hard
 
@@ -1859,6 +1860,22 @@ __metadata:
     readdirp: ^2.2.1
     upath: ^1.1.1
   checksum: 843ace6eb89aca519706c1c6ad2e31f84c744bfc0ef8ba8ad90eccbe7c976b07f8be00f38e0cc74093f70b20ad5f7e63ea21074ba9fd8c08dce0b874f682cfe0
+  languageName: node
+  linkType: hard
+
+"@noble/curves@npm:1.3.0, @noble/curves@npm:~1.3.0":
+  version: 1.3.0
+  resolution: "@noble/curves@npm:1.3.0"
+  dependencies:
+    "@noble/hashes": 1.3.3
+  checksum: 704bf8fda8e1365a9bb9e9945bd06645ef4ce85aa2fac5594abe09f19889197518152319481b89a271e0ee011787bd2ee87202441500bca7ca587a2c3ac10b01
+  languageName: node
+  linkType: hard
+
+"@noble/hashes@npm:1.3.3, @noble/hashes@npm:~1.3.2":
+  version: 1.3.3
+  resolution: "@noble/hashes@npm:1.3.3"
+  checksum: 23c020b33da4172c988e44100e33cd9f8f6250b68b43c467d3551f82070ebd9716e0d9d2347427aa3774c85934a35fa9ee6f026fca2117e3fa12db7bedae7668
   languageName: node
   linkType: hard
 
@@ -2030,6 +2047,34 @@ __metadata:
   version: 1.0.3
   resolution: "@opentelemetry/api@npm:1.0.3"
   checksum: 3f818dceeb6b7a4627af7175b4bada728ec97b99653660968a4bc34f7cb7fe78a1f4990e23a71badce3e4115ad585ebb98bab32601f02a76aaa02fbf271de9ca
+  languageName: node
+  linkType: hard
+
+"@scure/base@npm:~1.1.4":
+  version: 1.1.6
+  resolution: "@scure/base@npm:1.1.6"
+  checksum: 237a46a1f45391fc57719154f14295db936a0b1562ea3e182dd42d7aca082dbb7062a28d6c49af16a7e478b12dae8a0fe678d921ea5056bcc30238d29eb05c55
+  languageName: node
+  linkType: hard
+
+"@scure/bip32@npm:1.3.3":
+  version: 1.3.3
+  resolution: "@scure/bip32@npm:1.3.3"
+  dependencies:
+    "@noble/curves": ~1.3.0
+    "@noble/hashes": ~1.3.2
+    "@scure/base": ~1.1.4
+  checksum: 48fa04ebf0e3b56e3d086f029ae207ea753d8d8a1b3564f3c80fafea63dc3ee4edbd21e44eadb79bd4de4afffb075cbbbcb258fd5030a9680065cb524424eb83
+  languageName: node
+  linkType: hard
+
+"@scure/bip39@npm:1.2.2":
+  version: 1.2.2
+  resolution: "@scure/bip39@npm:1.2.2"
+  dependencies:
+    "@noble/hashes": ~1.3.2
+    "@scure/base": ~1.1.4
+  checksum: be38bc1dc10b9a763d8b02d91dc651a4f565c822486df6cb1d3cc84896c1aab3ef6acbf7b3dc7e4a981bc9366086a4d72020aa21e11a692734a750de049c887c
   languageName: node
   linkType: hard
 
@@ -5919,6 +5964,18 @@ __metadata:
   version: 1.8.1
   resolution: "etag@npm:1.8.1"
   checksum: 12be11ef62fb9817314d790089a0a49fae4e1b50594135dcb8076312b7d7e470884b5100d249b28c18581b7fd52f8b485689ffae22a11ed9ec17377a33a08f84
+  languageName: node
+  linkType: hard
+
+"ethereum-cryptography@npm:^2.0.0":
+  version: 2.1.3
+  resolution: "ethereum-cryptography@npm:2.1.3"
+  dependencies:
+    "@noble/curves": 1.3.0
+    "@noble/hashes": 1.3.3
+    "@scure/bip32": 1.3.3
+    "@scure/bip39": 1.2.2
+  checksum: a2f25ad5ffa44b4364b1540a57969ee6f1dd820aa08a446f40f31203fef54a09442a6c099e70e7c1485922f6391c4c45b90f2c401e04d88ac9cc4611b05e606f
   languageName: node
   linkType: hard
 
@@ -11739,7 +11796,7 @@ __metadata:
     "@babel/runtime": ^7.14.6
     "@babel/types": ^7.14.5
     "@chainsafe/ssz": "workspace:^"
-    "@lodestar/types": ^1.7.2
+    "@lodestar/types": ^1.14.0
     "@types/bn.js": ^5.1.0
     "@types/deep-equal": ^1.0.1
     "@types/file-saver": ^2.0.2


### PR DESCRIPTION
- Adding Deneb support to simpleserialize.com
- Set default fork to Deneb
- Bump `@lodestar/types` to `v1.14.0` to reflect the latest change of Deneb ssz type