### PR TITLE
fix: findDiffDepthi to support more than 31 bytes

### DIFF
--- a/packages/persistent-merkle-tree/src/tree.ts
+++ b/packages/persistent-merkle-tree/src/tree.ts
@@ -710,8 +710,8 @@ export function findDiffDepthi(from: number, to: number): number {
     throw Error(`Expect different positive inputs, from=${from} to=${to}`);
   }
   // 0 -> 0, 1 -> 1, 2 -> 2, 3 -> 2, 4 -> 3
-  const numBits0 = from > 0 ? Math.ceil(Math.log2(from + 1)) : 0;
-  const numBits1 = to > 0 ? Math.ceil(Math.log2(to + 1)) : 0;
+  const numBits0 = Math.ceil(Math.log2(from + 1));
+  const numBits1 = Math.ceil(Math.log2(to + 1));
 
   // these indexes stay in 2 sides of a merkle tree
   if (numBits0 !== numBits1) {

--- a/packages/persistent-merkle-tree/src/tree.ts
+++ b/packages/persistent-merkle-tree/src/tree.ts
@@ -692,6 +692,9 @@ export function treeZeroAfterIndex(rootNode: Node, nodesDepth: number, index: nu
   return node;
 }
 
+const NUMBER_32_MAX = 0xffffffff;
+const NUMBER_2_POW_32 = 2 ** 32;
+
 /**
  * depth depthi   gindexes   indexes
  * 0     1           1          0
@@ -704,7 +707,6 @@ export function treeZeroAfterIndex(rootNode: Node, nodesDepth: number, index: nu
  * @param from Index
  * @param to Index
  */
-const NUMBER_32_MAX = 0xffffffff;
 export function findDiffDepthi(from: number, to: number): number {
   if (from === to || from < 0 || to < 0) {
     throw Error(`Expect different positive inputs, from=${from} to=${to}`);
@@ -721,12 +723,14 @@ export function findDiffDepthi(from: number, to: number): number {
 
   // same number of bits and > 32
   if (numBits0 > 32) {
-    const highBits0 = Math.floor(from / NUMBER_32_MAX);
-    const highBits1 = Math.floor(to / NUMBER_32_MAX);
+    const highBits0 = Math.floor(from / NUMBER_2_POW_32) & NUMBER_32_MAX;
+    const highBits1 = Math.floor(to / NUMBER_2_POW_32) & NUMBER_32_MAX;
     if (highBits0 === highBits1) {
       // different part is just low bits
       return findDiffDepthi32Bits(from & NUMBER_32_MAX, to & NUMBER_32_MAX);
     }
+
+    // highBits are different, no need to compare low bits
     return 32 + findDiffDepthi32Bits(highBits0, highBits1);
   }
 


### PR DESCRIPTION
**Motivation**

The current `findDiffDepthi` only support up to 31 bits due to bit xor `^` limitation

**Description**

Support > 32 bits numbers:
- Return early of number of bits between `index0` and `index1` are different
- If it's > 32 bits, separate to higher bits part and lower bits part by masking operation

Fix the 32 bits number:
- Fix `findDiffDepthi()` itself by handling non-positive `xor` result

Closes #370

**Steps to test or reproduce**

Run all unit tests