### PR TITLE
feat: add `sliceFrom` to `ListCompositeTreeViewDU`

### DIFF
--- a/packages/ssz/src/viewDU/listComposite.ts
+++ b/packages/ssz/src/viewDU/listComposite.ts
@@ -89,7 +89,11 @@ export class ListCompositeTreeViewDU<
     let newChunksNode;
     let newLength;
 
-    if (index >= this.nodes.length) {
+    if (index > this.nodes.length) {
+      throw new Error(`Does not support sliceFrom() with index out of bound ${index}`);
+    }
+
+    if (index === this.nodes.length) {
       newChunksNode = zeroNode(this.type.chunkDepth);
       newLength = 0;
     } else {

--- a/packages/ssz/src/viewDU/listComposite.ts
+++ b/packages/ssz/src/viewDU/listComposite.ts
@@ -71,7 +71,7 @@ export class ListCompositeTreeViewDU<
    *
    * ```ts
    * const nodes = getChunkNodes()
-   * return listFromChunkNodes(node.clice(index))
+   * return listFromChunkNodes(node.slice(index))
    * ```
    *
    * Note: If index === n, returns an empty list of length 0

--- a/packages/ssz/src/viewDU/listComposite.ts
+++ b/packages/ssz/src/viewDU/listComposite.ts
@@ -67,8 +67,7 @@ export class ListCompositeTreeViewDU<
   }
 
   /**
-   * Returns a new ListCompositeTreeViewDU instance with the values from `index` to `n`
-   * where n is the length of the list.
+   * Returns a new ListCompositeTreeViewDU instance with the values from `index` to the end of list
    * 
    * ```ts
    * const nodes = getChunkNodes()

--- a/packages/ssz/src/viewDU/listComposite.ts
+++ b/packages/ssz/src/viewDU/listComposite.ts
@@ -68,12 +68,12 @@ export class ListCompositeTreeViewDU<
 
   /**
    * Returns a new ListCompositeTreeViewDU instance with the values from `index` to the end of list
-   * 
+   *
    * ```ts
    * const nodes = getChunkNodes()
    * return listFromChunkNodes(node.clice(index))
    * ```
-   * 
+   *
    * Note: If index === n, returns an empty list of length 0
    *
    */
@@ -84,7 +84,7 @@ export class ListCompositeTreeViewDU<
     // If slicing from 0, no slicing is necesary
     if (index <= 0) {
       return this;
-    } 
+    }
 
     let newChunksNode;
     let newLength;

--- a/packages/ssz/src/viewDU/listComposite.ts
+++ b/packages/ssz/src/viewDU/listComposite.ts
@@ -1,4 +1,4 @@
-import {Node, treeZeroAfterIndex} from "@chainsafe/persistent-merkle-tree";
+import {Node, subtreeFillToContents, treeZeroAfterIndex, zeroNode} from "@chainsafe/persistent-merkle-tree";
 import {ByteViews, ValueOf} from "../type/abstract";
 import {CompositeType, CompositeView, CompositeViewDU} from "../type/composite";
 import {ListCompositeType} from "../view/listComposite";
@@ -62,6 +62,44 @@ export class ListCompositeTreeViewDU<
     // Must set new length and commit to tree to restore the same tree at that index
     const newLength = index + 1;
     const newRootNode = this.type.tree_setChunksNode(rootNode, newChunksNode, newLength);
+
+    return this.type.getViewDU(newRootNode) as this;
+  }
+
+  /**
+   * Returns a new ListCompositeTreeViewDU instance with the values from `index` to `n`
+   * where n is the length of the list.
+   * 
+   * ```ts
+   * const nodes = getChunkNodes()
+   * return listFromChunkNodes(node.clice(index))
+   * ```
+   * 
+   * Note: If index === n, returns an empty list of length 0
+   *
+   */
+  sliceFrom(index: number): this {
+    // Commit before getting rootNode to ensure all pending data is in the rootNode
+    this.commit();
+
+    // If slicing from 0, no slicing is necesary
+    if (index <= 0) {
+      return this;
+    } 
+
+    let newChunksNode;
+    let newLength;
+
+    if (index >= this.nodes.length) {
+      newChunksNode = zeroNode(this.type.chunkDepth);
+      newLength = 0;
+    } else {
+      const nodes = this.nodes.slice(index);
+      newChunksNode = subtreeFillToContents(nodes, this.type.chunkDepth);
+      newLength = nodes.length;
+    }
+
+    const newRootNode = this.type.tree_setChunksNode(this._rootNode, newChunksNode, newLength);
 
     return this.type.getViewDU(newRootNode) as this;
   }

