### PR TITLE
chore: bump node version in GitHub workflows

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,10 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - run: corepack enable
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           cache: yarn
-          node-version: 18
+          node-version: 20
       - run: yarn --immutable && yarn build && yarn generate
 
       - name: Run benchmarks

--- a/.github/workflows/cd-manual.yml
+++ b/.github/workflows/cd-manual.yml
@@ -11,10 +11,10 @@ jobs:
       steps:
           - uses: actions/checkout@v3
           - run: corepack enable
-          - uses: actions/setup-node@v3
+          - uses: actions/setup-node@v4
             with:
               cache: yarn
-              node-version: '16'
+              node-version: '20'
           - name: Bootstrap
             run: yarn --immutable
           - name: Build

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,10 +31,10 @@ jobs:
         
       - run: corepack enable
       
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           cache: 'yarn'
-          node-version: 16
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.releases_created }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [20]
+        node: [18, 20]
     steps:
       - uses: actions/checkout@v3
       - run: corepack enable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,11 +9,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: [16, 18]
+        node: [20]
     steps:
       - uses: actions/checkout@v3
       - run: corepack enable
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: ${{matrix.node}}
           cache: yarn


### PR DESCRIPTION
Use node20 and setup-node v4 in GitHub workflows as recommended [here](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)

This should fix CI errors when attempting to run yarn using node16. See [error log](https://github.com/ChainSafe/ssz/actions/runs/8751637236/job/24030166543)