--- a/packages/ssz/src/viewDU/listComposite.ts
+++ b/packages/ssz/src/viewDU/listComposite.ts
@@ -81,7 +81,11 @@ export class ListCompositeTreeViewDU<
     // Commit before getting rootNode to ensure all pending data is in the rootNode
     this.commit();
 
-    // If slicing from 0, no slicing is necesary
+    // If negative index, try to make it positive long as |index| < length
+    if (index < 0) {
+      index += this.nodes.length;
+    }
+    // If slicing from 0 or neg index, no slicing is necesary
     if (index <= 0) {
       return this;
     }
@@ -89,11 +93,7 @@ export class ListCompositeTreeViewDU<
     let newChunksNode;
     let newLength;
 
-    if (index > this.nodes.length) {
-      throw new Error(`Does not support sliceFrom() with index out of bound ${index}`);
-    }
-
-    if (index === this.nodes.length) {
+    if (index >= this.nodes.length) {
       newChunksNode = zeroNode(this.type.chunkDepth);
       newLength = 0;
     } else {

--- a/packages/ssz/test/unit/byType/listComposite/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listComposite/tree.test.ts
@@ -203,15 +203,13 @@ describe("ListCompositeType.sliceFrom", () => {
     const listView = listType.toViewDU(list);
 
     for (let i = -(listLength + 1); i < listLength + 1; i++) {
-      // compare list.slice(i) to listView.sliceFrom(i), they should be equivalent  
+      // compare list.slice(i) to listView.sliceFrom(i), they should be equivalent
       const slicedList = list.slice(i);
       const slicedListView = listView.sliceFrom(i);
 
       expect(slicedListView.length).to.equal(slicedList.length);
-      expect(toHexString(slicedListView.serialize()))
-        .to.equal(toHexString(listType.serialize(slicedList)));
-      expect(toHexString(slicedListView.hashTreeRoot()))
-        .to.equal(toHexString(listType.hashTreeRoot(slicedList)));
+      expect(toHexString(slicedListView.serialize())).to.equal(toHexString(listType.serialize(slicedList)));
+      expect(toHexString(slicedListView.hashTreeRoot())).to.equal(toHexString(listType.hashTreeRoot(slicedList)));
     }
   });
 });

--- a/packages/ssz/test/unit/byType/listComposite/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listComposite/tree.test.ts
@@ -223,6 +223,5 @@ describe("ListCompositeType.sliceFrom", () => {
       expect(toHexString(listSlice.serialize())).equals(listSerialized[index], `Wrong serialize at .sliceFrom(${i})`);
       expect(toHexString(listSlice.hashTreeRoot())).equals(listRoots[index], `Wrong root at .sliceFrom(${i})`);
     }
-
   });
 });

--- a/packages/ssz/test/unit/byType/listComposite/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listComposite/tree.test.ts
@@ -194,3 +194,35 @@ describe("ListCompositeType.sliceTo", () => {
     }
   });
 });
+
+describe("ListCompositeType.sliceFrom", () => {
+  it("Slice List at multiple length", () => {
+    const listType = new ListCompositeType(ssz.Root, 1024);
+    const listView = listType.defaultViewDU();
+    const listRoots: string[] = [];
+    const listSerialized: string[] = [];
+
+    for (let i = 0; i < 16; i++) {
+      listView.push(Buffer.alloc(32, 0xf + i));
+    }
+
+    for (let i = 0; i < 16; i++) {
+      const currentListView = listType.defaultViewDU();
+
+      for (let j = i; j < 16; j++) {
+        currentListView.push(Buffer.alloc(32, 0xf + j));
+        listSerialized[i] = toHexString(currentListView.serialize());
+        listRoots[i] = toHexString(currentListView.hashTreeRoot());
+      }
+    }
+
+    for (let i = -1; i < 16; i++) {
+      const index = i !== -1 ? i : 0;
+      const listSlice = listView.sliceFrom(index);
+      expect(listSlice.length).to.equal(16 - index, `Wrong length at .sliceFrom(${i})`);
+      expect(toHexString(listSlice.serialize())).equals(listSerialized[index], `Wrong serialize at .sliceFrom(${i})`);
+      expect(toHexString(listSlice.hashTreeRoot())).equals(listRoots[index], `Wrong root at .sliceFrom(${i})`);
+    }
+
+  });
+});

--- a/packages/ssz/test/unit/byType/listComposite/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listComposite/tree.test.ts
@@ -196,6 +196,37 @@ describe("ListCompositeType.sliceTo", () => {
 });
 
 describe("ListCompositeType.sliceFrom", () => {
+  it("Slice List at -1", () => {
+    const listType = new ListCompositeType(ssz.Root, 1024);
+    const listView = listType.defaultViewDU();
+
+    for (let i = 0; i < 16; i++) {
+      listView.push(Buffer.alloc(32, 0xf + 1));
+    }
+
+    const listSerialized = toHexString(listView.serialize());
+    const listRoot = toHexString(listView.hashTreeRoot());
+
+    const listSlice = listView.sliceFrom(-1);
+    expect(listSlice.length).to.equal(listView.length, "Wrong length at .sliceFrom(-1)");
+    expect(toHexString(listSlice.serialize())).equals(listSerialized, "Wrong serialize at .sliceFrom(-1)");
+    expect(toHexString(listSlice.hashTreeRoot())).equals(listRoot, "Wrong root at .sliceFrom(-1)");
+  });
+  it("Slice List at n", () => {
+    const listType = new ListCompositeType(ssz.Root, 1024);
+    const listView = listType.defaultViewDU();
+    const listSerialized = toHexString(listView.serialize()); // Zeros serialized
+    const listRoot = toHexString(listView.hashTreeRoot()); // Zeros root
+
+    for (let i = 0; i < 16; i++) {
+      listView.push(Buffer.alloc(32, 0xf + 1));
+    }
+
+    const listSlice = listView.sliceFrom(16);
+    expect(listSlice.length).to.equal(0, "Wrong length at .sliceFrom(n)");
+    expect(toHexString(listSlice.serialize())).equals(listSerialized, "Wrong serialize at .sliceFrom(n)");
+    expect(toHexString(listSlice.hashTreeRoot())).equals(listRoot, "Wrong root at .sliceFrom(n)");
+  });
   it("Slice List at multiple length", () => {
     const listType = new ListCompositeType(ssz.Root, 1024);
     const listView = listType.defaultViewDU();

--- a/packages/ssz/test/unit/byType/listComposite/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listComposite/tree.test.ts
@@ -196,7 +196,7 @@ describe("ListCompositeType.sliceTo", () => {
 });
 
 describe("ListCompositeType.sliceFrom", () => {
-  it("Slice List at -1", () => {
+  it("Slice List from -1", () => {
     const listType = new ListCompositeType(ssz.Root, 1024);
     const listView = listType.defaultViewDU();
 
@@ -212,7 +212,7 @@ describe("ListCompositeType.sliceFrom", () => {
     expect(toHexString(listSlice.serialize())).equals(listSerialized, "Wrong serialize at .sliceFrom(-1)");
     expect(toHexString(listSlice.hashTreeRoot())).equals(listRoot, "Wrong root at .sliceFrom(-1)");
   });
-  it("Slice List at n", () => {
+  it("Slice List from n", () => {
     const listType = new ListCompositeType(ssz.Root, 1024);
     const listView = listType.defaultViewDU();
     const listSerialized = toHexString(listView.serialize()); // Zeros serialized
@@ -227,7 +227,7 @@ describe("ListCompositeType.sliceFrom", () => {
     expect(toHexString(listSlice.serialize())).equals(listSerialized, "Wrong serialize at .sliceFrom(n)");
     expect(toHexString(listSlice.hashTreeRoot())).equals(listRoot, "Wrong root at .sliceFrom(n)");
   });
-  it("Slice List at multiple length", () => {
+  it("Slice List from multiple length", () => {
     const listType = new ListCompositeType(ssz.Root, 1024);
     const listView = listType.defaultViewDU();
     const listRoots: string[] = [];


### PR DESCRIPTION
Add `sliceFrom` to `ListCompositeTreeViewDU`. 

Used in EIP-7251 to slice various beacon state fields like `pendingBalanceDeposit`, `pendingConsolidation` during epoch processing. 

Refer to the spec for more details:
[`process_pending_balance_deposits`](https://github.com/ethereum/consensus-specs/blob/f5207db2c415f676bb61d173031d1c233579f1a8/specs/_features/eip7251/beacon-chain.md?plain=1#L599)
[`process_pending_consolidations `](https://github.com/ethereum/consensus-specs/blob/f5207db2c415f676bb61d173031d1c233579f1a8/specs/_features/eip7251/beacon-chain.md?plain=1#L628)
[`process_withdrawals`](https://github.com/ethereum/consensus-specs/blob/f5207db2c415f676bb61d173031d1c233579f1a8/specs/_features/eip7251/beacon-chain.md?plain=1#L734)
