### PR TITLE
Te/batch hash tree root

### DIFF
--- a/packages/as-sha256/test/perf/simd.test.ts
+++ b/packages/as-sha256/test/perf/simd.test.ts
@@ -5,12 +5,13 @@ import {byteArrayToHashObject} from "../../src/hashObject";
 /**
  * This really depends on cpu, on a test ubuntu node, batch*() is 2x faster than digest64
  * On Mac M1 May 2025:
- * digest64 vs batchHash4UintArray64s vs batchHash4HashObjectInputs
-    ✓ digest64 200092 times                                               6.850496 ops/s    145.9748 ms/op        -         66 runs   10.2 s
-    ✓ hash 200092 times using batchHash4UintArray64s                      8.454788 ops/s    118.2762 ms/op        -         82 runs   10.2 s
-    ✓ hash 200092 times using batchHash4HashObjectInputs                  8.454464 ops/s    118.2807 ms/op        -         82 runs   10.2 s
+ * digest64 vs batchHash4UintArray64s vs digest64HashObjects vs batchHash4HashObjectInputs
+    ✓ digest64 200092 times                                               6.648102 ops/s    150.4189 ms/op        -         64 runs   10.2 s
+    ✓ hash 200092 times using batchHash4UintArray64s                      9.120131 ops/s    109.6476 ms/op        -         88 runs   10.2 s
+    ✓ digest64HashObjects 200092 times                                    7.095494 ops/s    140.9345 ms/op        -         68 runs   10.2 s
+    ✓ hash 200092 times using batchHash4HashObjectInputs                  9.211751 ops/s    108.5570 ms/op        -         88 runs   10.1 s
  */
-describe("digest64 vs batchHash4UintArray64s vs batchHash4HashObjectInputs", function () {
+describe("digest64 vs batchHash4UintArray64s vs digest64HashObjects vs batchHash4HashObjectInputs", function () {
   this.timeout(0);
 
   setBenchOpts({
@@ -32,6 +33,10 @@ describe("digest64 vs batchHash4UintArray64s vs batchHash4HashObjectInputs", fun
   });
 
   const hashObject = byteArrayToHashObject(Buffer.from("gajindergajindergajindergajinder", "utf8"));
+  itBench(`digest64HashObjects ${iterations * 4} times`, () => {
+    for (let j = 0; j < iterations * 4; j++) sha256.digest64HashObjects(hashObject, hashObject);
+  });
+
   const hashInputs = Array.from({length: 8}, () => hashObject);
   // batchHash4HashObjectInputs do 4 sha256 in parallel
   itBench(`hash ${iterations * 4} times using batchHash4HashObjectInputs`, () => {

--- a/packages/persistent-merkle-tree/package.json
+++ b/packages/persistent-merkle-tree/package.json
@@ -20,7 +20,8 @@
     "clean": "rm -rf lib",
     "build": "tsc",
     "lint": "eslint --color --ext .ts src/",
-    "benchmark": "node --max-old-space-size=4096 --expose-gc -r ts-node/register ./node_modules/.bin/benchmark 'test/perf/*.perf.ts'",
+    "benchmark:files": "node --max-old-space-size=4096 --expose-gc -r ts-node/register ../../node_modules/.bin/benchmark",
+    "benchmark": "yarn benchmark:files 'test/perf/*.test.ts'",
     "benchmark:local": "yarn benchmark --local",
     "test": "mocha -r ts-node/register 'test/unit/**/*.test.ts'"
   },

--- a/packages/persistent-merkle-tree/package.json
+++ b/packages/persistent-merkle-tree/package.json
@@ -48,6 +48,9 @@
     "@chainsafe/hashtree": "1.0.0",
     "@noble/hashes": "^1.3.0"
   },
+  "devDependencies": {
+    "@chainsafe/hashtree-darwin-arm64": "1.0.0"
+  },
   "peerDependencies": {
     "@chainsafe/hashtree-linux-x64-gnu": "1.0.0",
     "@chainsafe/hashtree-linux-arm64-gnu": "1.0.0",

--- a/packages/persistent-merkle-tree/package.json
+++ b/packages/persistent-merkle-tree/package.json
@@ -45,6 +45,12 @@
   "homepage": "https://github.com/ChainSafe/persistent-merkle-tree#readme",
   "dependencies": {
     "@chainsafe/as-sha256": "0.4.2",
+    "@chainsafe/hashtree": "1.0.0",
     "@noble/hashes": "^1.3.0"
+  },
+  "peerDependencies": {
+    "@chainsafe/hashtree-linux-x64-gnu": "1.0.0",
+    "@chainsafe/hashtree-linux-arm64-gnu": "1.0.0",
+    "@chainsafe/hashtree-darwin-arm64": "1.0.0"
   }
 }

--- a/packages/persistent-merkle-tree/package.json
+++ b/packages/persistent-merkle-tree/package.json
@@ -49,9 +49,6 @@
     "@chainsafe/hashtree": "1.0.0",
     "@noble/hashes": "^1.3.0"
   },
-  "devDependencies": {
-    "@chainsafe/hashtree-darwin-arm64": "1.0.0"
-  },
   "peerDependencies": {
     "@chainsafe/hashtree-linux-x64-gnu": "1.0.0",
     "@chainsafe/hashtree-linux-arm64-gnu": "1.0.0",

--- a/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
+++ b/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
@@ -1,5 +1,6 @@
 import {digest2Bytes32, digest64HashObjects, HashObject, batchHash4HashObjectInputs} from "@chainsafe/as-sha256";
 import type {Hasher} from "./types";
+import {HashComputation} from "../node";
 
 export const hasher: Hasher = {
   digest64: digest2Bytes32,
@@ -15,8 +16,8 @@ export const hasher: Hasher = {
     const batch = Math.floor(inputs.length / 8);
     const outputs = new Array<HashObject>();
     for (let i = 0; i < batch; i++) {
-      const [out0, out1, out2, out3] = batchHash4HashObjectInputs(inputs.slice(i * 8, i * 8 + 8));
-      outputs.push(out0, out1, out2, out3);
+      const outs = batchHash4HashObjectInputs(inputs.slice(i * 8, i * 8 + 8));
+      outputs.push(...outs);
     }
 
     for (let i = batch * 8; i < inputs.length; i += 2) {
@@ -25,5 +26,44 @@ export const hasher: Hasher = {
     }
 
     return outputs;
+  },
+  executeHashComputations: (hashComputations: Array<HashComputation[]>) => {
+    for (let level = hashComputations.length - 1; level >= 0; level--) {
+      const hcArr = hashComputations[level];
+      if (!hcArr) {
+        // should not happen
+        throw Error(`no hash computations for level ${level}`);
+      }
+
+      // HashComputations of the same level are safe to batch
+      const batch = Math.floor(hcArr.length / 4);
+      for (let i = 0; i < batch; i++) {
+        const index = i * 4;
+        const outs = batchHash4HashObjectInputs([
+          hcArr[index].src0,
+          hcArr[index].src1,
+          hcArr[index + 1].src0,
+          hcArr[index + 1].src1,
+          hcArr[index + 2].src0,
+          hcArr[index + 2].src1,
+          hcArr[index + 3].src0,
+          hcArr[index + 3].src1,
+        ]);
+        if (outs.length !== 4) {
+          throw Error(`batchHash4HashObjectInputs returned ${outs.length} outputs, expected 4`);
+        }
+        hcArr[index].dest.applyHash(outs[0]);
+        hcArr[index + 1].dest.applyHash(outs[1]);
+        hcArr[index + 2].dest.applyHash(outs[2]);
+        hcArr[index + 3].dest.applyHash(outs[3]);
+      }
+
+      // remaining
+      for (let i = batch * 4; i < hcArr.length; i++) {
+        const {src0, src1, dest} = hcArr[i];
+        const output = digest64HashObjects(src0, src1);
+        dest.applyHash(output);
+      }
+    }
   },
 };

--- a/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
+++ b/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
@@ -51,6 +51,7 @@ export const hasher: Hasher = {
 
       for (const [i, hc] of hcArr.entries()) {
         const indexInBatch = i % 4;
+
         switch (indexInBatch) {
           case 0:
             src0_0 = hc.src0;
@@ -71,56 +72,56 @@ export const hasher: Hasher = {
             src0_3 = hc.src0;
             src1_3 = hc.src1;
             dest3 = hc.dest;
+
+            if (
+              src0_0 !== null &&
+              src1_0 !== null &&
+              dest0 !== null &&
+              src0_1 !== null &&
+              src1_1 !== null &&
+              dest1 !== null &&
+              src0_2 !== null &&
+              src1_2 !== null &&
+              dest2 !== null &&
+              src0_3 !== null &&
+              src1_3 !== null &&
+              dest3 !== null
+            ) {
+              const [o0, o1, o2, o3] = batchHash4HashObjectInputs([
+                src0_0,
+                src1_0,
+                src0_1,
+                src1_1,
+                src0_2,
+                src1_2,
+                src0_3,
+                src1_3,
+              ]);
+              if (o0 == null || o1 == null || o2 == null || o3 == null) {
+                throw Error(`batchHash4HashObjectInputs return null or undefined at batch ${i} level ${level}`);
+              }
+              dest0.applyHash(o0);
+              dest1.applyHash(o1);
+              dest2.applyHash(o2);
+              dest3.applyHash(o3);
+
+              // reset for next batch
+              src0_0 = null;
+              src1_0 = null;
+              dest0 = null;
+              src0_1 = null;
+              src1_1 = null;
+              dest1 = null;
+              src0_2 = null;
+              src1_2 = null;
+              dest2 = null;
+              src0_3 = null;
+              src1_3 = null;
+              dest3 = null;
+            }
             break;
           default:
             throw Error(`Unexpected indexInBatch ${indexInBatch}`);
-        }
-
-        if (
-          indexInBatch === 3 &&
-          src0_0 !== null &&
-          src1_0 !== null &&
-          dest0 !== null &&
-          src0_1 !== null &&
-          src1_1 !== null &&
-          dest1 !== null &&
-          src0_2 !== null &&
-          src1_2 !== null &&
-          dest2 !== null &&
-          src0_3 !== null &&
-          src1_3 !== null &&
-          dest3 !== null
-        ) {
-          const [o0, o1, o2, o3] = batchHash4HashObjectInputs([
-            src0_0,
-            src1_0,
-            src0_1,
-            src1_1,
-            src0_2,
-            src1_2,
-            src0_3,
-            src1_3,
-          ]);
-          if (o0 == null || o1 == null || o2 == null || o3 == null) {
-            throw Error(`batchHash4HashObjectInputs return null or undefined at batch ${i} level ${level}`);
-          }
-          dest0.applyHash(o0);
-          dest1.applyHash(o1);
-          dest2.applyHash(o2);
-          dest3.applyHash(o3);
-
-          src0_0 = null;
-          src1_0 = null;
-          dest0 = null;
-          src0_1 = null;
-          src1_1 = null;
-          dest1 = null;
-          src0_2 = null;
-          src1_2 = null;
-          dest2 = null;
-          src0_3 = null;
-          src1_3 = null;
-          dest3 = null;
         }
       }
 

--- a/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
+++ b/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
@@ -38,16 +38,16 @@ export const hasher: Hasher = {
       // HashComputations of the same level are safe to batch
       let src0_0: Node | null = null;
       let src1_0: Node | null = null;
-      let dest_0: Node | null = null;
+      let dest0: Node | null = null;
       let src0_1: Node | null = null;
       let src1_1: Node | null = null;
-      let dest_1: Node | null = null;
+      let dest1: Node | null = null;
       let src0_2: Node | null = null;
       let src1_2: Node | null = null;
-      let dest_2: Node | null = null;
+      let dest2: Node | null = null;
       let src0_3: Node | null = null;
       let src1_3: Node | null = null;
-      let dest_3: Node | null = null;
+      let dest3: Node | null = null;
 
       for (const [i, hc] of hcArr.entries()) {
         const indexInBatch = i % 4;
@@ -55,22 +55,22 @@ export const hasher: Hasher = {
           case 0:
             src0_0 = hc.src0;
             src1_0 = hc.src1;
-            dest_0 = hc.dest;
+            dest0 = hc.dest;
             break;
           case 1:
             src0_1 = hc.src0;
             src1_1 = hc.src1;
-            dest_1 = hc.dest;
+            dest1 = hc.dest;
             break;
           case 2:
             src0_2 = hc.src0;
             src1_2 = hc.src1;
-            dest_2 = hc.dest;
+            dest2 = hc.dest;
             break;
           case 3:
             src0_3 = hc.src0;
             src1_3 = hc.src1;
-            dest_3 = hc.dest;
+            dest3 = hc.dest;
             break;
           default:
             throw Error(`Unexpected indexInBatch ${indexInBatch}`);
@@ -80,16 +80,16 @@ export const hasher: Hasher = {
           indexInBatch === 3 &&
           src0_0 !== null &&
           src1_0 !== null &&
-          dest_0 !== null &&
+          dest0 !== null &&
           src0_1 !== null &&
           src1_1 !== null &&
-          dest_1 !== null &&
+          dest1 !== null &&
           src0_2 !== null &&
           src1_2 !== null &&
-          dest_2 !== null &&
+          dest2 !== null &&
           src0_3 !== null &&
           src1_3 !== null &&
-          dest_3 !== null
+          dest3 !== null
         ) {
           const [o0, o1, o2, o3] = batchHash4HashObjectInputs([
             src0_0,
@@ -102,40 +102,40 @@ export const hasher: Hasher = {
             src1_3,
           ]);
           if (o0 == null || o1 == null || o2 == null || o3 == null) {
-            throw Error(`batchHash4HashObjectInputs return null at batch ${i} level ${level}`);
+            throw Error(`batchHash4HashObjectInputs return null or undefined at batch ${i} level ${level}`);
           }
-          dest_0.applyHash(o0);
-          dest_1.applyHash(o1);
-          dest_2.applyHash(o2);
-          dest_3.applyHash(o3);
+          dest0.applyHash(o0);
+          dest1.applyHash(o1);
+          dest2.applyHash(o2);
+          dest3.applyHash(o3);
 
           src0_0 = null;
           src1_0 = null;
-          dest_0 = null;
+          dest0 = null;
           src0_1 = null;
           src1_1 = null;
-          dest_1 = null;
+          dest1 = null;
           src0_2 = null;
           src1_2 = null;
-          dest_2 = null;
+          dest2 = null;
           src0_3 = null;
           src1_3 = null;
-          dest_3 = null;
+          dest3 = null;
         }
       }
 
       // remaining
-      if (src0_0 !== null && src1_0 !== null && dest_0 !== null) {
-        dest_0.applyHash(digest64HashObjects(src0_0, src1_0));
+      if (src0_0 !== null && src1_0 !== null && dest0 !== null) {
+        dest0.applyHash(digest64HashObjects(src0_0, src1_0));
       }
-      if (src0_1 !== null && src1_1 !== null && dest_1 !== null) {
-        dest_1.applyHash(digest64HashObjects(src0_1, src1_1));
+      if (src0_1 !== null && src1_1 !== null && dest1 !== null) {
+        dest1.applyHash(digest64HashObjects(src0_1, src1_1));
       }
-      if (src0_2 !== null && src1_2 !== null && dest_2 !== null) {
-        dest_2.applyHash(digest64HashObjects(src0_2, src1_2));
+      if (src0_2 !== null && src1_2 !== null && dest2 !== null) {
+        dest2.applyHash(digest64HashObjects(src0_2, src1_2));
       }
-      if (src0_3 !== null && src1_3 !== null && dest_3 !== null) {
-        dest_3.applyHash(digest64HashObjects(src0_3, src1_3));
+      if (src0_3 !== null && src1_3 !== null && dest3 !== null) {
+        dest3.applyHash(digest64HashObjects(src0_3, src1_3));
       }
     }
   },

--- a/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
+++ b/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
@@ -1,8 +1,8 @@
-import {digest2Bytes32, digest64HashObjects, hash8HashObjects} from "@chainsafe/as-sha256";
+import {digest2Bytes32, digest64HashObjects, batchHash4HashObjectInputs} from "@chainsafe/as-sha256";
 import type {Hasher} from "./types";
 
 export const hasher: Hasher = {
   digest64: digest2Bytes32,
   digest64HashObjects,
-  hash8HashObjects,
+  batchHash4HashObjectInputs,
 };

--- a/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
+++ b/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
@@ -1,7 +1,8 @@
-import {digest2Bytes32, digest64HashObjects} from "@chainsafe/as-sha256";
+import {digest2Bytes32, digest64HashObjects, hash8HashObjects} from "@chainsafe/as-sha256";
 import type {Hasher} from "./types";
 
 export const hasher: Hasher = {
   digest64: digest2Bytes32,
   digest64HashObjects,
+  hash8HashObjects,
 };

--- a/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
+++ b/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
@@ -3,6 +3,7 @@ import type {Hasher} from "./types";
 import {HashComputation, Node} from "../node";
 
 export const hasher: Hasher = {
+  name: "as-sha256",
   digest64: digest2Bytes32,
   digest64HashObjects,
   batchHashObjects: (inputs: HashObject[]) => {

--- a/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
+++ b/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
@@ -1,8 +1,29 @@
-import {digest2Bytes32, digest64HashObjects, batchHash4HashObjectInputs} from "@chainsafe/as-sha256";
+import {digest2Bytes32, digest64HashObjects, HashObject, batchHash4HashObjectInputs} from "@chainsafe/as-sha256";
 import type {Hasher} from "./types";
 
 export const hasher: Hasher = {
   digest64: digest2Bytes32,
   digest64HashObjects,
-  batchHash4HashObjectInputs,
+  batchHashObjects: (inputs: HashObject[]) => {
+    // as-sha256 uses SIMD for batch hash
+    if (inputs.length === 0) {
+      return [];
+    } else if (inputs.length % 2 !== 0) {
+      throw new Error(`Expect inputs.length to be even, got ${inputs.length}`);
+    }
+
+    const batch = Math.floor(inputs.length / 8);
+    const outputs = new Array<HashObject>();
+    for (let i = 0; i < batch; i++) {
+      const [out0, out1, out2, out3] = batchHash4HashObjectInputs(inputs.slice(i * 8, i * 8 + 8));
+      outputs.push(out0, out1, out2, out3);
+    }
+
+    for (let i = batch * 8; i < inputs.length; i += 2) {
+      const output = digest64HashObjects(inputs[i], inputs[i + 1]);
+      outputs.push(output);
+    }
+
+    return outputs;
+  },
 };

--- a/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
+++ b/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
@@ -39,23 +39,29 @@ export const hasher: Hasher = {
       const batch = Math.floor(hcArr.length / 4);
       for (let i = 0; i < batch; i++) {
         const index = i * 4;
-        const outs = batchHash4HashObjectInputs([
-          hcArr[index].src0,
-          hcArr[index].src1,
-          hcArr[index + 1].src0,
-          hcArr[index + 1].src1,
-          hcArr[index + 2].src0,
-          hcArr[index + 2].src1,
-          hcArr[index + 3].src0,
-          hcArr[index + 3].src1,
+        // access array once
+        const {src0: src0_0, src1: src1_0, dest: dest_0} = hcArr[index];
+        const {src0: src0_1, src1: src1_1, dest: dest_1} = hcArr[index + 1];
+        const {src0: src0_2, src1: src1_2, dest: dest_2} = hcArr[index + 2];
+        const {src0: src0_3, src1: src1_3, dest: dest_3} = hcArr[index + 3];
+
+        const [o0, o1, o2, o3] = batchHash4HashObjectInputs([
+          src0_0,
+          src1_0,
+          src0_1,
+          src1_1,
+          src0_2,
+          src1_2,
+          src0_3,
+          src1_3,
         ]);
-        if (outs.length !== 4) {
-          throw Error(`batchHash4HashObjectInputs returned ${outs.length} outputs, expected 4`);
+        if (o0 == null || o1 == null || o2 == null || o3 == null) {
+          throw Error(`batchHash4HashObjectInputs return null at batch ${i} level ${level}`);
         }
-        hcArr[index].dest.applyHash(outs[0]);
-        hcArr[index + 1].dest.applyHash(outs[1]);
-        hcArr[index + 2].dest.applyHash(outs[2]);
-        hcArr[index + 3].dest.applyHash(outs[3]);
+        dest_0.applyHash(o0);
+        dest_1.applyHash(o1);
+        dest_2.applyHash(o2);
+        dest_3.applyHash(o3);
       }
 
       // remaining

--- a/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
+++ b/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
@@ -1,6 +1,6 @@
 import {digest2Bytes32, digest64HashObjects, HashObject, batchHash4HashObjectInputs} from "@chainsafe/as-sha256";
 import type {Hasher} from "./types";
-import {HashComputation} from "../node";
+import {HashComputation, Node} from "../node";
 
 export const hasher: Hasher = {
   digest64: digest2Bytes32,
@@ -36,39 +36,106 @@ export const hasher: Hasher = {
       }
 
       // HashComputations of the same level are safe to batch
-      const batch = Math.floor(hcArr.length / 4);
-      for (let i = 0; i < batch; i++) {
-        const index = i * 4;
-        // access array once
-        const {src0: src0_0, src1: src1_0, dest: dest_0} = hcArr[index];
-        const {src0: src0_1, src1: src1_1, dest: dest_1} = hcArr[index + 1];
-        const {src0: src0_2, src1: src1_2, dest: dest_2} = hcArr[index + 2];
-        const {src0: src0_3, src1: src1_3, dest: dest_3} = hcArr[index + 3];
+      let src0_0: Node | null = null;
+      let src1_0: Node | null = null;
+      let dest_0: Node | null = null;
+      let src0_1: Node | null = null;
+      let src1_1: Node | null = null;
+      let dest_1: Node | null = null;
+      let src0_2: Node | null = null;
+      let src1_2: Node | null = null;
+      let dest_2: Node | null = null;
+      let src0_3: Node | null = null;
+      let src1_3: Node | null = null;
+      let dest_3: Node | null = null;
 
-        const [o0, o1, o2, o3] = batchHash4HashObjectInputs([
-          src0_0,
-          src1_0,
-          src0_1,
-          src1_1,
-          src0_2,
-          src1_2,
-          src0_3,
-          src1_3,
-        ]);
-        if (o0 == null || o1 == null || o2 == null || o3 == null) {
-          throw Error(`batchHash4HashObjectInputs return null at batch ${i} level ${level}`);
+      for (const [i, hc] of hcArr.entries()) {
+        const indexInBatch = i % 4;
+        switch (indexInBatch) {
+          case 0:
+            src0_0 = hc.src0;
+            src1_0 = hc.src1;
+            dest_0 = hc.dest;
+            break;
+          case 1:
+            src0_1 = hc.src0;
+            src1_1 = hc.src1;
+            dest_1 = hc.dest;
+            break;
+          case 2:
+            src0_2 = hc.src0;
+            src1_2 = hc.src1;
+            dest_2 = hc.dest;
+            break;
+          case 3:
+            src0_3 = hc.src0;
+            src1_3 = hc.src1;
+            dest_3 = hc.dest;
+            break;
+          default:
+            throw Error(`Unexpected indexInBatch ${indexInBatch}`);
         }
-        dest_0.applyHash(o0);
-        dest_1.applyHash(o1);
-        dest_2.applyHash(o2);
-        dest_3.applyHash(o3);
+
+        if (
+          indexInBatch === 3 &&
+          src0_0 !== null &&
+          src1_0 !== null &&
+          dest_0 !== null &&
+          src0_1 !== null &&
+          src1_1 !== null &&
+          dest_1 !== null &&
+          src0_2 !== null &&
+          src1_2 !== null &&
+          dest_2 !== null &&
+          src0_3 !== null &&
+          src1_3 !== null &&
+          dest_3 !== null
+        ) {
+          const [o0, o1, o2, o3] = batchHash4HashObjectInputs([
+            src0_0,
+            src1_0,
+            src0_1,
+            src1_1,
+            src0_2,
+            src1_2,
+            src0_3,
+            src1_3,
+          ]);
+          if (o0 == null || o1 == null || o2 == null || o3 == null) {
+            throw Error(`batchHash4HashObjectInputs return null at batch ${i} level ${level}`);
+          }
+          dest_0.applyHash(o0);
+          dest_1.applyHash(o1);
+          dest_2.applyHash(o2);
+          dest_3.applyHash(o3);
+
+          src0_0 = null;
+          src1_0 = null;
+          dest_0 = null;
+          src0_1 = null;
+          src1_1 = null;
+          dest_1 = null;
+          src0_2 = null;
+          src1_2 = null;
+          dest_2 = null;
+          src0_3 = null;
+          src1_3 = null;
+          dest_3 = null;
+        }
       }
 
       // remaining
-      for (let i = batch * 4; i < hcArr.length; i++) {
-        const {src0, src1, dest} = hcArr[i];
-        const output = digest64HashObjects(src0, src1);
-        dest.applyHash(output);
+      if (src0_0 !== null && src1_0 !== null && dest_0 !== null) {
+        dest_0.applyHash(digest64HashObjects(src0_0, src1_0));
+      }
+      if (src0_1 !== null && src1_1 !== null && dest_1 !== null) {
+        dest_1.applyHash(digest64HashObjects(src0_1, src1_1));
+      }
+      if (src0_2 !== null && src1_2 !== null && dest_2 !== null) {
+        dest_2.applyHash(digest64HashObjects(src0_2, src1_2));
+      }
+      if (src0_3 !== null && src1_3 !== null && dest_3 !== null) {
+        dest_3.applyHash(digest64HashObjects(src0_3, src1_3));
       }
     }
   },

--- a/packages/persistent-merkle-tree/src/hasher/hashtree.ts
+++ b/packages/persistent-merkle-tree/src/hasher/hashtree.ts
@@ -5,10 +5,14 @@ import {HashComputation, Node} from "../node";
 
 export const hasher: Hasher = {
   digest64(obj1: Uint8Array, obj2: Uint8Array): Uint8Array {
-    return hash(Uint8Array.of(obj1, obj2));
+    return hash(Uint8Array.from([...obj1, ...obj2]));
   },
   digest64HashObjects(obj1: HashObject, obj2: HashObject): HashObject {
-    return byteArrayToHashObject(hasher.digest64(hashObjectToByteArray(obj1), hashObjectToByteArray(obj2)));
+    const input1 = Uint8Array.from(new Array<number>(32));
+    const input2 = Uint8Array.from(new Array<number>(32));
+    hashObjectToByteArray(obj1, input1, 0);
+    hashObjectToByteArray(obj2, input2, 0);
+    return byteArrayToHashObject(hasher.digest64(input1, input2));
   },
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   batchHashObjects(inputs: HashObject[]): HashObject[] {
@@ -23,7 +27,7 @@ export const hasher: Hasher = {
       }
 
       // size input array to 2 HashObject per computation * 32 bytes per object
-      const input: Uint8Array = Uint8Array.of(new Array(hcArr.length * 2 * 32));
+      const input: Uint8Array = Uint8Array.from(new Array(hcArr.length * 2 * 32));
       const output: Node[] = [];
       for (const [i, hc] of hcArr.entries()) {
         const offset = (i - 1) * 64; // zero index * 2 leafs * 32 bytes
@@ -36,7 +40,7 @@ export const hasher: Hasher = {
 
       for (const [i, out] of output.entries()) {
         const offset = (i - 1) * 32;
-        out.applyHash(result.slice(offset, offset + 32));
+        out.applyHash(byteArrayToHashObject(result.slice(offset, offset + 32)));
       }
     }
   },

--- a/packages/persistent-merkle-tree/src/hasher/hashtree.ts
+++ b/packages/persistent-merkle-tree/src/hasher/hashtree.ts
@@ -1,1 +1,43 @@
-// TODO - batch: use @chainsafe/hashtree
+import {hash} from "@chainsafe/hashtree";
+import {byteArrayToHashObject, hashObjectToByteArray} from "@chainsafe/as-sha256";
+import {Hasher, HashObject} from "./types";
+import {HashComputation, Node} from "../node";
+
+export const hasher: Hasher = {
+  digest64(obj1: Uint8Array, obj2: Uint8Array): Uint8Array {
+    return hash(Uint8Array.of(obj1, obj2));
+  },
+  digest64HashObjects(obj1: HashObject, obj2: HashObject): HashObject {
+    return byteArrayToHashObject(hasher.digest64(hashObjectToByteArray(obj1), hashObjectToByteArray(obj2)));
+  },
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  batchHashObjects(inputs: HashObject[]): HashObject[] {
+    throw new Error("batchHashObjects not implemented for hashtree hasher");
+  },
+  executeHashComputations(hashComputations: Array<HashComputation[]>): void {
+    for (let level = hashComputations.length - 1; level >= 0; level--) {
+      const hcArr = hashComputations[level];
+      if (!hcArr) {
+        // should not happen
+        throw Error(`no hash computations for level ${level}`);
+      }
+
+      // size input array to 2 HashObject per computation * 32 bytes per object
+      const input: Uint8Array = Uint8Array.of(new Array(hcArr.length * 2 * 32));
+      const output: Node[] = [];
+      for (const [i, hc] of hcArr.entries()) {
+        const offset = (i - 1) * 64; // zero index * 2 leafs * 32 bytes
+        hashObjectToByteArray(hc.src0, input, offset);
+        hashObjectToByteArray(hc.src1, input, offset + 32);
+        output.push(hc.dest);
+      }
+
+      const result: Uint8Array = hash(input);
+
+      for (const [i, out] of output.entries()) {
+        const offset = (i - 1) * 32;
+        out.applyHash(result.slice(offset, offset + 32));
+      }
+    }
+  },
+};

--- a/packages/persistent-merkle-tree/src/hasher/hashtree.ts
+++ b/packages/persistent-merkle-tree/src/hasher/hashtree.ts
@@ -53,7 +53,7 @@ export const hasher: Hasher = {
 
       for (const [i, out] of output.entries()) {
         const offset = i * 32;
-        out.applyHash(byteArrayToHashObject(result.slice(offset, offset + 32)));
+        out.applyHash(byteArrayToHashObject(result.subarray(offset, offset + 32)));
       }
     }
   },

--- a/packages/persistent-merkle-tree/src/hasher/hashtree.ts
+++ b/packages/persistent-merkle-tree/src/hasher/hashtree.ts
@@ -6,11 +6,11 @@ import {HashComputation, Node} from "../node";
 export const hasher: Hasher = {
   name: "hashtree",
   digest64(obj1: Uint8Array, obj2: Uint8Array): Uint8Array {
-    return hash(Uint8Array.from([...obj1, ...obj2]));
+    return hash(Buffer.concat([obj1, obj2], 64));
   },
   digest64HashObjects(obj1: HashObject, obj2: HashObject): HashObject {
-    const input1 = Uint8Array.from(new Array<number>(32));
-    const input2 = Uint8Array.from(new Array<number>(32));
+    const input1 = new Uint8Array(32);
+    const input2 = new Uint8Array(32);
     hashObjectToByteArray(obj1, input1, 0);
     hashObjectToByteArray(obj2, input2, 0);
     return byteArrayToHashObject(hasher.digest64(input1, input2));
@@ -21,9 +21,9 @@ export const hasher: Hasher = {
       return [];
     }
     // size input array to 2 HashObject per computation * 32 bytes per object
-    const input: Uint8Array = Uint8Array.from(new Array(inputs.length * 32));
+    const input = new Uint8Array(inputs.length * 32);
     inputs.forEach((hashObject, i) => hashObjectToByteArray(hashObject, input, i * 32));
-    const result: Uint8Array = hash(input);
+    const result = hash(input);
     const outputs: HashObject[] = [];
     for (let i = 0; i < inputs.length / 2; i++) {
       const offset = i * 32;

--- a/packages/persistent-merkle-tree/src/hasher/hashtree.ts
+++ b/packages/persistent-merkle-tree/src/hasher/hashtree.ts
@@ -1,0 +1,1 @@
+// TODO - batch: use @chainsafe/hashtree

--- a/packages/persistent-merkle-tree/src/hasher/index.ts
+++ b/packages/persistent-merkle-tree/src/hasher/index.ts
@@ -7,9 +7,12 @@ export * from "./types";
 export * from "./util";
 
 /**
- * Hasher used across the SSZ codebase
+ * Default hasher used across the SSZ codebase, this does not support batch hash.
+ * Use `as-sha256` hasher for batch hashing using SIMD.
+ * TODO - batch: Use `hashtree` hasher for 20x speedup
  */
 // export let hasher: Hasher = nobleHasher;
+// For testing purposes, we use the as-sha256 hasher
 export let hasher: Hasher = csHasher;
 
 /**

--- a/packages/persistent-merkle-tree/src/hasher/index.ts
+++ b/packages/persistent-merkle-tree/src/hasher/index.ts
@@ -1,8 +1,8 @@
 import {Hasher} from "./types";
 // import {hasher as nobleHasher} from "./noble";
-import {hasher as csHasher} from "./as-sha256";
+// import {hasher as csHasher} from "./as-sha256";
+import {hasher as hashtreeHasher} from "./hashtree";
 
-export {HashObject} from "@chainsafe/as-sha256/lib/hashObject";
 export * from "./types";
 export * from "./util";
 
@@ -13,7 +13,10 @@ export * from "./util";
  */
 // export let hasher: Hasher = nobleHasher;
 // For testing purposes, we use the as-sha256 hasher
-export let hasher: Hasher = csHasher;
+// export let hasher: Hasher = csHasher;
+
+// For testing purposes, we use the hashtree hasher
+export let hasher: Hasher = hashtreeHasher;
 
 /**
  * Set the hasher to be used across the SSZ codebase

--- a/packages/persistent-merkle-tree/src/hasher/index.ts
+++ b/packages/persistent-merkle-tree/src/hasher/index.ts
@@ -1,5 +1,6 @@
 import {Hasher} from "./types";
-import {hasher as nobleHasher} from "./noble";
+// import {hasher as nobleHasher} from "./noble";
+import {hasher as csHasher} from "./as-sha256";
 
 export {HashObject} from "@chainsafe/as-sha256/lib/hashObject";
 export * from "./types";
@@ -8,7 +9,8 @@ export * from "./util";
 /**
  * Hasher used across the SSZ codebase
  */
-export let hasher: Hasher = nobleHasher;
+// export let hasher: Hasher = nobleHasher;
+export let hasher: Hasher = csHasher;
 
 /**
  * Set the hasher to be used across the SSZ codebase

--- a/packages/persistent-merkle-tree/src/hasher/noble.ts
+++ b/packages/persistent-merkle-tree/src/hasher/noble.ts
@@ -6,6 +6,7 @@ import {hashObjectToUint8Array, uint8ArrayToHashObject} from "./util";
 const digest64 = (a: Uint8Array, b: Uint8Array): Uint8Array => sha256.create().update(a).update(b).digest();
 
 export const hasher: Hasher = {
+  name: "noble",
   digest64,
   digest64HashObjects: (a, b) => uint8ArrayToHashObject(digest64(hashObjectToUint8Array(a), hashObjectToUint8Array(b))),
   batchHashObjects: (inputs: HashObject[]) => {

--- a/packages/persistent-merkle-tree/src/hasher/noble.ts
+++ b/packages/persistent-merkle-tree/src/hasher/noble.ts
@@ -7,7 +7,7 @@ const digest64 = (a: Uint8Array, b: Uint8Array): Uint8Array => sha256.create().u
 export const hasher: Hasher = {
   digest64,
   digest64HashObjects: (a, b) => uint8ArrayToHashObject(digest64(hashObjectToUint8Array(a), hashObjectToUint8Array(b))),
-  hash8HashObjects: () => {
-    throw Error("not implemented");
+  batchHash4HashObjectInputs: () => {
+    throw Error("TODO: not implemented");
   },
 };

--- a/packages/persistent-merkle-tree/src/hasher/noble.ts
+++ b/packages/persistent-merkle-tree/src/hasher/noble.ts
@@ -23,4 +23,17 @@ export const hasher: Hasher = {
     }
     return outputs;
   },
+  executeHashComputations: (hashComputations) => {
+    for (let level = hashComputations.length - 1; level >= 0; level--) {
+      const hcArr = hashComputations[level];
+      if (!hcArr) {
+        // should not happen
+        throw Error(`no hash computations for level ${level}`);
+      }
+
+      for (const hc of hcArr) {
+        hc.dest.applyHash(digest64HashObjects(hc.src0, hc.src1));
+      }
+    }
+  },
 };

--- a/packages/persistent-merkle-tree/src/hasher/noble.ts
+++ b/packages/persistent-merkle-tree/src/hasher/noble.ts
@@ -7,4 +7,7 @@ const digest64 = (a: Uint8Array, b: Uint8Array): Uint8Array => sha256.create().u
 export const hasher: Hasher = {
   digest64,
   digest64HashObjects: (a, b) => uint8ArrayToHashObject(digest64(hashObjectToUint8Array(a), hashObjectToUint8Array(b))),
+  hash8HashObjects: () => {
+    throw Error("not implemented");
+  },
 };

--- a/packages/persistent-merkle-tree/src/hasher/noble.ts
+++ b/packages/persistent-merkle-tree/src/hasher/noble.ts
@@ -1,4 +1,5 @@
 import {sha256} from "@noble/hashes/sha256";
+import {digest64HashObjects, HashObject} from "@chainsafe/as-sha256";
 import type {Hasher} from "./types";
 import {hashObjectToUint8Array, uint8ArrayToHashObject} from "./util";
 
@@ -7,7 +8,19 @@ const digest64 = (a: Uint8Array, b: Uint8Array): Uint8Array => sha256.create().u
 export const hasher: Hasher = {
   digest64,
   digest64HashObjects: (a, b) => uint8ArrayToHashObject(digest64(hashObjectToUint8Array(a), hashObjectToUint8Array(b))),
-  batchHash4HashObjectInputs: () => {
-    throw Error("TODO: not implemented");
+  batchHashObjects: (inputs: HashObject[]) => {
+    // noble does not support batch hash
+    if (inputs.length === 0) {
+      return [];
+    } else if (inputs.length % 2 !== 0) {
+      throw new Error(`Expect inputs.length to be even, got ${inputs.length}`);
+    }
+
+    const outputs = new Array<HashObject>();
+    for (let i = 0; i < inputs.length; i += 2) {
+      const output = digest64HashObjects(inputs[i], inputs[i + 1]);
+      outputs.push(output);
+    }
+    return outputs;
   },
 };

--- a/packages/persistent-merkle-tree/src/hasher/types.ts
+++ b/packages/persistent-merkle-tree/src/hasher/types.ts
@@ -9,4 +9,5 @@ export type Hasher = {
    * Hash two 32-byte HashObjects
    */
   digest64HashObjects(a: HashObject, b: HashObject): HashObject;
+  hash8HashObjects(inputs: HashObject[]): HashObject[];
 };

--- a/packages/persistent-merkle-tree/src/hasher/types.ts
+++ b/packages/persistent-merkle-tree/src/hasher/types.ts
@@ -4,6 +4,8 @@ import {HashComputation} from "../node";
 export type {HashObject};
 
 export type Hasher = {
+  // name of the hashing library
+  name: string;
   /**
    * Hash two 32-byte Uint8Arrays
    */

--- a/packages/persistent-merkle-tree/src/hasher/types.ts
+++ b/packages/persistent-merkle-tree/src/hasher/types.ts
@@ -9,5 +9,5 @@ export type Hasher = {
    * Hash two 32-byte HashObjects
    */
   digest64HashObjects(a: HashObject, b: HashObject): HashObject;
-  hash8HashObjects(inputs: HashObject[]): HashObject[];
+  batchHash4HashObjectInputs(inputs: HashObject[]): HashObject[];
 };

--- a/packages/persistent-merkle-tree/src/hasher/types.ts
+++ b/packages/persistent-merkle-tree/src/hasher/types.ts
@@ -9,5 +9,8 @@ export type Hasher = {
    * Hash two 32-byte HashObjects
    */
   digest64HashObjects(a: HashObject, b: HashObject): HashObject;
-  batchHash4HashObjectInputs(inputs: HashObject[]): HashObject[];
+  /**
+   * Batch hash 2 * n HashObjects, return n HashObjects output
+   */
+  batchHashObjects(inputs: HashObject[]): HashObject[];
 };

--- a/packages/persistent-merkle-tree/src/hasher/types.ts
+++ b/packages/persistent-merkle-tree/src/hasher/types.ts
@@ -1,4 +1,5 @@
 import type {HashObject} from "@chainsafe/as-sha256/lib/hashObject";
+import {HashComputation} from "../node";
 
 export type Hasher = {
   /**
@@ -13,4 +14,8 @@ export type Hasher = {
    * Batch hash 2 * n HashObjects, return n HashObjects output
    */
   batchHashObjects(inputs: HashObject[]): HashObject[];
+  /**
+   * Execute a batch of HashComputations
+   */
+  executeHashComputations(hashComputations: Array<HashComputation[]>): void;
 };

--- a/packages/persistent-merkle-tree/src/hasher/types.ts
+++ b/packages/persistent-merkle-tree/src/hasher/types.ts
@@ -1,6 +1,8 @@
 import type {HashObject} from "@chainsafe/as-sha256/lib/hashObject";
 import {HashComputation} from "../node";
 
+export type {HashObject};
+
 export type Hasher = {
   /**
    * Hash two 32-byte Uint8Arrays

--- a/packages/persistent-merkle-tree/src/node.ts
+++ b/packages/persistent-merkle-tree/src/node.ts
@@ -395,7 +395,6 @@ export function bitwiseOrNodeH(node: Node, hIndex: number, value: number): void 
   else throw Error("hIndex > 7");
 }
 
-
 export function getHashComputations(node: Node, offset: number, hashCompsByLevel: Array<HashComputation[]>): void {
   if (node.h0 === null) {
     const hashComputations = arrayAtIndex(hashCompsByLevel, offset);
@@ -409,6 +408,10 @@ export function getHashComputations(node: Node, offset: number, hashCompsByLevel
   }
 
   // else stop the recursion, LeafNode should have h0
+}
+
+export function executeHashComputations(hashComputations: Array<HashComputation[]>): void {
+  hasher.executeHashComputations(hashComputations);
 }
 
 export function arrayAtIndex<T>(twoDArray: Array<T[]>, index: number): T[] {

--- a/packages/persistent-merkle-tree/src/node.ts
+++ b/packages/persistent-merkle-tree/src/node.ts
@@ -84,9 +84,7 @@ export class BranchNode extends Node {
   }
 
   batchHash(): Uint8Array {
-    const hashComputations: HashComputation[][] = [];
-    getHashComputations(this, 0, hashComputations);
-    executeHashComputations(hashComputations);
+    executeHashComputations(this.hashComputations);
 
     if (this.h0 === null) {
       throw Error("Root is not computed by batch");
@@ -115,6 +113,12 @@ export class BranchNode extends Node {
 
   get right(): Node {
     return this._right;
+  }
+
+  get hashComputations(): HashComputation[][] {
+    const hashComputations: HashComputation[][] = [];
+    getHashComputations(this, 0, hashComputations);
+    return hashComputations;
   }
 }
 

--- a/packages/persistent-merkle-tree/src/node.ts
+++ b/packages/persistent-merkle-tree/src/node.ts
@@ -3,7 +3,7 @@ import {hashObjectToUint8Array, hasher, uint8ArrayToHashObject} from "./hasher";
 
 const TWO_POWER_32 = 2 ** 32;
 
-type HashComputation = {
+export type HashComputation = {
   src0: Node;
   src1: Node;
   dest: Node;
@@ -76,7 +76,7 @@ export class BranchNode extends Node {
     }
   }
 
-  // TODO: private, unit tests
+  // TODO: private, unit tests, use Array[HashComputation[]] for better performance
   getHashComputation(level: number, hashCompsByLevel: Map<number, HashComputation[]>): void {
     if (this.h0 === null) {
       let hashComputations = hashCompsByLevel.get(level);

--- a/packages/persistent-merkle-tree/src/node.ts
+++ b/packages/persistent-merkle-tree/src/node.ts
@@ -402,13 +402,11 @@ export function bitwiseOrNodeH(node: Node, hIndex: number, value: number): void 
 export function getHashComputations(node: Node, offset: number, hashCompsByLevel: Array<HashComputation[]>): void {
   if (node.h0 === null) {
     const hashComputations = arrayAtIndex(hashCompsByLevel, offset);
-    hashComputations.push({src0: node.left, src1: node.right, dest: node});
-    if (!node.left.isLeaf()) {
-      getHashComputations(node.left, offset + 1, hashCompsByLevel);
-    }
-    if (!node.right.isLeaf()) {
-      getHashComputations(node.right, offset + 1, hashCompsByLevel);
-    }
+    const {left, right} = node;
+    hashComputations.push({src0: left, src1: right, dest: node});
+    // leaf nodes should have h0 to stop the recursion
+    getHashComputations(left, offset + 1, hashCompsByLevel);
+    getHashComputations(right, offset + 1, hashCompsByLevel);
   }
 
   // else stop the recursion, LeafNode should have h0

--- a/packages/persistent-merkle-tree/src/node.ts
+++ b/packages/persistent-merkle-tree/src/node.ts
@@ -414,7 +414,7 @@ export function executeHashComputations(hashComputations: Array<HashComputation[
       const item2 = hcArr[i * 4 + 2];
       const item3 = hcArr[i * 4 + 3];
 
-      const [dest0, dest1, dest2, dest3] = hasher.hash8HashObjects([
+      const [dest0, dest1, dest2, dest3] = hasher.batchHash4HashObjectInputs([
         item0.src0,
         item0.src1,
         item1.src0,

--- a/packages/persistent-merkle-tree/src/node.ts
+++ b/packages/persistent-merkle-tree/src/node.ts
@@ -86,7 +86,7 @@ export class BranchNode extends Node {
   batchHash(): Uint8Array {
     const hashComputations: HashComputation[][] = [];
     getHashComputations(this, 0, hashComputations);
-    executeHashComputations(hashComputations);
+    hasher.executeHashComputations(hashComputations);
 
     if (this.h0 === null) {
       throw Error("Root is not computed by batch");
@@ -395,33 +395,6 @@ export function bitwiseOrNodeH(node: Node, hIndex: number, value: number): void 
   else throw Error("hIndex > 7");
 }
 
-/**
- * Given an array of HashComputation, execute them from the end
- * The consumer has the root node so it should be able to get the final root from there
- */
-export function executeHashComputations(hashComputations: Array<HashComputation[]>): void {
-  for (let level = hashComputations.length - 1; level >= 0; level--) {
-    const hcArr = hashComputations[level];
-    if (!hcArr) {
-      // should not happen
-      throw Error(`no hash computations for level ${level}`);
-    }
-    // HashComputations of the same level are safe to batch
-    const inputs: HashObject[] = [];
-    const dests: Node[] = [];
-    for (const {src0, src1, dest} of hcArr) {
-      inputs.push(src0, src1);
-      dests.push(dest);
-    }
-    const outputs = hasher.batchHashObjects(inputs);
-    if (outputs.length !== dests.length) {
-      throw Error(`${inputs.length} inputs produce ${outputs.length} outputs, expected ${dests.length} outputs`);
-    }
-    for (let i = 0; i < outputs.length; i++) {
-      dests[i].applyHash(outputs[i]);
-    }
-  }
-}
 
 export function getHashComputations(node: Node, offset: number, hashCompsByLevel: Array<HashComputation[]>): void {
   if (node.h0 === null) {

--- a/packages/persistent-merkle-tree/src/node.ts
+++ b/packages/persistent-merkle-tree/src/node.ts
@@ -86,7 +86,7 @@ export class BranchNode extends Node {
   batchHash(): Uint8Array {
     const hashComputations: HashComputation[][] = [];
     getHashComputations(this, 0, hashComputations);
-    hasher.executeHashComputations(hashComputations);
+    executeHashComputations(hashComputations);
 
     if (this.h0 === null) {
       throw Error("Root is not computed by batch");

--- a/packages/persistent-merkle-tree/src/subtree.ts
+++ b/packages/persistent-merkle-tree/src/subtree.ts
@@ -1,4 +1,4 @@
-import {BranchNode, Node} from "./node";
+import {BranchNode, HashComputationGroup, Node, arrayAtIndex, getHashComputations} from "./node";
 import {zeroNode} from "./zeroNode";
 
 export function subtreeFillToDepth(bottom: Node, depth: number): Node {
@@ -37,9 +37,16 @@ export function subtreeFillToLength(bottom: Node, depth: number, length: number)
 
 /**
  * WARNING: Mutates the provided nodes array.
+ * @param hashCompRootNode is a hacky way from ssz to set `dest` of HashComputation for BranchNodeStruct
  * TODO: Don't mutate the nodes array.
+ * TODO - batch: check consumers of this function, can we compute HashComputationGroup when deserializing ViewDU from Uint8Array?
  */
-export function subtreeFillToContents(nodes: Node[], depth: number): Node {
+export function subtreeFillToContents(
+  nodes: Node[],
+  depth: number,
+  hashComps: HashComputationGroup | null = null,
+  hashCompRootNode: Node | null = null
+): Node {
   const maxLength = 2 ** depth;
   if (nodes.length > maxLength) {
     throw new Error(`nodes.length ${nodes.length} over maxIndex at depth ${depth}`);
@@ -50,15 +57,33 @@ export function subtreeFillToContents(nodes: Node[], depth: number): Node {
   }
 
   if (depth === 0) {
-    return nodes[0];
+    const node = nodes[0];
+    if (hashComps !== null) {
+      // only use hashCompRootNode for >=1 nodes where we have a rebind
+      getHashComputations(node, hashComps.offset, hashComps.byLevel);
+    }
+    return node;
   }
 
   if (depth === 1) {
-    return nodes.length > 1
-      ? // All nodes at depth 1 available
-        new BranchNode(nodes[0], nodes[1])
-      : // Pad with zero node
-        new BranchNode(nodes[0], zeroNode(0));
+    // All nodes at depth 1 available
+    // If there is only one node, pad with zero node
+    const leftNode = nodes[0];
+    const rightNode = nodes.length > 1 ? nodes[1] : zeroNode(0);
+    const rootNode = new BranchNode(leftNode, rightNode);
+
+    if (hashComps !== null) {
+      const offset = hashComps.offset;
+      getHashComputations(leftNode, offset + 1, hashComps.byLevel);
+      getHashComputations(rightNode, offset + 1, hashComps.byLevel);
+      arrayAtIndex(hashComps.byLevel, offset).push({
+        src0: leftNode,
+        src1: rightNode,
+        dest: hashCompRootNode ?? rootNode,
+      });
+    }
+
+    return rootNode;
   }
 
   let count = nodes.length;
@@ -66,14 +91,43 @@ export function subtreeFillToContents(nodes: Node[], depth: number): Node {
   for (let d = depth; d > 0; d--) {
     const countRemainder = count % 2;
     const countEven = count - countRemainder;
+    const offset = hashComps ? hashComps.offset + d - 1 : null;
 
     // For each depth level compute the new BranchNodes and overwrite the nodes array
     for (let i = 0; i < countEven; i += 2) {
-      nodes[i / 2] = new BranchNode(nodes[i], nodes[i + 1]);
+      const left = nodes[i];
+      const right = nodes[i + 1];
+      const node = new BranchNode(left, right);
+      nodes[i / 2] = node;
+      if (offset !== null && hashComps !== null) {
+        arrayAtIndex(hashComps.byLevel, offset).push({
+          src0: left,
+          src1: right,
+          // d = 1 means we are at root node, use hashCompRootNode if possible
+          dest: d === 1 ? hashCompRootNode ?? node : node,
+        });
+        if (d === depth) {
+          // bottom up strategy so we don't need to go down the tree except for the last level
+          getHashComputations(left, offset + 1, hashComps.byLevel);
+          getHashComputations(right, offset + 1, hashComps.byLevel);
+        }
+      }
     }
 
     if (countRemainder > 0) {
-      nodes[countEven / 2] = new BranchNode(nodes[countEven], zeroNode(depth - d));
+      const left = nodes[countEven];
+      const right = zeroNode(depth - d);
+      const node = new BranchNode(left, right);
+      nodes[countEven / 2] = node;
+      if (offset !== null && hashComps !== null) {
+        if (d === depth) {
+          // only go down on the last level
+          getHashComputations(left, offset + 1, hashComps.byLevel);
+        }
+        // no need to getHashComputations for zero node
+        // no need to set hashCompRootNode here
+        arrayAtIndex(hashComps.byLevel, offset).push({src0: left, src1: right, dest: node});
+      }
     }
 
     // If there was remainer, 2 nodes are added to the count

--- a/packages/persistent-merkle-tree/src/tree.ts
+++ b/packages/persistent-merkle-tree/src/tree.ts
@@ -73,6 +73,13 @@ export class Tree {
     return this.rootNode.root;
   }
 
+  batchHash(): Uint8Array {
+    if (!this.rootNode.isLeaf()) {
+      return (this.rootNode as BranchNode).batchHash();
+    }
+    return this.root;
+  }
+
   /**
    * Return a copy of the tree
    */

--- a/packages/persistent-merkle-tree/src/tree.ts
+++ b/packages/persistent-merkle-tree/src/tree.ts
@@ -782,6 +782,47 @@ export function findDiffDepthi(from: number, to: number): number {
 }
 
 /**
+ * depth depthi   gindexes   indexes
+ * 0     1           1          0
+ * 1     0         2   3      0   1
+ * 2     -        4 5 6 7    0 1 2 3
+ *
+ * **Conditions**:
+ * - `from` and `to` must not be equal
+ *
+ * @param from Index
+ * @param to Index
+ */
+const NUMBER_32_MAX = 0xffffffff;
+export function findDiffDepthi(from: number, to: number): number {
+  if (from === to || from < 0 || to < 0) {
+    throw Error(`Expect different positive inputs, from=${from} to=${to}`);
+  }
+  // 0 -> 0, 1 -> 1, 2 -> 2, 3 -> 2, 4 -> 3
+  const numBits0 = from > 0 ? Math.ceil(Math.log2(from + 1)) : 0;
+  const numBits1 = to > 0 ? Math.ceil(Math.log2(to + 1)) : 0;
+
+  // these indexes stay in 2 sides of a merkle tree
+  if (numBits0 !== numBits1) {
+    // Must offset by one to match the depthi scale
+    return Math.max(numBits0, numBits1) - 1;
+  }
+
+  // same number of bits
+  if (numBits0 > 32) {
+    const highBits0 = Math.floor(from / NUMBER_32_MAX);
+    const highBits1 = Math.floor(to / NUMBER_32_MAX);
+    if (highBits0 === highBits1) {
+      // different part is just low bits
+      return findDiffDepthi32Bits(from & NUMBER_32_MAX, to & NUMBER_32_MAX);
+    }
+    return 32 + findDiffDepthi32Bits(highBits0, highBits1);
+  }
+
+  return findDiffDepthi32Bits(from, to);
+}
+
+/**
  * Returns true if the `index` at `depth` is a left node, false if it is a right node.
  *
  * Supports index up to `Number.MAX_SAFE_INTEGER`.

--- a/packages/persistent-merkle-tree/src/tree.ts
+++ b/packages/persistent-merkle-tree/src/tree.ts
@@ -1,6 +1,6 @@
 import {zeroNode} from "./zeroNode";
 import {Gindex, GindexBitstring, convertGindexToBitstring} from "./gindex";
-import {Node, LeafNode, BranchNode} from "./node";
+import {Node, LeafNode, BranchNode, HashComputation} from "./node";
 import {createNodeFromProof, createProof, Proof, ProofInput} from "./proof";
 import {createSingleProof} from "./proof/single";
 
@@ -341,8 +341,15 @@ export function setNodeAtDepth(rootNode: Node, nodesDepth: number, index: number
  * gindex and navigate upwards creating or caching nodes as necessary. Loop and repeat.
  *
  * Supports index up to `Number.MAX_SAFE_INTEGER`.
+ * TODO: add offset to consume from ssz
  */
-export function setNodesAtDepth(rootNode: Node, nodesDepth: number, indexes: number[], nodes: Node[]): Node {
+export function setNodesAtDepth(
+  rootNode: Node,
+  nodesDepth: number,
+  indexes: number[],
+  nodes: Node[],
+  hashCompsByLevel: Array<HashComputation[]> | null = null
+): Node {
   // depth depthi   gindexes   indexes
   // 0     1           1          0
   // 1     0         2   3      0   1
@@ -426,13 +433,26 @@ export function setNodesAtDepth(rootNode: Node, nodesDepth: number, indexes: num
       // Next node is the very next to the right of current node
       if (index + 1 === indexes[i + 1]) {
         node = new BranchNode(nodes[i], nodes[i + 1]);
+        if (hashCompsByLevel != null) {
+          // go with level of dest node (level 0 goes with root node)
+          // in this case dest node is nodesDept - 2, same for below
+          hashCompsByLevel[nodesDepth - 1].push({src0: nodes[i], src1: nodes[i + 1], dest: node});
+        }
         // Move pointer one extra forward since node has consumed two nodes
         i++;
       } else {
-        node = new BranchNode(nodes[i], node.right);
+        const oldNode = node;
+        node = new BranchNode(nodes[i], oldNode.right);
+        if (hashCompsByLevel != null) {
+          hashCompsByLevel[nodesDepth - 1].push({src0: nodes[i], src1: oldNode.right, dest: node});
+        }
       }
     } else {
-      node = new BranchNode(node.left, nodes[i]);
+      const oldNode = node;
+      node = new BranchNode(oldNode.left, nodes[i]);
+      if (hashCompsByLevel != null) {
+        hashCompsByLevel[nodesDepth - 1].push({src0: oldNode.left, src1: nodes[i], dest: node});
+      }
     }
 
     // Here `node` is the new BranchNode at depthi `depthiParent`
@@ -463,11 +483,19 @@ export function setNodesAtDepth(rootNode: Node, nodesDepth: number, indexes: num
     for (let d = depthiParent + 1; d <= diffDepthi; d++) {
       // If node is on the left, store for latter
       // If node is on the right merge with stored left node
+      const depth = nodesDepth - d - 1;
+      if (depth < 0) {
+        throw Error(`Invalid depth ${depth}, d=${d}, nodesDepth=${nodesDepth}`);
+      }
       if (isLeftNode(d, index)) {
         if (isLastIndex || d !== diffDepthi) {
           // If it's last index, bind with parent since it won't navigate to the right anymore
           // Also, if still has to move upwards, rebind since the node won't be visited anymore
-          node = new BranchNode(node, parentNodeStack[d].right);
+          const oldNode = node;
+          node = new BranchNode(oldNode, parentNodeStack[d].right);
+          if (hashCompsByLevel != null) {
+            hashCompsByLevel[depth].push({src0: oldNode, src1: parentNodeStack[d].right, dest: node});
+          }
         } else {
           // Only store the left node if it's at d = diffDepth
           leftParentNodeStack[d] = node;
@@ -477,10 +505,18 @@ export function setNodesAtDepth(rootNode: Node, nodesDepth: number, indexes: num
         const leftNode = leftParentNodeStack[d];
 
         if (leftNode !== undefined) {
-          node = new BranchNode(leftNode, node);
+          const oldNode = node;
+          node = new BranchNode(leftNode, oldNode);
+          if (hashCompsByLevel != null) {
+            hashCompsByLevel[depth].push({src0: leftNode, src1: oldNode, dest: node});
+          }
           leftParentNodeStack[d] = undefined;
         } else {
-          node = new BranchNode(parentNodeStack[d].left, node);
+          const oldNode = node;
+          node = new BranchNode(parentNodeStack[d].left, oldNode);
+          if (hashCompsByLevel != null) {
+            hashCompsByLevel[depth].push({src0: parentNodeStack[d].left, src1: oldNode, dest: node});
+          }
         }
       }
     }

--- a/packages/persistent-merkle-tree/src/tree.ts
+++ b/packages/persistent-merkle-tree/src/tree.ts
@@ -799,46 +799,6 @@ export function findDiffDepthi(from: number, to: number): number {
   return findDiffDepthi32Bits(from, to);
 }
 
-/**
- * depth depthi   gindexes   indexes
- * 0     1           1          0
- * 1     0         2   3      0   1
- * 2     -        4 5 6 7    0 1 2 3
- *
- * **Conditions**:
- * - `from` and `to` must not be equal
- *
- * @param from Index
- * @param to Index
- */
-const NUMBER_32_MAX = 0xffffffff;
-export function findDiffDepthi(from: number, to: number): number {
-  if (from === to || from < 0 || to < 0) {
-    throw Error(`Expect different positive inputs, from=${from} to=${to}`);
-  }
-  // 0 -> 0, 1 -> 1, 2 -> 2, 3 -> 2, 4 -> 3
-  const numBits0 = from > 0 ? Math.ceil(Math.log2(from + 1)) : 0;
-  const numBits1 = to > 0 ? Math.ceil(Math.log2(to + 1)) : 0;
-
-  // these indexes stay in 2 sides of a merkle tree
-  if (numBits0 !== numBits1) {
-    // Must offset by one to match the depthi scale
-    return Math.max(numBits0, numBits1) - 1;
-  }
-
-  // same number of bits
-  if (numBits0 > 32) {
-    const highBits0 = Math.floor(from / NUMBER_32_MAX);
-    const highBits1 = Math.floor(to / NUMBER_32_MAX);
-    if (highBits0 === highBits1) {
-      // different part is just low bits
-      return findDiffDepthi32Bits(from & NUMBER_32_MAX, to & NUMBER_32_MAX);
-    }
-    return 32 + findDiffDepthi32Bits(highBits0, highBits1);
-  }
-
-  return findDiffDepthi32Bits(from, to);
-}
 
 /**
  * Returns true if the `index` at `depth` is a left node, false if it is a right node.

--- a/packages/persistent-merkle-tree/src/zeroNode.ts
+++ b/packages/persistent-merkle-tree/src/zeroNode.ts
@@ -19,6 +19,11 @@ export function zeroNode(height: number): Node {
     for (let i = zeroes.length; i <= height; i++) {
       zeroes[i] = new BranchNode(zeroes[i - 1], zeroes[i - 1]);
     }
+
+    // make sure hash is precomputed in order not to put zeroNodes to HashComputation
+    // otherwise get OOM
+    zeroes[height].root;
   }
+
   return zeroes[height];
 }

--- a/packages/persistent-merkle-tree/test/perf/hasher.test.ts
+++ b/packages/persistent-merkle-tree/test/perf/hasher.test.ts
@@ -44,7 +44,7 @@ describe("hasher", function () {
       });
 
       itBench({
-        id: `batchHash - ${hasher.name}`,
+        id: `batchHashObjects - ${hasher.name}`,
         fn: () => {
           hasher.batchHashObjects(hashObjects);
         },

--- a/packages/persistent-merkle-tree/test/perf/hasher.test.ts
+++ b/packages/persistent-merkle-tree/test/perf/hasher.test.ts
@@ -8,9 +8,7 @@ import {buildComparisonTrees} from "../utils/tree";
 describe("hasher", function () {
   this.timeout(0);
 
-  // total number of time running hash for 250_000 validators
-  // const iterations = 2_250_026;
-  const iterations = 1_000_000;
+  const iterations = 500_000;
 
   const root1 = new Uint8Array(32);
   const root2 = new Uint8Array(32);
@@ -20,8 +18,6 @@ describe("hasher", function () {
   for (let i = 0; i < root2.length; i++) {
     root2[i] = 2;
   }
-
-  const [tree] = buildComparisonTrees(16);
 
   const hashObjects: HashObject[] = [];
   for (let i = 0; i < iterations; i++) {
@@ -56,7 +52,11 @@ describe("hasher", function () {
 
       itBench({
         id: `executeHashComputations - ${hasher.name}`,
-        fn: () => {
+        beforeEach: () => {
+          const [tree] = buildComparisonTrees(16);
+          return tree;
+        },
+        fn: (tree) => {
           hasher.executeHashComputations(tree.hashComputations);
         },
       });

--- a/packages/persistent-merkle-tree/test/perf/hasher.test.ts
+++ b/packages/persistent-merkle-tree/test/perf/hasher.test.ts
@@ -31,3 +31,5 @@ describe("hasher", () => {
     });
   }
 });
+
+// TODO - batch: test more methods

--- a/packages/persistent-merkle-tree/test/perf/hasher.test.ts
+++ b/packages/persistent-merkle-tree/test/perf/hasher.test.ts
@@ -2,8 +2,11 @@ import {itBench} from "@dapplion/benchmark";
 import {uint8ArrayToHashObject} from "../../src/hasher";
 import {hasher as asShaHasher} from "../../src/hasher/as-sha256";
 import {hasher as nobleHasher} from "../../src/hasher/noble";
+import {hasher as hashtreeHasher} from "../../src/hasher/hashtree";
+import {buildComparisonTrees} from "../utils/tree";
 
-describe("hasher", () => {
+describe("hasher", function () {
+  this.timeout(0);
   const root1 = new Uint8Array(32);
   const root2 = new Uint8Array(32);
   for (let i = 0; i < root1.length; i++) {
@@ -13,21 +16,38 @@ describe("hasher", () => {
     root2[i] = 2;
   }
 
+  const [tree] = buildComparisonTrees(16);
+
   // total number of time running hash for 250_000 validators
-  const iterations = 2250026;
+  // const iterations = 2_250_026;
+  const iterations = 1_000_000;
 
-  for (const {hasher, name} of [
-    {hasher: asShaHasher, name: "as-sha256"},
-    {hasher: nobleHasher, name: "noble"},
-  ]) {
-    itBench(`hash 2 Uint8Array ${iterations} times - ${name}`, () => {
-      for (let j = 0; j < iterations; j++) hasher.digest64(root1, root2);
-    });
+  for (const hasher of [asShaHasher, nobleHasher, hashtreeHasher]) {
+    describe(hasher.name, () => {
+      itBench(`hash 2 Uint8Array ${iterations} times - ${hasher.name}`, () => {
+        for (let j = 0; j < iterations; j++) hasher.digest64(root1, root2);
+      });
 
-    const obj1 = uint8ArrayToHashObject(root1);
-    const obj2 = uint8ArrayToHashObject(root2);
-    itBench(`hashTwoObjects ${iterations} times - ${name}`, () => {
-      for (let j = 0; j < iterations; j++) hasher.digest64HashObjects(obj1, obj2);
+      itBench({
+        id: `hashTwoObjects ${iterations} times - ${hasher.name}`,
+        before: () => ({
+          obj1: uint8ArrayToHashObject(root1),
+          obj2: uint8ArrayToHashObject(root2),
+        }),
+        beforeEach: (params) => params,
+        fn: ({obj1, obj2}) => {
+          for (let j = 0; j < iterations; j++) hasher.digest64HashObjects(obj1, obj2);
+        },
+      });
+
+      // itBench(`batchHash - ${hasher.name}`, () => {});
+
+      itBench({
+        id: `executeHashComputations - ${hasher.name}`,
+        fn: () => {
+          hasher.executeHashComputations(tree.hashComputations);
+        },
+      });
     });
   }
 });

--- a/packages/persistent-merkle-tree/test/perf/node.test.ts
+++ b/packages/persistent-merkle-tree/test/perf/node.test.ts
@@ -43,15 +43,12 @@ describe("HashObject LeafNode", () => {
 });
 
 describe("Node batchHash", () => {
-  const numNodes = [250_000, 500_000, 1_000_000, 2_000_000];
+  const numNodes = [250_000, 500_000, 1_000_000];
 
   for (const numNode of numNodes) {
     itBench({
       id: `batchHash ${numNode} nodes`,
-      before: () => {
-        return createList(numNode);
-      },
-      beforeEach: (rootNode: BranchNode) => rootNode,
+      beforeEach: () => createList(numNode),
       fn: (rootNode: BranchNode) => {
         rootNode.batchHash();
       },
@@ -59,10 +56,7 @@ describe("Node batchHash", () => {
 
     itBench({
       id: `get root ${numNode} nodes`,
-      before: () => {
-        return createList(numNode);
-      },
-      beforeEach: (rootNode: BranchNode) => rootNode,
+      beforeEach: () => createList(numNode),
       fn: (rootNode: BranchNode) => {
         rootNode.root;
       },

--- a/packages/persistent-merkle-tree/test/perf/node.test.ts
+++ b/packages/persistent-merkle-tree/test/perf/node.test.ts
@@ -1,5 +1,5 @@
 import {itBench} from "@dapplion/benchmark";
-import {BranchNode, getNodeH, LeafNode} from "../../src/node";
+import {BranchNode, getHashComputations, getNodeH, HashComputation, LeafNode} from "../../src/node";
 import {countToDepth, subtreeFillToContents} from "../../src";
 
 describe("HashObject LeafNode", () => {
@@ -46,6 +46,15 @@ describe("Node batchHash", () => {
   const numNodes = [250_000, 500_000, 1_000_000];
 
   for (const numNode of numNodes) {
+    itBench({
+      id: `getHashComputations ${numNode} nodes`,
+      beforeEach: () => createList(numNode),
+      fn: (rootNode: BranchNode) => {
+        const hashComputations: HashComputation[][] = [];
+        getHashComputations(rootNode, 0, hashComputations);
+      },
+    });
+
     itBench({
       id: `batchHash ${numNode} nodes`,
       beforeEach: () => createList(numNode),

--- a/packages/persistent-merkle-tree/test/perf/node.test.ts
+++ b/packages/persistent-merkle-tree/test/perf/node.test.ts
@@ -1,5 +1,6 @@
 import {itBench} from "@dapplion/benchmark";
-import {getNodeH, LeafNode} from "../../src/node";
+import {BranchNode, getNodeH, LeafNode} from "../../src/node";
+import {countToDepth, subtreeFillToContents} from "../../src";
 
 describe("HashObject LeafNode", () => {
   // Number of new nodes created in processAttestations() on average
@@ -40,3 +41,43 @@ describe("HashObject LeafNode", () => {
     }
   });
 });
+
+describe("Node batchHash", () => {
+  const numNodes = [250_000, 500_000, 1_000_000, 2_000_000];
+
+  for (const numNode of numNodes) {
+    itBench({
+      id: `batchHash ${numNode} nodes`,
+      before: () => {
+        return createList(numNode);
+      },
+      beforeEach: (rootNode: BranchNode) => rootNode,
+      fn: (rootNode: BranchNode) => {
+        rootNode.batchHash();
+      },
+    });
+
+    itBench({
+      id: `get root ${numNode} nodes`,
+      before: () => {
+        return createList(numNode);
+      },
+      beforeEach: (rootNode: BranchNode) => rootNode,
+      fn: (rootNode: BranchNode) => {
+        rootNode.root;
+      },
+    });
+  }
+});
+
+function createList(numNode: number): BranchNode {
+  const nodes = Array.from({length: numNode}, (_, i) => newLeafNodeFilled(i));
+  // add 1 to countToDepth for mix_in_length spec
+  const depth = countToDepth(BigInt(numNode)) + 1;
+  const node = subtreeFillToContents(nodes, depth);
+  return node as BranchNode;
+}
+
+function newLeafNodeFilled(i: number): LeafNode {
+  return LeafNode.fromRoot(new Uint8Array(Array.from({length: 32}, () => i % 256)));
+}

--- a/packages/persistent-merkle-tree/test/perf/validators.test.ts
+++ b/packages/persistent-merkle-tree/test/perf/validators.test.ts
@@ -1,5 +1,13 @@
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
-import {BranchNode, LeafNode, subtreeFillToContents, Node, countToDepth, zeroNode} from "../../src";
+import {
+  BranchNode,
+  LeafNode,
+  subtreeFillToContents,
+  Node,
+  countToDepth,
+  zeroNode,
+  getHashComputations,
+} from "../../src";
 import {MemoryTracker} from "../utils/memTracker";
 
 /**
@@ -68,8 +76,7 @@ describe("Track the performance of validators", () => {
       return node;
     },
     fn: (node) => {
-      const hashComputationsByLevel = new Map();
-      (node as BranchNode).getHashComputation(0, hashComputationsByLevel);
+      (node as BranchNode).hashComputations;
     },
   });
 });

--- a/packages/persistent-merkle-tree/test/perf/validators.test.ts
+++ b/packages/persistent-merkle-tree/test/perf/validators.test.ts
@@ -1,66 +1,99 @@
-import {itBench} from "@dapplion/benchmark";
-import {BranchNode, LeafNode, subtreeFillToContents, Node, countToDepth} from "../../src";
+import {itBench, setBenchOpts} from "@dapplion/benchmark";
+import {BranchNode, LeafNode, subtreeFillToContents, Node, countToDepth, zeroNode} from "../../src";
 import {MemoryTracker} from "../utils/memTracker";
 
+/**
+ * Below is measured on Mac M1.
+ * It takes less than 10% of the original hashTreeRoot() time to traverse the tree.
+ * The remaining time depends on how better is the batch hash.
+ * Below it shows: `batchHash = 101ms + 0.81 * hash` where 101ms is the time to traverse and precompute hash computations by level
+ *   Track the performance of validators
+    ✓ 1600000 validators root getter                                     0.8134348 ops/s    1.229355  s/op        -         12 runs   16.4 s
+    ✓ 1600000 validators batchHash()                                     0.9135884 ops/s    1.094585  s/op        -         13 runs   15.8 s
+    ✓ 1600000 validators hashComputations                                 9.857173 ops/s    101.4490 ms/op        -         17 runs   2.90 s
+
+ * Refer to SIMD, it shows `batchHash = 0.81 * hash`
+      digest64 vs hash4Inputs vs hash8HashObjects
+    ✓ digest64 50023 times                                                27.09631 ops/s    36.90539 ms/op        -        259 runs   10.1 s
+    ✓ hash 200092 times using hash4Inputs                                 8.393366 ops/s    119.1417 ms/op        -         81 runs   10.2 s
+    ✓ hash 200092 times using hash8HashObjects                            8.433091 ops/s    118.5805 ms/op        -         81 runs   10.2 s
+ */
 describe("Track the performance of validators", () => {
+  setBenchOpts({
+    maxMs: 2 * 60 * 1000,
+  });
   if (global.gc) {
     global.gc();
   }
 
   const tracker = new MemoryTracker();
   tracker.logDiff("Start");
-  const node = createValidatorList(250_000);
+  // const vc = 250_000;
+  const vc = 1_600_000;
+  // see createValidatorList
+  const depth = countToDepth(BigInt(vc)) + 1;
+  // cache roots of zero nodes
+  zeroNode(depth).root;
+  const node = createValidatorList(vc);
   tracker.logDiff("Create validator tree");
   node.root;
   tracker.logDiff("Calculate tree root");
 
   itBench({
-    id: "250k validators",
+    id: `${vc} validators root getter`,
     beforeEach: () => {
-      resetNodes(node);
+      resetNodes(node, depth);
       return node;
     },
     fn: (node) => {
       node.root;
     },
   });
+
+  itBench({
+    id: `${vc} validators batchHash()`,
+    beforeEach: () => {
+      resetNodes(node, depth);
+      return node;
+    },
+    fn: (node) => {
+      (node as BranchNode).batchHash();
+    },
+  });
+
+  itBench({
+    id: `${vc} validators hashComputations`,
+    beforeEach: () => {
+      resetNodes(node, depth);
+      return node;
+    },
+    fn: (node) => {
+      const hashComputationsByLevel = new Map();
+      (node as BranchNode).getHashComputation(0, hashComputationsByLevel);
+    },
+  });
 });
 
-function resetNodes(node: Node): void {
+function resetNodes(node: Node, depth: number): void {
   if (node.isLeaf()) return;
+  // do not reset zeroNode
+  if (node === zeroNode(depth)) return;
   // this is to ask Node to calculate node again
   node.h0 = null as unknown as number;
-  // in the old version, we should do
-  // node._root = null;
-  resetNodes(node.left);
-  resetNodes(node.right);
+  resetNodes(node.left, depth - 1);
+  resetNodes(node.right, depth - 1);
 }
 
 function createValidator(i: number): Node {
-  const nodes: Node[] = [];
-  // pubkey, 48 bytes => 2 nodes
-  const pubkeyNode1 = newLeafNodeFilled(i);
-  const pubkeyNode2 = newLeafNodeFilled(i);
-  nodes.push(new BranchNode(pubkeyNode1, pubkeyNode2));
-  // withdrawalCredentials, 32 bytes => 1 node
-  nodes.push(newLeafNodeFilled(i));
-  // effectiveBalance, 8 bytes => 1 node
-  nodes.push(newLeafNodeFilled(i));
-  // slashed => 1 node
-  nodes.push(LeafNode.fromRoot(new Uint8Array(32)));
-  // 4 epoch nodes, 8 bytes => 1 node
-  nodes.push(newLeafNodeFilled(i));
-  nodes.push(newLeafNodeFilled(i));
-  nodes.push(newLeafNodeFilled(i));
-  nodes.push(newLeafNodeFilled(i));
-
-  return subtreeFillToContents(nodes, countToDepth(BigInt(nodes.length)));
+  return newLeafNodeFilled(i);
 }
 
 function createValidatorList(numValidator: number): Node {
   const validators = Array.from({length: numValidator}, (_, i) => createValidator(i));
   // add 1 to countToDepth for mix_in_length spec
-  return subtreeFillToContents(validators, countToDepth(BigInt(numValidator)) + 1);
+  const depth = countToDepth(BigInt(numValidator)) + 1;
+  const rootNode = subtreeFillToContents(validators, depth);
+  return rootNode;
 }
 
 function newLeafNodeFilled(i: number): LeafNode {

--- a/packages/persistent-merkle-tree/test/unit/batchHash.test.ts
+++ b/packages/persistent-merkle-tree/test/unit/batchHash.test.ts
@@ -5,8 +5,8 @@ import {subtreeFillToContents} from "../../src/subtree";
 import {zeroNode} from "../../src/zeroNode";
 
 describe("batchHash", function () {
-  // const numNodes = [200, 201, 202, 203];
-  const numNodes = [32, 33, 64];
+  const numNodes = [200, 201, 202, 203];
+  // const numNodes = [32, 33, 64];
   for (const numNode of numNodes) {
     it(`${numNode} nodes`, () => {
       const rootNode = createList(numNode);
@@ -36,7 +36,7 @@ function resetNodes(node: Node, depth: number): void {
 }
 
 function newLeafNodeFilled(i: number): LeafNode {
-  return LeafNode.fromRoot(new Uint8Array(Array.from({length: 32}, () => i % 255)));
+  return LeafNode.fromRoot(new Uint8Array(Array.from({length: 32}, () => i % 256)));
 }
 
 function createList(numNode: number): BranchNode {

--- a/packages/persistent-merkle-tree/test/unit/batchHash.test.ts
+++ b/packages/persistent-merkle-tree/test/unit/batchHash.test.ts
@@ -1,0 +1,48 @@
+import {expect} from "chai";
+import {countToDepth} from "../../src/gindex";
+import {BranchNode, LeafNode, Node} from "../../src/node";
+import {subtreeFillToContents} from "../../src/subtree";
+import {zeroNode} from "../../src/zeroNode";
+
+describe("batchHash", function () {
+  // const numNodes = [200, 201, 202, 203];
+  const numNodes = [32, 33, 64];
+  for (const numNode of numNodes) {
+    it(`${numNode} nodes`, () => {
+      const rootNode = createList(numNode);
+      const root1 = rootNode.batchHash();
+      const rootNode2 = createList(numNode);
+      const root2 = rootNode2.root;
+      expect(root2).to.be.deep.equal(root1);
+
+      const depth = countToDepth(BigInt(numNode)) + 1;
+      resetNodes(rootNode, depth);
+      resetNodes(rootNode2, depth);
+      expect(rootNode.batchHash()).to.be.deep.equal(rootNode2.batchHash());
+    });
+  }
+});
+
+function resetNodes(node: Node, depth: number): void {
+  if (node.isLeaf()) return;
+  // do not reset zeroNode
+  if (node === zeroNode(depth)) return;
+  // this is to ask Node to calculate node again
+  node.h0 = null as unknown as number;
+  // in the old version, we should do
+  // node._root = null;
+  resetNodes(node.left, depth - 1);
+  resetNodes(node.right, depth - 1);
+}
+
+function newLeafNodeFilled(i: number): LeafNode {
+  return LeafNode.fromRoot(new Uint8Array(Array.from({length: 32}, () => i % 255)));
+}
+
+function createList(numNode: number): BranchNode {
+  const nodes = Array.from({length: numNode}, (_, i) => newLeafNodeFilled(i));
+  // add 1 to countToDepth for mix_in_length spec
+  const depth = countToDepth(BigInt(numNode)) + 1;
+  const node = subtreeFillToContents(nodes, depth);
+  return node as BranchNode;
+}

--- a/packages/persistent-merkle-tree/test/unit/hasher.test.ts
+++ b/packages/persistent-merkle-tree/test/unit/hasher.test.ts
@@ -4,19 +4,9 @@ import {hasher as nobleHasher} from "../../src/hasher/noble";
 import {hasher as asSha256Hasher} from "../../src/hasher/as-sha256";
 import {hasher as hashtreeHasher} from "../../src/hasher/hashtree";
 import {linspace} from "../utils/misc";
-import {BranchNode, LeafNode} from "../../src/node";
-import {subtreeFillToContents} from "../../src";
+import {buildComparisonTrees} from "../utils/tree";
 
 const hashers = [hashtreeHasher, asSha256Hasher, nobleHasher];
-
-function buildComparisonTrees(depth: number): [BranchNode, BranchNode] {
-  const width = 2 ** (depth - 1);
-  const nodes = linspace(width).map((num) => LeafNode.fromRoot(Uint8Array.from(Buffer.alloc(32, num))));
-  const copy = nodes.map((node) => node.clone());
-  const branch1 = subtreeFillToContents(nodes, depth) as BranchNode;
-  const branch2 = subtreeFillToContents(copy, depth) as BranchNode;
-  return [branch1, branch2];
-}
 
 describe("hashers", function () {
   describe("digest64 vs digest64HashObjects methods should be the same", () => {

--- a/packages/persistent-merkle-tree/test/unit/hasher.test.ts
+++ b/packages/persistent-merkle-tree/test/unit/hasher.test.ts
@@ -64,7 +64,9 @@ describe("hashers", function () {
     for (const hasher of hashers) {
       it(hasher.name, () => {
         const [tree1, tree2] = buildComparisonTrees(8);
-        expectEqualHex(tree1.root, tree2.batchHash());
+        const hashComputations = tree2.hashComputations;
+        hasher.executeHashComputations(hashComputations);
+        expectEqualHex(tree1.root, tree2.root);
       });
     }
   });

--- a/packages/persistent-merkle-tree/test/unit/hasher.test.ts
+++ b/packages/persistent-merkle-tree/test/unit/hasher.test.ts
@@ -1,17 +1,82 @@
-import {expect} from "chai";
-import {uint8ArrayToHashObject, hasher, hashObjectToUint8Array} from "../../src/hasher";
+import {expectEqualHex} from "../utils/expectHex";
+import {uint8ArrayToHashObject, hashObjectToUint8Array} from "../../src/hasher/util";
+import {hasher as nobleHasher} from "../../src/hasher/noble";
+import {hasher as asSha256Hasher} from "../../src/hasher/as-sha256";
+import {hasher as hashtreeHasher} from "../../src/hasher/hashtree";
+import {linspace} from "../utils/misc";
+import {BranchNode, LeafNode} from "../../src/node";
+import {subtreeFillToContents} from "../../src";
 
-describe("hasher", function () {
-  it("hasher methods should be the same", () => {
-    const root1 = Buffer.alloc(32, 1);
-    const root2 = Buffer.alloc(32, 2);
-    const root = hasher.digest64(root1, root2);
+const hashers = [hashtreeHasher, asSha256Hasher, nobleHasher];
 
-    const obj1 = uint8ArrayToHashObject(root1);
-    const obj2 = uint8ArrayToHashObject(root2);
-    const obj = hasher.digest64HashObjects(obj1, obj2);
-    const newRoot = hashObjectToUint8Array(obj);
-    expect(newRoot).to.be.deep.equal(root, "hash and hash2 is not equal");
+function buildComparisonTrees(depth: number): [BranchNode, BranchNode] {
+  const width = 2 ** (depth - 1);
+  const nodes = linspace(width).map((num) => LeafNode.fromRoot(Uint8Array.from(Buffer.alloc(32, num))));
+  const copy = nodes.map((node) => node.clone());
+  const branch1 = subtreeFillToContents(nodes, depth) as BranchNode;
+  const branch2 = subtreeFillToContents(copy, depth) as BranchNode;
+  return [branch1, branch2];
+}
+
+describe("hashers", function () {
+  describe("digest64 vs digest64HashObjects methods should be the same", () => {
+    for (const hasher of hashers) {
+      it(`${hasher.name} hasher`, () => {
+        const root1 = Buffer.alloc(32, 1);
+        const root2 = Buffer.alloc(32, 2);
+        const root = hasher.digest64(root1, root2);
+
+        const obj1 = uint8ArrayToHashObject(root1);
+        const obj2 = uint8ArrayToHashObject(root2);
+        const obj = hasher.digest64HashObjects(obj1, obj2);
+        const newRoot = hashObjectToUint8Array(obj);
+        expectEqualHex(root, newRoot);
+      });
+    }
+  });
+
+  it("all hashers should return the same values from digest64", () => {
+    const root1 = Buffer.alloc(32, 0x01);
+    const root2 = Buffer.alloc(32, 0xff);
+    const hash1 = nobleHasher.digest64(root1, root2);
+    const hash2 = asSha256Hasher.digest64(root1, root2);
+    const hash3 = hashtreeHasher.digest64(root1, root2);
+    expectEqualHex(hash1, hash2);
+    expectEqualHex(hash1, hash3);
+  });
+
+  it("all hashers should return the same values from digest64HashObjects", () => {
+    const root1 = Buffer.alloc(32, 0x01);
+    const hashObject1 = uint8ArrayToHashObject(root1);
+    const root2 = Buffer.alloc(32, 0xff);
+    const hashObject2 = uint8ArrayToHashObject(root2);
+    const hash1 = hashObjectToUint8Array(nobleHasher.digest64HashObjects(hashObject1, hashObject2));
+    const hash2 = hashObjectToUint8Array(asSha256Hasher.digest64HashObjects(hashObject1, hashObject2));
+    const hash3 = hashObjectToUint8Array(hashtreeHasher.digest64HashObjects(hashObject1, hashObject2));
+    expectEqualHex(hash1, hash2);
+    expectEqualHex(hash1, hash3);
+  });
+
+  it("all hashers should return the same values from batchHashObjects", () => {
+    const hashObjects = linspace(254)
+      .map((num) => Buffer.alloc(32, num))
+      .map(uint8ArrayToHashObject);
+    const results1 = nobleHasher.batchHashObjects(hashObjects).map(hashObjectToUint8Array);
+    const results2 = asSha256Hasher.batchHashObjects(hashObjects).map(hashObjectToUint8Array);
+    const results3 = hashtreeHasher.batchHashObjects(hashObjects).map(hashObjectToUint8Array);
+    Object.values(results1).forEach((result1, i) => {
+      expectEqualHex(result1, results2[i]);
+      expectEqualHex(result1, results3[i]);
+    });
+  });
+
+  describe("all hashers should return the same values from executeHashComputations", () => {
+    for (const hasher of hashers) {
+      it(hasher.name, () => {
+        const [tree1, tree2] = buildComparisonTrees(8);
+        expectEqualHex(tree1.root, tree2.batchHash());
+      });
+    }
   });
 });
 

--- a/packages/persistent-merkle-tree/test/unit/hasher.test.ts
+++ b/packages/persistent-merkle-tree/test/unit/hasher.test.ts
@@ -1,4 +1,4 @@
-import { expect } from "chai";
+import {expect} from "chai";
 import {uint8ArrayToHashObject, hasher, hashObjectToUint8Array} from "../../src/hasher";
 
 describe("hasher", function () {
@@ -14,3 +14,5 @@ describe("hasher", function () {
     expect(newRoot).to.be.deep.equal(root, "hash and hash2 is not equal");
   });
 });
+
+// TODO - batch: test more methods

--- a/packages/persistent-merkle-tree/test/unit/tree.test.ts
+++ b/packages/persistent-merkle-tree/test/unit/tree.test.ts
@@ -12,6 +12,7 @@ import {
   findDiffDepthi,
   BranchNode,
   HashComputation,
+  findDiffDepthi,
 } from "../../src";
 
 describe("fixed-depth tree iteration", () => {

--- a/packages/persistent-merkle-tree/test/unit/tree.test.ts
+++ b/packages/persistent-merkle-tree/test/unit/tree.test.ts
@@ -10,6 +10,7 @@ import {
   uint8ArrayToHashObject,
   setNodesAtDepth,
   findDiffDepthi,
+  BranchNode,
 } from "../../src";
 
 describe("fixed-depth tree iteration", () => {
@@ -108,7 +109,7 @@ describe("Tree.setNode vs Tree.setHashObjectFn", () => {
     tree2.setNodeWithFn(BigInt(18), getNewNodeFn);
     tree2.setNodeWithFn(BigInt(46), getNewNodeFn);
     tree2.setNodeWithFn(BigInt(60), getNewNodeFn);
-    expect(toHex(tree2.root)).to.equal("02607e58782c912e2f96f4ff9daf494d0d115e7c37e8c2b7ddce17213591151b");
+    expect(toHex((tree2.rootNode as BranchNode).batchHash())).to.equal("02607e58782c912e2f96f4ff9daf494d0d115e7c37e8c2b7ddce17213591151b");
   });
 
   it("Should throw for gindex 0", () => {

--- a/packages/persistent-merkle-tree/test/unit/tree.test.ts
+++ b/packages/persistent-merkle-tree/test/unit/tree.test.ts
@@ -12,7 +12,6 @@ import {
   findDiffDepthi,
   BranchNode,
   HashComputation,
-  findDiffDepthi,
   getHashComputations,
 } from "../../src";
 

--- a/packages/persistent-merkle-tree/test/unit/tree.test.ts
+++ b/packages/persistent-merkle-tree/test/unit/tree.test.ts
@@ -142,8 +142,7 @@ describe("Tree batch setNodes", () => {
     {depth: 5, gindexes: [33, 34]},
     {depth: 10, gindexes: [1024, 1061, 1098, 1135, 1172, 1209, 1246, 1283]},
     {depth: 40, gindexes: [Math.pow(2, 40) + 1000, Math.pow(2, 40) + 1_000_000, Math.pow(2, 40) + 1_000_000_000]},
-    // TODO: make sure index < 0xffffffff for findDiffDepthi not to return NaN
-    // {depth: 40, gindexes: [1157505940782, 1349082402477, 1759777921993]},
+    {depth: 40, gindexes: [1157505940782, 1349082402477, 1759777921993]},
   ];
 
   for (const {depth, gindexes} of testCases) {

--- a/packages/persistent-merkle-tree/test/utils/expectHex.ts
+++ b/packages/persistent-merkle-tree/test/utils/expectHex.ts
@@ -1,0 +1,20 @@
+import {expect} from "chai";
+
+type BufferLike = string | Uint8Array | Buffer;
+
+export function toHexString(bytes: BufferLike): string {
+  if (typeof bytes === "string") return bytes;
+  if (bytes instanceof Buffer) return bytes.toString("hex");
+  if (bytes instanceof Uint8Array) return Buffer.from(bytes).toString("hex");
+  throw Error("toHexString only accepts BufferLike types");
+}
+
+export function toHex(bytes: BufferLike): string {
+  const hex = toHexString(bytes);
+  if (hex.startsWith("0x")) return hex;
+  return "0x" + hex;
+}
+
+export function expectEqualHex(value: BufferLike, expected: BufferLike): void {
+  expect(toHex(value)).to.be.equal(toHex(expected));
+}

--- a/packages/persistent-merkle-tree/test/utils/tree.ts
+++ b/packages/persistent-merkle-tree/test/utils/tree.ts
@@ -1,8 +1,19 @@
+import {subtreeFillToContents} from "../../src";
 import {BranchNode, LeafNode, Node} from "../../src/node";
+import {linspace} from "./misc";
 
 export function createTree(depth: number, index = 0): Node {
   if (!depth) {
     return LeafNode.fromRoot(Buffer.alloc(32, index));
   }
   return new BranchNode(createTree(depth - 1, 2 ** depth + index), createTree(depth - 1, 2 ** depth + index + 1));
+}
+
+export function buildComparisonTrees(depth: number): [BranchNode, BranchNode] {
+  const width = 2 ** (depth - 1);
+  const nodes = linspace(width).map((num) => LeafNode.fromRoot(Uint8Array.from(Buffer.alloc(32, num))));
+  const copy = nodes.map((node) => node.clone());
+  const branch1 = subtreeFillToContents(nodes, depth) as BranchNode;
+  const branch2 = subtreeFillToContents(copy, depth) as BranchNode;
+  return [branch1, branch2];
 }

--- a/packages/persistent-merkle-tree/tsconfig.json
+++ b/packages/persistent-merkle-tree/tsconfig.json
@@ -5,6 +5,7 @@
     "module": "commonjs",
     "lib": ["esnext", "dom"],
     "outDir": "lib",
+    "sourceMap": true,
     "strict": true,
     "strictNullChecks": true,
     "pretty": true,

--- a/packages/simpleserialize.com/package.json
+++ b/packages/simpleserialize.com/package.json
@@ -25,6 +25,7 @@
     "eyzy-tree": "^0.2.2",
     "file-saver": "^2.0.5",
     "js-yaml": "^4.1.0",
+    "null-loader": "^4.0.1",
     "react": "^17.0.2",
     "react-alert": "^7.0.1",
     "react-alert-template-basic": "^1.0.0",

--- a/packages/simpleserialize.com/webpack.config.js
+++ b/packages/simpleserialize.com/webpack.config.js
@@ -1,22 +1,22 @@
-const webpack = require('webpack');
-const { resolve } = require('path');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin')
-const HtmlWebpackPlugin = require('html-webpack-plugin');
+const webpack = require("webpack");
+const {resolve} = require("path");
+const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const HtmlWebpackPlugin = require("html-webpack-plugin");
 
-const isProd = process.env.NODE_ENV === 'production';
+const isProd = process.env.NODE_ENV === "production";
 
 const config = {
   devtool: "source-map",
-  mode: isProd ? 'production' : 'development',
+  mode: isProd ? "production" : "development",
   entry: {
-    index: './src/index.tsx',
+    index: "./src/index.tsx",
   },
   output: {
-    path: resolve(__dirname, 'dist'),
-    filename: '[name].js',
+    path: resolve(__dirname, "dist"),
+    filename: "[name].js",
   },
   resolve: {
-    extensions: ['.js', '.jsx', '.ts', '.tsx'],
+    extensions: [".js", ".jsx", ".ts", ".tsx"],
   },
   module: {
     rules: [
@@ -27,45 +27,49 @@ const config = {
         },
       },
       {
-      test: /\.scss$/,
-      use: [
+        test: /\.scss$/,
+        use: [
           MiniCssExtractPlugin.loader,
           {
-            loader: 'css-loader'
+            loader: "css-loader",
           },
           {
-            loader: 'sass-loader',
+            loader: "sass-loader",
             options: {
               sourceMap: true,
-            }
-          }
-        ]
-      },{
+            },
+          },
+        ],
+      },
+      {
         test: /\.tsx?$/,
-        use: 'babel-loader',
+        use: "babel-loader",
         exclude: /node_modules/,
-      }
+      },
+      {
+        use: "null-loader",
+        test: /@chainsafe\/hashtree/,
+      },
     ],
   },
   plugins: [
     new webpack.ProvidePlugin({
-      process: 'process/browser',
-      Buffer: ['buffer', 'Buffer'],
+      process: "process/browser",
+      Buffer: ["buffer", "Buffer"],
     }),
     new MiniCssExtractPlugin({
-      filename: 'css/[name].bundle.css'
+      filename: "css/[name].bundle.css",
     }),
     new HtmlWebpackPlugin({
-      title: 'Simple Serialize | Chainsafe Systems',
-      template: 'src/index.html',
+      title: "Simple Serialize | Chainsafe Systems",
+      template: "src/index.html",
     }),
   ],
 };
 
 if (isProd) {
   config.optimization = {
-    minimizer: [
-    ],
+    minimizer: [],
   };
 } else {
   config.devServer = {
@@ -73,7 +77,7 @@ if (isProd) {
     open: true, // https://webpack.js.org/configuration/dev-server/#devserveropen
     hot: true, // https://webpack.js.org/configuration/dev-server/#devserverhot
     compress: true, // https://webpack.js.org/configuration/dev-server/#devservercompress
-    stats: 'errors-only', // https://webpack.js.org/configuration/dev-server/#devserverstats-
+    stats: "errors-only", // https://webpack.js.org/configuration/dev-server/#devserverstats-
     overlay: true, // https://webpack.js.org/configuration/dev-server/#devserveroverlay
   };
 }
@@ -81,14 +85,14 @@ if (isProd) {
 const workerConfig = {
   name: "worker",
   resolve: {
-    extensions: ['.js', '.jsx', '.ts', '.tsx'],
+    extensions: [".js", ".jsx", ".ts", ".tsx"],
   },
   entry: {
-    index: './src/components/worker/index.ts',
+    index: "./src/components/worker/index.ts",
   },
   output: {
-    path: resolve(__dirname, 'dist'),
-    filename: 'worker.js',
+    path: resolve(__dirname, "dist"),
+    filename: "worker.js",
   },
   module: {
     rules: [
@@ -100,21 +104,25 @@ const workerConfig = {
       },
       {
         test: /worker?$/,
-        loader: 'threads-webpack-plugin',
+        loader: "threads-webpack-plugin",
       },
       {
         test: /\.ts?$/,
-        use: 'babel-loader',
+        use: "babel-loader",
         exclude: /node_modules/,
-      }
+      },
+      {
+        use: "null-loader",
+        test: /@chainsafe\/hashtree/,
+      },
     ],
   },
   plugins: [
     new webpack.ProvidePlugin({
-      process: 'process/browser',
-      Buffer: ['buffer', 'Buffer'],
+      process: "process/browser",
+      Buffer: ["buffer", "Buffer"],
     }),
-  ]
-}
+  ],
+};
 
 module.exports = [config, workerConfig];

--- a/packages/ssz/src/branchNodeStruct.ts
+++ b/packages/ssz/src/branchNodeStruct.ts
@@ -2,22 +2,27 @@ import {HashObject} from "@chainsafe/as-sha256/lib/hashObject";
 import {hashObjectToUint8Array, Node} from "@chainsafe/persistent-merkle-tree";
 
 /**
- * BranchNode whose children's data is represented as a struct, not a tree.
+ * BranchNode whose children's data is represented as a struct, the backed tree is lazily computed from the struct.
  *
  * This approach is usefull for memory efficiency of data that is not modified often, for example the validators
  * registry in Ethereum consensus `state.validators`. The tradeoff is that getting the hash, are proofs is more
  * expensive because the tree has to be recreated every time.
  */
 export class BranchNodeStruct<T> extends Node {
+  /**
+   * this represents the backed tree which is lazily computed from value
+   */
+  private _rootNode: Node | null = null;
   constructor(private readonly valueToNode: (value: T) => Node, readonly value: T) {
     // First null value is to save an extra variable to check if a node has a root or not
     super(null as unknown as number, 0, 0, 0, 0, 0, 0, 0);
+    this._rootNode = null;
   }
 
   get rootHashObject(): HashObject {
+    // return this.rootNode.rootHashObject;
     if (this.h0 === null) {
-      const node = this.valueToNode(this.value);
-      super.applyHash(node.rootHashObject);
+      super.applyHash(this.rootNode.rootHashObject);
     }
     return this;
   }
@@ -31,10 +36,21 @@ export class BranchNodeStruct<T> extends Node {
   }
 
   get left(): Node {
-    return this.valueToNode(this.value).left;
+    return this.rootNode.left;
   }
 
   get right(): Node {
-    return this.valueToNode(this.value).right;
+    return this.rootNode.right;
+  }
+
+  /**
+   * Singleton implementation to make sure there is single backed tree for this node.
+   * This is important for batching HashComputations
+   */
+  private get rootNode(): Node {
+    if (this._rootNode === null) {
+      this._rootNode = this.valueToNode(this.value);
+    }
+    return this._rootNode;
   }
 }

--- a/packages/ssz/src/type/bitArray.ts
+++ b/packages/ssz/src/type/bitArray.ts
@@ -1,4 +1,4 @@
-import {concatGindices, Gindex, Node, toGindex, Tree} from "@chainsafe/persistent-merkle-tree";
+import {concatGindices, Gindex, HashComputationGroup, Node, toGindex, Tree} from "@chainsafe/persistent-merkle-tree";
 import {fromHexString, toHexString, byteArrayEquals} from "../util/byteArray";
 import {splitIntoRootChunks} from "../util/merkleize";
 import {CompositeType, LENGTH_GINDEX} from "./composite";
@@ -29,8 +29,8 @@ export abstract class BitArrayType extends CompositeType<BitArray, BitArrayTreeV
     return view.node;
   }
 
-  commitViewDU(view: BitArrayTreeViewDU): Node {
-    view.commit();
+  commitViewDU(view: BitArrayTreeViewDU, hashComps: HashComputationGroup | null = null): Node {
+    view.commit(hashComps);
     return view.node;
   }
 

--- a/packages/ssz/src/type/byteArray.ts
+++ b/packages/ssz/src/type/byteArray.ts
@@ -1,4 +1,4 @@
-import {concatGindices, Gindex, Node, toGindex, Tree} from "@chainsafe/persistent-merkle-tree";
+import {concatGindices, Gindex, HashComputationGroup, Node, toGindex, Tree} from "@chainsafe/persistent-merkle-tree";
 import {fromHexString, toHexString, byteArrayEquals} from "../util/byteArray";
 import {splitIntoRootChunks} from "../util/merkleize";
 import {ByteViews} from "./abstract";
@@ -37,7 +37,8 @@ export abstract class ByteArrayType extends CompositeType<ByteArray, ByteArray, 
     return this.commitViewDU(view);
   }
 
-  commitViewDU(view: ByteArray): Node {
+  // TODO: batch
+  commitViewDU(view: ByteArray, hashComps: HashComputationGroup | null = null): Node {
     const uint8Array = new Uint8Array(this.value_serializedSize(view));
     const dataView = new DataView(uint8Array.buffer, uint8Array.byteOffset, uint8Array.byteLength);
     this.value_serializeToBytes({uint8Array, dataView}, 0, view);

--- a/packages/ssz/src/type/byteArray.ts
+++ b/packages/ssz/src/type/byteArray.ts
@@ -37,7 +37,7 @@ export abstract class ByteArrayType extends CompositeType<ByteArray, ByteArray, 
     return this.commitViewDU(view);
   }
 
-  // TODO: batch
+  // TODO - batch
   commitViewDU(view: ByteArray, hashComps: HashComputationGroup | null = null): Node {
     const uint8Array = new Uint8Array(this.value_serializedSize(view));
     const dataView = new DataView(uint8Array.buffer, uint8Array.byteOffset, uint8Array.byteLength);
@@ -68,6 +68,12 @@ export abstract class ByteArrayType extends CompositeType<ByteArray, ByteArray, 
   value_deserializeFromBytes(data: ByteViews, start: number, end: number): ByteArray {
     this.assertValidSize(end - start);
     return Uint8Array.prototype.slice.call(data.uint8Array, start, end);
+  }
+
+  value_toTree(value: ByteArray): Node {
+    // this saves 1 allocation of Uint8Array
+    const dataView = new DataView(value.buffer, value.byteOffset, value.byteLength);
+    return this.tree_deserializeFromBytes({uint8Array: value, dataView}, 0, value.length);
   }
 
   // Merkleization

--- a/packages/ssz/src/type/composite.ts
+++ b/packages/ssz/src/type/composite.ts
@@ -3,6 +3,7 @@ import {
   createProof,
   getNode,
   Gindex,
+  HashComputationGroup,
   Node,
   Proof,
   ProofType,
@@ -126,7 +127,7 @@ export abstract class CompositeType<V, TV, TVDU> extends Type<V> {
   /** INTERNAL METHOD: Given a Tree View, returns a `Node` with all its updated data */
   abstract commitView(view: TV): Node;
   /** INTERNAL METHOD: Given a Deferred Update Tree View returns a `Node` with all its updated data */
-  abstract commitViewDU(view: TVDU): Node;
+  abstract commitViewDU(view: TVDU, hashComps?: HashComputationGroup | null): Node;
   /** INTERNAL METHOD: Return the cache of a Deferred Update Tree View. May return `undefined` if this ViewDU has no cache */
   abstract cacheOfViewDU(view: TVDU): unknown;
 

--- a/packages/ssz/src/type/container.ts
+++ b/packages/ssz/src/type/container.ts
@@ -7,6 +7,7 @@ import {
   toGindex,
   concatGindices,
   getNode,
+  HashComputationGroup,
 } from "@chainsafe/persistent-merkle-tree";
 import {maxChunksToDepth} from "../util/merkleize";
 import {Require} from "../util/types";
@@ -162,8 +163,8 @@ export class ContainerType<Fields extends Record<string, Type<unknown>>> extends
     return view.node;
   }
 
-  commitViewDU(view: ContainerTreeViewDUType<Fields>): Node {
-    view.commit();
+  commitViewDU(view: ContainerTreeViewDUType<Fields>, hashComps: HashComputationGroup | null = null): Node {
+    view.commit(hashComps);
     return view.node;
   }
 

--- a/packages/ssz/src/type/containerNodeStruct.ts
+++ b/packages/ssz/src/type/containerNodeStruct.ts
@@ -1,4 +1,4 @@
-import {Node, subtreeFillToContents} from "@chainsafe/persistent-merkle-tree";
+import {HashComputationGroup, Node, subtreeFillToContents} from "@chainsafe/persistent-merkle-tree";
 import {Type, ByteViews} from "./abstract";
 import {isCompositeType} from "./composite";
 import {ContainerType, ContainerOptions, renderContainerTypeName} from "./container";
@@ -106,9 +106,13 @@ export class ContainerNodeStructType<Fields extends Record<string, Type<unknown>
     return new BranchNodeStruct(this.valueToTree.bind(this), value);
   }
 
-  private valueToTree(value: ValueOfFields<Fields>): Node {
-    // TODO - batch get hash computations while creating tree
+  private valueToTree(
+    value: ValueOfFields<Fields>,
+    hashComps: HashComputationGroup | null = null,
+    hashCompRootNode: Node | null = null
+  ): Node {
     const nodes = this.fieldsEntries.map(({fieldName, fieldType}) => fieldType.value_toTree(value[fieldName]));
-    return subtreeFillToContents(nodes, this.depth);
+    const rootNode = subtreeFillToContents(nodes, this.depth, hashComps, hashCompRootNode);
+    return rootNode;
   }
 }

--- a/packages/ssz/src/type/containerNodeStruct.ts
+++ b/packages/ssz/src/type/containerNodeStruct.ts
@@ -1,4 +1,4 @@
-import {Node} from "@chainsafe/persistent-merkle-tree";
+import {Node, subtreeFillToContents} from "@chainsafe/persistent-merkle-tree";
 import {Type, ByteViews} from "./abstract";
 import {isCompositeType} from "./composite";
 import {ContainerType, ContainerOptions, renderContainerTypeName} from "./container";
@@ -106,11 +106,9 @@ export class ContainerNodeStructType<Fields extends Record<string, Type<unknown>
     return new BranchNodeStruct(this.valueToTree.bind(this), value);
   }
 
-  // TODO: Optimize conversion
   private valueToTree(value: ValueOfFields<Fields>): Node {
-    const uint8Array = new Uint8Array(this.value_serializedSize(value));
-    const dataView = new DataView(uint8Array.buffer, uint8Array.byteOffset, uint8Array.byteLength);
-    this.value_serializeToBytes({uint8Array, dataView}, 0, value);
-    return super.tree_deserializeFromBytes({uint8Array, dataView}, 0, uint8Array.length);
+    // TODO - batch get hash computations while creating tree
+    const nodes = this.fieldsEntries.map(({fieldName, fieldType}) => fieldType.value_toTree(value[fieldName]));
+    return subtreeFillToContents(nodes, this.depth);
   }
 }

--- a/packages/ssz/src/type/listBasic.ts
+++ b/packages/ssz/src/type/listBasic.ts
@@ -1,4 +1,4 @@
-import {LeafNode, Node, Tree} from "@chainsafe/persistent-merkle-tree";
+import {HashComputationGroup, LeafNode, Node, Tree} from "@chainsafe/persistent-merkle-tree";
 import {ValueOf} from "./abstract";
 import {BasicType} from "./basic";
 import {ByteViews} from "./composite";
@@ -93,8 +93,8 @@ export class ListBasicType<ElementType extends BasicType<unknown>>
     return view.node;
   }
 
-  commitViewDU(view: ListBasicTreeViewDU<ElementType>): Node {
-    view.commit();
+  commitViewDU(view: ListBasicTreeViewDU<ElementType>, hashComps: HashComputationGroup | null = null): Node {
+    view.commit(hashComps);
     return view.node;
   }
 
@@ -144,8 +144,18 @@ export class ListBasicType<ElementType extends BasicType<unknown>>
     return node.left;
   }
 
-  tree_setChunksNode(rootNode: Node, chunksNode: Node, newLength?: number): Node {
-    return setChunksNode(rootNode, chunksNode, newLength);
+  tree_chunksNodeOffset(): number {
+    // one more level for length, see setChunksNode below
+    return 1;
+  }
+
+  tree_setChunksNode(
+    rootNode: Node,
+    chunksNode: Node,
+    newLength: number | null,
+    hashComps: HashComputationGroup | null
+  ): Node {
+    return setChunksNode(rootNode, chunksNode, newLength, hashComps);
   }
 
   // Merkleization

--- a/packages/ssz/src/type/listComposite.ts
+++ b/packages/ssz/src/type/listComposite.ts
@@ -1,4 +1,4 @@
-import {Node, Tree} from "@chainsafe/persistent-merkle-tree";
+import {HashComputationGroup, Node, Tree} from "@chainsafe/persistent-merkle-tree";
 import {
   mixInLength,
   maxChunksToDepth,
@@ -97,8 +97,8 @@ export class ListCompositeType<
     return view.node;
   }
 
-  commitViewDU(view: ListCompositeTreeViewDU<ElementType>): Node {
-    view.commit();
+  commitViewDU(view: ListCompositeTreeViewDU<ElementType>, hashComps: HashComputationGroup | null = null): Node {
+    view.commit(hashComps);
     return view.node;
   }
 
@@ -150,8 +150,18 @@ export class ListCompositeType<
     return node.left;
   }
 
-  tree_setChunksNode(rootNode: Node, chunksNode: Node, newLength?: number): Node {
-    return setChunksNode(rootNode, chunksNode, newLength);
+  tree_chunksNodeOffset(): number {
+    // one more level for length, see setChunksNode below
+    return 1;
+  }
+
+  tree_setChunksNode(
+    rootNode: Node,
+    chunksNode: Node,
+    newLength: number | null,
+    hashComps: HashComputationGroup | null
+  ): Node {
+    return setChunksNode(rootNode, chunksNode, newLength, hashComps);
   }
 
   // Merkleization

--- a/packages/ssz/src/type/optional.ts
+++ b/packages/ssz/src/type/optional.ts
@@ -1,4 +1,4 @@
-import {concatGindices, Gindex, Node, Tree, zeroNode} from "@chainsafe/persistent-merkle-tree";
+import {concatGindices, Gindex, HashComputationGroup, Node, Tree, zeroNode} from "@chainsafe/persistent-merkle-tree";
 import {mixInLength} from "../util/merkleize";
 import {Require} from "../util/types";
 import {namedClass} from "../util/named";
@@ -75,7 +75,8 @@ export class OptionalType<ElementType extends Type<unknown>> extends CompositeTy
   }
 
   // TODO add an OptionalViewDU
-  commitViewDU(view: ValueOfType<ElementType>): Node {
+  // TODO: batch
+  commitViewDU(view: ValueOfType<ElementType>, hashComps: HashComputationGroup | null = null): Node {
     return this.value_toTree(view);
   }
 

--- a/packages/ssz/src/type/optional.ts
+++ b/packages/ssz/src/type/optional.ts
@@ -75,7 +75,7 @@ export class OptionalType<ElementType extends Type<unknown>> extends CompositeTy
   }
 
   // TODO add an OptionalViewDU
-  // TODO: batch
+  // TODO - batch
   commitViewDU(view: ValueOfType<ElementType>, hashComps: HashComputationGroup | null = null): Node {
     return this.value_toTree(view);
   }

--- a/packages/ssz/src/type/uint.ts
+++ b/packages/ssz/src/type/uint.ts
@@ -133,6 +133,12 @@ export class UintNumberType extends BasicType<number> {
     }
   }
 
+  value_toTree(value: number): Node {
+    const node = LeafNode.fromZero();
+    node.setUint(this.byteLength, 0, value, this.clipInfinity);
+    return node;
+  }
+
   tree_serializeToBytes(output: ByteViews, offset: number, node: Node): number {
     const value = (node as LeafNode).getUint(this.byteLength, 0, this.clipInfinity);
     this.value_serializeToBytes(output, offset, value);

--- a/packages/ssz/src/type/union.ts
+++ b/packages/ssz/src/type/union.ts
@@ -106,7 +106,7 @@ export class UnionType<Types extends Type<unknown>[]> extends CompositeType<
     return this.value_toTree(view);
   }
 
-  // TODO: batch
+  // TODO - batch
   commitViewDU(view: ValueOfTypes<Types>, hashComps: HashComputationGroup | null = null): Node {
     return this.value_toTree(view);
   }

--- a/packages/ssz/src/type/union.ts
+++ b/packages/ssz/src/type/union.ts
@@ -1,4 +1,4 @@
-import {concatGindices, getNode, Gindex, Node, Tree} from "@chainsafe/persistent-merkle-tree";
+import {concatGindices, getNode, Gindex, HashComputationGroup, Node, Tree} from "@chainsafe/persistent-merkle-tree";
 import {mixInLength} from "../util/merkleize";
 import {Require} from "../util/types";
 import {namedClass} from "../util/named";
@@ -106,7 +106,8 @@ export class UnionType<Types extends Type<unknown>[]> extends CompositeType<
     return this.value_toTree(view);
   }
 
-  commitViewDU(view: ValueOfTypes<Types>): Node {
+  // TODO: batch
+  commitViewDU(view: ValueOfTypes<Types>, hashComps: HashComputationGroup | null = null): Node {
     return this.value_toTree(view);
   }
 

--- a/packages/ssz/src/type/vectorBasic.ts
+++ b/packages/ssz/src/type/vectorBasic.ts
@@ -1,4 +1,4 @@
-import {Node, Tree} from "@chainsafe/persistent-merkle-tree";
+import {HashComputationGroup, Node, Tree} from "@chainsafe/persistent-merkle-tree";
 import {maxChunksToDepth, splitIntoRootChunks} from "../util/merkleize";
 import {Require} from "../util/types";
 import {namedClass} from "../util/named";
@@ -83,8 +83,8 @@ export class VectorBasicType<ElementType extends BasicType<unknown>>
     return view.node;
   }
 
-  commitViewDU(view: ArrayBasicTreeViewDU<ElementType>): Node {
-    view.commit();
+  commitViewDU(view: ArrayBasicTreeViewDU<ElementType>, hashComps: HashComputationGroup | null = null): Node {
+    view.commit(hashComps);
     return view.node;
   }
 
@@ -130,6 +130,10 @@ export class VectorBasicType<ElementType extends BasicType<unknown>>
 
   tree_getChunksNode(node: Node): Node {
     return node;
+  }
+
+  tree_chunksNodeOffset(): number {
+    return 0;
   }
 
   tree_setChunksNode(rootNode: Node, chunksNode: Node): Node {

--- a/packages/ssz/src/type/vectorComposite.ts
+++ b/packages/ssz/src/type/vectorComposite.ts
@@ -1,4 +1,4 @@
-import {Node, Tree} from "@chainsafe/persistent-merkle-tree";
+import {HashComputationGroup, Node, Tree} from "@chainsafe/persistent-merkle-tree";
 import {maxChunksToDepth} from "../util/merkleize";
 import {Require} from "../util/types";
 import {namedClass} from "../util/named";
@@ -90,8 +90,8 @@ export class VectorCompositeType<
     return view.node;
   }
 
-  commitViewDU(view: ArrayCompositeTreeViewDU<ElementType>): Node {
-    view.commit();
+  commitViewDU(view: ArrayCompositeTreeViewDU<ElementType>, hashComps: HashComputationGroup | null = null): Node {
+    view.commit(hashComps);
     return view.node;
   }
 
@@ -137,6 +137,10 @@ export class VectorCompositeType<
 
   tree_getChunksNode(node: Node): Node {
     return node;
+  }
+
+  tree_chunksNodeOffset(): number {
+    return 0;
   }
 
   tree_setChunksNode(rootNode: Node, chunksNode: Node): Node {

--- a/packages/ssz/src/view/arrayBasic.ts
+++ b/packages/ssz/src/view/arrayBasic.ts
@@ -1,4 +1,4 @@
-import {getNodesAtDepth, LeafNode, Node, Tree} from "@chainsafe/persistent-merkle-tree";
+import {getNodesAtDepth, HashComputationGroup, LeafNode, Node, Tree} from "@chainsafe/persistent-merkle-tree";
 import {ValueOf} from "../type/abstract";
 import {BasicType} from "../type/basic";
 import {CompositeType} from "../type/composite";
@@ -21,8 +21,15 @@ export type ArrayBasicType<ElementType extends BasicType<unknown>> = CompositeTy
   tree_setLength(tree: Tree, length: number): void;
   /** INTERNAL METHOD: Return the chunks node from a root node */
   tree_getChunksNode(rootNode: Node): Node;
+  /** INTERNAL METHOD: Return the offset from root for HashComputation */
+  tree_chunksNodeOffset(): number;
   /** INTERNAL METHOD: Return a new root node with changed chunks node and length */
-  tree_setChunksNode(rootNode: Node, chunksNode: Node, newLength?: number): Node;
+  tree_setChunksNode(
+    rootNode: Node,
+    chunksNode: Node,
+    newLength: number | null,
+    hashComps: HashComputationGroup | null
+  ): Node;
 };
 
 export class ArrayBasicTreeView<ElementType extends BasicType<unknown>> extends TreeView<ArrayBasicType<ElementType>> {

--- a/packages/ssz/src/view/arrayComposite.ts
+++ b/packages/ssz/src/view/arrayComposite.ts
@@ -1,4 +1,4 @@
-import {getNodesAtDepth, Node, toGindexBitstring, Tree} from "@chainsafe/persistent-merkle-tree";
+import {getNodesAtDepth, HashComputationGroup, Node, toGindexBitstring, Tree} from "@chainsafe/persistent-merkle-tree";
 import {ValueOf} from "../type/abstract";
 import {CompositeType, CompositeView, CompositeViewDU} from "../type/composite";
 import {TreeView} from "./abstract";
@@ -16,8 +16,15 @@ export type ArrayCompositeType<
   tree_setLength(tree: Tree, length: number): void;
   /** INTERNAL METHOD: Return the chunks node from a root node */
   tree_getChunksNode(rootNode: Node): Node;
+  /** INTERNAL METHOD: Return the offset from root for HashComputation */
+  tree_chunksNodeOffset(): number;
   /** INTERNAL METHOD: Return a new root node with changed chunks node and length */
-  tree_setChunksNode(rootNode: Node, chunksNode: Node, newLength?: number): Node;
+  tree_setChunksNode(
+    rootNode: Node,
+    chunksNode: Node,
+    newLength: number | null,
+    hashComps: HashComputationGroup | null
+  ): Node;
 };
 
 export class ArrayCompositeTreeView<

--- a/packages/ssz/src/viewDU/abstract.ts
+++ b/packages/ssz/src/viewDU/abstract.ts
@@ -1,4 +1,3 @@
-import {hasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/index";
 import {HashComputationGroup, executeHashComputations} from "@chainsafe/persistent-merkle-tree";
 import {ByteViews, CompositeType} from "../type/composite";
 import {TreeView} from "../view/abstract";
@@ -65,7 +64,7 @@ export abstract class TreeViewDU<T extends CompositeType<unknown, unknown, unkno
     if (this.node.h0 === null) {
       throw Error("Root is not computed by batch");
     }
-    return super.hashTreeRoot();
+    return this.node.root;
   }
 
   /**

--- a/packages/ssz/src/viewDU/bitArray.ts
+++ b/packages/ssz/src/viewDU/bitArray.ts
@@ -1,4 +1,4 @@
-import {Node} from "@chainsafe/persistent-merkle-tree";
+import {HashComputationGroup, Node, getHashComputations} from "@chainsafe/persistent-merkle-tree";
 import {BitArray} from "../value/bitArray";
 import {CompositeType} from "../type/composite";
 import {TreeViewDU} from "./abstract";
@@ -22,9 +22,13 @@ export class BitArrayTreeViewDU extends TreeViewDU<CompositeType<BitArray, unkno
     return;
   }
 
-  commit(): void {
+  commit(hashComps: HashComputationGroup | null = null): void {
     if (this._bitArray !== null) {
       this._rootNode = this.type.value_toTree(this._bitArray);
+    }
+
+    if (hashComps !== null && this._rootNode.h0 === null) {
+      getHashComputations(this._rootNode, hashComps.offset, hashComps.byLevel);
     }
   }
 

--- a/packages/ssz/src/viewDU/container.ts
+++ b/packages/ssz/src/viewDU/container.ts
@@ -120,6 +120,7 @@ class ContainerTreeViewDU<Fields extends Record<string, Type<unknown>>> extends 
       isOldRootHashed ? hashComps : null
     );
 
+    // old root is not hashed, need to traverse and put to HashComputationGroup
     if (!isOldRootHashed && hashComps !== null) {
       getHashComputations(this._rootNode, hashComps.offset, hashComps.byLevel);
     }

--- a/packages/ssz/src/viewDU/containerNodeStruct.ts
+++ b/packages/ssz/src/viewDU/containerNodeStruct.ts
@@ -1,4 +1,4 @@
-import {HashComputationGroup, Node, getHashComputations} from "@chainsafe/persistent-merkle-tree";
+import {HashComputationGroup, Node} from "@chainsafe/persistent-merkle-tree";
 import {Type, ValueOf} from "../type/abstract";
 import {isCompositeType} from "../type/composite";
 import {BranchNodeStruct} from "../branchNodeStruct";
@@ -34,8 +34,8 @@ class ContainerTreeViewDU<Fields extends Record<string, Type<unknown>>> extends 
       this._rootNode = this.type.value_toTree(value) as BranchNodeStruct<ValueOfFields<Fields>>;
     }
 
-    if (hashComps !== null && this._rootNode.h0 === null) {
-      getHashComputations(this._rootNode, hashComps.offset, hashComps.byLevel);
+    if (hashComps !== null) {
+      this._rootNode.getHashComputations(hashComps);
     }
   }
 

--- a/packages/ssz/src/viewDU/containerNodeStruct.ts
+++ b/packages/ssz/src/viewDU/containerNodeStruct.ts
@@ -1,4 +1,4 @@
-import {Node} from "@chainsafe/persistent-merkle-tree";
+import {HashComputationGroup, Node, getHashComputations} from "@chainsafe/persistent-merkle-tree";
 import {Type, ValueOf} from "../type/abstract";
 import {isCompositeType} from "../type/composite";
 import {BranchNodeStruct} from "../branchNodeStruct";
@@ -27,15 +27,16 @@ class ContainerTreeViewDU<Fields extends Record<string, Type<unknown>>> extends 
     return;
   }
 
-  commit(): void {
-    if (this.valueChanged === null) {
-      return;
+  commit(hashComps: HashComputationGroup | null = null): void {
+    if (this.valueChanged !== null) {
+      const value = this.valueChanged;
+      this.valueChanged = null;
+      this._rootNode = this.type.value_toTree(value) as BranchNodeStruct<ValueOfFields<Fields>>;
     }
 
-    const value = this.valueChanged;
-    this.valueChanged = null;
-
-    this._rootNode = this.type.value_toTree(value) as BranchNodeStruct<ValueOfFields<Fields>>;
+    if (hashComps !== null && this._rootNode.h0 === null) {
+      getHashComputations(this._rootNode, hashComps.offset, hashComps.byLevel);
+    }
   }
 
   protected clearCache(): void {

--- a/packages/ssz/src/viewDU/listComposite.ts
+++ b/packages/ssz/src/viewDU/listComposite.ts
@@ -105,7 +105,7 @@ export class ListCompositeTreeViewDU<
       newLength = nodes.length;
     }
 
-    const newRootNode = this.type.tree_setChunksNode(this._rootNode, newChunksNode, newLength);
+    const newRootNode = this.type.tree_setChunksNode(this._rootNode, newChunksNode, newLength, null);
 
     return this.type.getViewDU(newRootNode) as this;
   }

--- a/packages/ssz/test/perf/eth2/beaconState.test.ts
+++ b/packages/ssz/test/perf/eth2/beaconState.test.ts
@@ -1,5 +1,5 @@
 import {itBench} from "@dapplion/benchmark";
-import {HashComputationGroup} from "@chainsafe/persistent-merkle-tree";
+import {BranchNode, HashComputationGroup} from "@chainsafe/persistent-merkle-tree";
 import {BeaconState} from "../../lodestarTypes/altair/sszTypes";
 import {BitArray, CompositeViewDU} from "../../../src";
 
@@ -11,7 +11,7 @@ const numModified = vc / 2;
  */
 describe("BeaconState ViewDU partially modified tree", function () {
   itBench({
-    id: `BeaconState ViewDU batchHash vc=${vc}`,
+    id: `BeaconState ViewDU hashTreeRoot vc=${vc}`,
     beforeEach: () => createPartiallyModifiedDenebState(),
     fn: (state: CompositeViewDU<typeof BeaconState>) => {
       // commit() step is inside hashTreeRoot()
@@ -42,6 +42,15 @@ describe("BeaconState ViewDU partially modified tree", function () {
       for (let i = 0; i < vc / 2; i++) {
         state.validators.get(i).commit(hashComps);
       }
+    },
+  });
+
+  itBench({
+    id: `BeaconState ViewDU batchHash vc=${vc}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      state.commit();
+      (state.node as BranchNode).batchHash();
     },
   });
 

--- a/packages/ssz/test/perf/eth2/beaconState.test.ts
+++ b/packages/ssz/test/perf/eth2/beaconState.test.ts
@@ -1,0 +1,120 @@
+import {itBench} from "@dapplion/benchmark";
+import {HashComputationGroup} from "@chainsafe/persistent-merkle-tree";
+import {BeaconState} from "../../lodestarTypes/altair/sszTypes";
+import {BitArray, CompositeViewDU} from "../../../src";
+
+const vc = 100_000;
+const numModified = vc / 2;
+
+/**
+ * The fresh tree batch hash bechmark is in packages/persistent-merkle-tree/test/perf/node.test.ts
+ */
+describe("BeaconState ViewDU partially modified tree", function () {
+  itBench({
+    id: `BeaconState ViewDU batchHash vc=${vc}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      // commit() step is inside hashTreeRoot()
+      state.hashTreeRoot();
+    },
+  });
+
+  itBench({
+    id: `BeaconState ViewDU batchHash - commit step vc=${vc}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      const hashComps: HashComputationGroup = {
+        byLevel: [],
+        offset: 0,
+      };
+      state.commit(hashComps);
+    },
+  });
+
+  itBench({
+    id: `BeaconState ViewDU batchHash - commit step each validator vc=${vc}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      const hashComps: HashComputationGroup = {
+        byLevel: [],
+        offset: 0,
+      };
+      for (let i = 0; i < vc / 2; i++) {
+        state.validators.get(i).commit(hashComps);
+      }
+    },
+  });
+
+  itBench({
+    id: `BeaconState ViewDU recursive hash vc=${vc}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      state.commit();
+      state.node.root;
+    },
+  });
+
+  itBench({
+    id: `BeaconState ViewDU recursive hash - commit step vc=${vc}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      state.commit();
+    },
+  });
+});
+
+function createPartiallyModifiedDenebState(): CompositeViewDU<typeof BeaconState> {
+  const state = createDenebState(vc);
+  // cache all roots
+  state.hashTreeRoot();
+  // modify half of validators and balances
+  for (let i = 0; i < numModified; i++) {
+    state.validators.get(i).effectiveBalance += 1e9;
+    state.balances.set(i, state.balances.get(i) + 1e9);
+  }
+  return state;
+}
+
+function createDenebState(vc: number): CompositeViewDU<typeof BeaconState> {
+  const state = BeaconState.defaultViewDU();
+  state.genesisTime = 1e9;
+  state.genesisValidatorsRoot = Buffer.alloc(32, 1);
+  state.fork = BeaconState.fields.fork.toViewDU({
+    epoch: 1000,
+    previousVersion: Buffer.alloc(4, 0x03),
+    currentVersion: Buffer.alloc(4, 0x04),
+  });
+  state.latestBlockHeader = BeaconState.fields.latestBlockHeader.toViewDU({
+    slot: 1000,
+    proposerIndex: 1,
+    parentRoot: Buffer.alloc(32, 0xac),
+    stateRoot: Buffer.alloc(32, 0xed),
+    bodyRoot: Buffer.alloc(32, 0x32),
+  });
+  const validators = Array.from({length: vc}, () => {
+    return {
+      pubkey: Buffer.alloc(48, 0xaa),
+      withdrawalCredentials: Buffer.alloc(32, 0xbb),
+      effectiveBalance: 32e9,
+      slashed: false,
+      activationEligibilityEpoch: 1_000_000,
+      activationEpoch: 2_000_000,
+      exitEpoch: 3_000_000,
+      withdrawableEpoch: 4_000_000,
+    };
+  });
+  state.validators = BeaconState.fields.validators.toViewDU(validators);
+  state.balances = BeaconState.fields.balances.toViewDU(Array.from({length: vc}, () => 32e9));
+  // randomMixes
+  // slashings
+  state.previousEpochParticipation = BeaconState.fields.previousEpochParticipation.toViewDU(
+    Array.from({length: vc}, () => 7)
+  );
+  state.currentEpochParticipation = BeaconState.fields.previousEpochParticipation.toViewDU(
+    Array.from({length: vc}, () => 7)
+  );
+  state.justificationBits = BeaconState.fields.justificationBits.toViewDU(
+    BitArray.fromBoolArray([true, false, true, true])
+  );
+  return state;
+}

--- a/packages/ssz/test/unit/byType/bitArray/tree.test.ts
+++ b/packages/ssz/test/unit/byType/bitArray/tree.test.ts
@@ -1,3 +1,4 @@
+import {expect} from "chai";
 import {BitVectorType, BitListType, BitArray} from "../../../../src";
 import {runViewTestMutation} from "../runViewTestMutation";
 
@@ -49,6 +50,22 @@ for (const type of [new BitVectorType(4), new BitListType(4)]) {
     ],
   });
 }
+
+describe("BitArray batchHash", () => {
+  const sszType = new BitListType(4);
+  const value = fromNum(4, 0b0010);
+  const expectedRoot = sszType.toView(value).hashTreeRoot();
+
+  it("fresh ViewDU", () => {
+    expect(sszType.toViewDU(value).hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("set then hashTreeRoot", () => {
+    const viewDU = sszType.toViewDU(fromNum(4, 0b0011));
+    viewDU.set(0, false);
+    expect(sszType.toViewDU(value).hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+});
 
 function fromNum(bitLen: number, num: number): BitArray {
   const bitArray = BitArray.fromBitLen(bitLen);

--- a/packages/ssz/test/unit/byType/bitVector/tree.test.ts
+++ b/packages/ssz/test/unit/byType/bitVector/tree.test.ts
@@ -1,3 +1,4 @@
+import {expect} from "chai";
 import {BitVectorType, BitArray} from "../../../../src";
 import {runViewTestMutation} from "../runViewTestMutation";
 
@@ -46,6 +47,22 @@ runViewTestMutation({
       },
     },
   ],
+});
+
+describe("BitVector batchHash", () => {
+  const sszType = new BitVectorType(4);
+  const value = fromNum(4, 0b0010);
+  const expectedRoot = sszType.toView(value).hashTreeRoot();
+
+  it("fresh ViewDU", () => {
+    expect(sszType.toViewDU(value).hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("set then hashTreeRoot", () => {
+    const viewDU = sszType.toViewDU(fromNum(4, 0b0011));
+    viewDU.set(0, false);
+    expect(sszType.toViewDU(value).hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
 });
 
 function fromNum(bitLen: number, num: number): BitArray {

--- a/packages/ssz/test/unit/byType/listBasic/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listBasic/tree.test.ts
@@ -240,3 +240,55 @@ describe("ListBasicType.sliceTo", () => {
     });
   }
 });
+
+describe("ListBasicType batchHash", function () {
+  const value = [1, 2, 3, 4];
+  const expectedRoot = ListN64Uint64NumberType.toView(value).hashTreeRoot();
+
+  it("fresh ViewDU", () => {
+    expect(ListN64Uint64NumberType.toViewDU(value).hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("push then hashTreeRoot()", () => {
+    const viewDU = ListN64Uint64NumberType.defaultViewDU();
+    viewDU.push(1);
+    viewDU.push(2);
+    viewDU.push(3);
+    viewDU.push(4);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("push then modify then hashTreeRoot()", () => {
+    const viewDU = ListN64Uint64NumberType.defaultViewDU();
+    viewDU.push(1);
+    viewDU.push(2);
+    viewDU.push(3);
+    viewDU.push(44);
+    viewDU.set(3, 4);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify", () => {
+    const viewDU = ListN64Uint64NumberType.defaultViewDU();
+    viewDU.push(1);
+    viewDU.push(2);
+    viewDU.push(33);
+    viewDU.push(44);
+    viewDU.hashTreeRoot();
+    viewDU.set(2, 3);
+    viewDU.set(3, 4);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  // similar to a fresh ViewDU but it's good to test
+  it("sliceTo()", () => {
+    const viewDU = ListN64Uint64NumberType.defaultViewDU();
+    viewDU.push(1);
+    viewDU.push(2);
+    viewDU.push(3);
+    viewDU.push(4);
+    viewDU.push(5);
+    viewDU.hashTreeRoot();
+    expect(viewDU.sliceTo(3).hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+});

--- a/packages/ssz/test/unit/byType/listComposite/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listComposite/tree.test.ts
@@ -213,3 +213,74 @@ describe("ListCompositeType.sliceFrom", () => {
     }
   });
 });
+
+describe("ListCompositeType batchHash", () => {
+  const value = [
+    {a: 1, b: 2},
+    {a: 3, b: 4},
+  ];
+  const expectedRoot = listOfContainersType.toView(value).hashTreeRoot();
+
+  it("fresh ViewDU", () => {
+    expect(listOfContainersType.toViewDU(value).hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("push then hashTreeRoot()", () => {
+    const viewDU = listOfContainersType.defaultViewDU();
+    viewDU.push(containerUintsType.toViewDU({a: 1, b: 2}));
+    viewDU.push(containerUintsType.toViewDU({a: 3, b: 4}));
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify full non-hashed child element", () => {
+    const viewDU = listOfContainersType.defaultViewDU();
+    viewDU.push(containerUintsType.toViewDU({a: 1, b: 2}));
+    viewDU.push(containerUintsType.toViewDU({a: 33, b: 44}));
+    viewDU.hashTreeRoot();
+    viewDU.set(1, containerUintsType.toViewDU({a: 3, b: 4}));
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify partially hashed child element", () => {
+    const viewDU = listOfContainersType.defaultViewDU();
+    viewDU.push(containerUintsType.toViewDU({a: 1, b: 2}));
+    viewDU.push(containerUintsType.toViewDU({a: 33, b: 44}));
+    viewDU.hashTreeRoot();
+    const item1 = containerUintsType.toViewDU({a: 3, b: 44});
+    item1.hashTreeRoot();
+    item1.b = 4;
+    viewDU.set(1, item1);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify full hashed child element", () => {
+    const viewDU = listOfContainersType.defaultViewDU();
+    viewDU.push(containerUintsType.toViewDU({a: 1, b: 2}));
+    viewDU.push(containerUintsType.toViewDU({a: 33, b: 44}));
+    viewDU.hashTreeRoot();
+    const item1 = containerUintsType.toViewDU({a: 3, b: 4});
+    item1.hashTreeRoot();
+    viewDU.set(1, item1);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify partial child element", () => {
+    const viewDU = listOfContainersType.defaultViewDU();
+    viewDU.push(containerUintsType.toViewDU({a: 1, b: 2}));
+    viewDU.push(containerUintsType.toViewDU({a: 33, b: 44}));
+    viewDU.hashTreeRoot();
+    viewDU.get(1).a = 3;
+    viewDU.get(1).b = 4;
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  // similar to a fresh ViewDU but it's good to test
+  it("sliceTo()", () => {
+    const viewDU = listOfContainersType.defaultViewDU();
+    viewDU.push(containerUintsType.toViewDU({a: 1, b: 2}));
+    viewDU.push(containerUintsType.toViewDU({a: 3, b: 4}));
+    viewDU.push(containerUintsType.toViewDU({a: 5, b: 6}));
+    viewDU.hashTreeRoot();
+    expect(viewDU.sliceTo(1).hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+});

--- a/packages/ssz/test/unit/eth2/beaconState.test.ts
+++ b/packages/ssz/test/unit/eth2/beaconState.test.ts
@@ -1,0 +1,201 @@
+import {expect} from "chai";
+import {BeaconState} from "../../lodestarTypes/deneb/sszTypes";
+import {ListUintNum64Type} from "../../../src/type/listUintNum64";
+import {altair, phase0, ssz} from "../../lodestarTypes";
+import {BitArray, fromHexString} from "../../../src";
+
+const VALIDATOR_REGISTRY_LIMIT = 1099511627776;
+export const Balances = new ListUintNum64Type(VALIDATOR_REGISTRY_LIMIT);
+
+// TODO - batch: mix the commit() or hashTreeRoot()?
+describe("BeaconState ViewDU batch hash", function () {
+  const view = BeaconState.defaultView();
+  const viewDU = BeaconState.defaultViewDU();
+
+  it("BeaconState ViewDU should have same hashTreeRoot() to View", () => {
+    // genesisTime
+    viewDU.genesisTime = view.genesisTime = 1e9;
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // genesisValidatorsRoot
+    viewDU.genesisValidatorsRoot = view.genesisValidatorsRoot = Buffer.alloc(32, 1);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // fork
+    const fork: phase0.Fork = {
+      epoch: 1000,
+      previousVersion: fromHexString("0x03001020"),
+      currentVersion: fromHexString("0x04001020"),
+    };
+    view.fork = BeaconState.fields.fork.toView(fork);
+    viewDU.fork = BeaconState.fields.fork.toViewDU(fork);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // latestBlockHeader
+    const latestBlockHeader: phase0.BeaconBlockHeader = {
+      slot: 1000,
+      proposerIndex: 1,
+      parentRoot: fromHexString("0xac80c66f413218e2c9c7bcb2408ccdceacf3bcd7e7df58474e0c6aa9d7f328a0"),
+      stateRoot: fromHexString("0xed29eed3dbee72caf3b13df84d01ebda1482dbd0ce084e1ce8862b4acb740ed8"),
+      bodyRoot: fromHexString("0x32c644ca1b5d1583d445e9d41c81b3e98465fefad4f0db16084cbce7f1b7b849"),
+    };
+    view.latestBlockHeader = BeaconState.fields.latestBlockHeader.toView(latestBlockHeader);
+    viewDU.latestBlockHeader = BeaconState.fields.latestBlockHeader.toViewDU(latestBlockHeader);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // blockRoots
+    const blockRoots = ssz.phase0.HistoricalBlockRoots.defaultValue();
+    blockRoots[0] = fromHexString("0x1234");
+    view.blockRoots = ssz.phase0.HistoricalBlockRoots.toView(blockRoots);
+    viewDU.blockRoots = ssz.phase0.HistoricalBlockRoots.toViewDU(blockRoots);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // stateRoots
+    const stateRoots = ssz.phase0.HistoricalStateRoots.defaultValue();
+    stateRoots[0] = fromHexString("0x5678");
+    view.stateRoots = ssz.phase0.HistoricalStateRoots.toView(stateRoots);
+    viewDU.stateRoots = ssz.phase0.HistoricalStateRoots.toViewDU(stateRoots);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // historical_roots Frozen in Capella, replaced by historical_summaries
+    // Eth1
+    const eth1Data: phase0.Eth1Data = {
+      depositRoot: fromHexString("0x1234"),
+      depositCount: 1000,
+      blockHash: fromHexString("0x5678"),
+    };
+    view.eth1Data = BeaconState.fields.eth1Data.toView(eth1Data);
+    viewDU.eth1Data = BeaconState.fields.eth1Data.toViewDU(eth1Data);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // Eth1DataVotes
+    const eth1DataVotes = ssz.phase0.Eth1DataVotes.defaultValue();
+    eth1DataVotes[0] = eth1Data;
+    view.eth1DataVotes = ssz.phase0.Eth1DataVotes.toView(eth1DataVotes);
+    viewDU.eth1DataVotes = ssz.phase0.Eth1DataVotes.toViewDU(eth1DataVotes);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // Eth1DepositIndex
+    view.eth1DepositIndex = 1000;
+    viewDU.eth1DepositIndex = 1000;
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // validators
+    const validator = {
+      pubkey: Buffer.alloc(48, 0xaa),
+      withdrawalCredentials: Buffer.alloc(32, 0xbb),
+      effectiveBalance: 32e9,
+      slashed: false,
+      activationEligibilityEpoch: 1_000_000,
+      activationEpoch: 2_000_000,
+      exitEpoch: 3_000_000,
+      withdrawableEpoch: 4_000_000,
+    };
+    view.validators = BeaconState.fields.validators.toView([validator]);
+    viewDU.validators = BeaconState.fields.validators.toViewDU([validator]);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // balances
+    view.balances = BeaconState.fields.balances.toView([1000, 2000, 3000]);
+    viewDU.balances = Balances.toViewDU([1000, 2000, 3000]);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // randaoMixes
+    const randaoMixes = ssz.phase0.RandaoMixes.defaultValue();
+    randaoMixes[0] = fromHexString("0x1234");
+    view.randaoMixes = ssz.phase0.RandaoMixes.toView(randaoMixes);
+    viewDU.randaoMixes = ssz.phase0.RandaoMixes.toViewDU(randaoMixes);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // slashings
+    view.slashings = BeaconState.fields.slashings.toView(Array.from({length: 64}, () => BigInt(1000)));
+    viewDU.slashings = BeaconState.fields.slashings.toViewDU(Array.from({length: 64}, () => BigInt(1000)));
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // previousEpochAttestations
+    view.previousEpochParticipation = BeaconState.fields.previousEpochParticipation.toView([1, 2, 3]);
+    viewDU.previousEpochParticipation = BeaconState.fields.previousEpochParticipation.toViewDU([1, 2, 3]);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // currentEpochAttestations
+    view.currentEpochParticipation = BeaconState.fields.currentEpochParticipation.toView([1, 2, 3]);
+    viewDU.currentEpochParticipation = BeaconState.fields.currentEpochParticipation.toViewDU([1, 2, 3]);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // justificationBits
+    view.justificationBits = BeaconState.fields.justificationBits.toView(
+      BitArray.fromBoolArray([true, false, true, true])
+    );
+    viewDU.justificationBits = BeaconState.fields.justificationBits.toViewDU(
+      BitArray.fromBoolArray([true, false, true, true])
+    );
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // previousJustifiedCheckpoint
+    const checkpoint: phase0.Checkpoint = {
+      epoch: 1000,
+      root: fromHexString("0x1234"),
+    };
+    view.previousJustifiedCheckpoint = BeaconState.fields.previousJustifiedCheckpoint.toView(checkpoint);
+    viewDU.previousJustifiedCheckpoint = BeaconState.fields.previousJustifiedCheckpoint.toViewDU(checkpoint);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // currentJustifiedCheckpoint
+    view.currentJustifiedCheckpoint = BeaconState.fields.currentJustifiedCheckpoint.toView(checkpoint);
+    viewDU.currentJustifiedCheckpoint = BeaconState.fields.currentJustifiedCheckpoint.toViewDU(checkpoint);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // finalizedCheckpoint
+    view.finalizedCheckpoint = BeaconState.fields.finalizedCheckpoint.toView(checkpoint);
+    viewDU.finalizedCheckpoint = BeaconState.fields.finalizedCheckpoint.toViewDU(checkpoint);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // inactivityScores
+    view.inactivityScores = BeaconState.fields.inactivityScores.toView([1, 2, 3]);
+    viewDU.inactivityScores = BeaconState.fields.inactivityScores.toViewDU([1, 2, 3]);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // currentSyncCommittee
+    const syncCommittee: altair.SyncCommittee = {
+      pubkeys: Array.from({length: 32}, () => Buffer.alloc(48, 0xaa)),
+      aggregatePubkey: fromHexString("0x1234"),
+    };
+    view.currentSyncCommittee = BeaconState.fields.currentSyncCommittee.toView(syncCommittee);
+    viewDU.currentSyncCommittee = BeaconState.fields.currentSyncCommittee.toViewDU(syncCommittee);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // nextSyncCommittee
+    view.nextSyncCommittee = BeaconState.fields.nextSyncCommittee.toView(syncCommittee);
+    viewDU.nextSyncCommittee = BeaconState.fields.nextSyncCommittee.toViewDU(syncCommittee);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // latestExecutionPayloadHeader
+    const latestExecutionPayloadHeader = BeaconState.fields.latestExecutionPayloadHeader.defaultValue();
+    latestExecutionPayloadHeader.blockNumber = 1000;
+    latestExecutionPayloadHeader.parentHash = fromHexString(
+      "0xac80c66f413218e2c9c7bcb2408ccdceacf3bcd7e7df58474e0c6aa9d7f328a0"
+    );
+    view.latestExecutionPayloadHeader =
+      BeaconState.fields.latestExecutionPayloadHeader.toView(latestExecutionPayloadHeader);
+    viewDU.latestExecutionPayloadHeader =
+      BeaconState.fields.latestExecutionPayloadHeader.toViewDU(latestExecutionPayloadHeader);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // nextWithdrawalIndex
+    viewDU.nextWithdrawalIndex = view.nextWithdrawalIndex = 1000;
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // nextWithdrawalValidatorIndex
+    viewDU.nextWithdrawalValidatorIndex = view.nextWithdrawalValidatorIndex = 1000;
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // historicalSummaries
+    const historicalSummaries = {
+      blockSummaryRoot: fromHexString("0xac80c66f413218e2c9c7bcb2408ccdceacf3bcd7e7df58474e0c6aa9d7f328a0"),
+      stateSummaryRoot: fromHexString("0x32c644ca1b5d1583d445e9d41c81b3e98465fefad4f0db16084cbce7f1b7b849"),
+    };
+    view.historicalSummaries = BeaconState.fields.historicalSummaries.toView([historicalSummaries]);
+    viewDU.historicalSummaries = BeaconState.fields.historicalSummaries.toViewDU([historicalSummaries]);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+  });
+});

--- a/setHasher.mjs
+++ b/setHasher.mjs
@@ -1,5 +1,5 @@
-// Set the hasher to as-sha256
-// Used to run benchmarks with with visibility into as-sha256 performance, useful for Lodestar
+// Set the hasher to hashtree
+// Used to run benchmarks with with visibility into hashtree performance, useful for Lodestar
 import {setHasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/index.js";
-import {hasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/as-sha256.js";
+import {hasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/hashtree.js";
 setHasher(hasher);

--- a/yarn.lock
+++ b/yarn.lock
@@ -8980,6 +8980,14 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
+null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+
 nx@19.0.4, "nx@>=17.1.2 < 20":
   version "19.0.4"
   resolved "https://registry.yarnpkg.com/nx/-/nx-19.0.4.tgz#c39803f6186f6b009c39f5f30f902ce8e136dcde"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1252,6 +1252,23 @@
     core-js "2.6.10"
     require-resolve "0.0.2"
 
+"@chainsafe/hashtree-darwin-arm64@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/hashtree-darwin-arm64/-/hashtree-darwin-arm64-1.0.0.tgz#a9fb6b70eaf1f715c14caff22a64152a1903258e"
+  integrity sha512-duJfn57lUXkSedvEisEhXNJcUZAZLKY3D3t5Jx2EUfNS1PpVLM9k5oBG2cjolyNso2n94LJGlyYKFMrPoPig1w==
+
+"@chainsafe/hashtree-linux-arm64-gnu@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/hashtree-linux-arm64-gnu/-/hashtree-linux-arm64-gnu-1.0.0.tgz#168db259636261d9f3612354cad9f730a4be7110"
+  integrity sha512-XdYEV6z503Oxa7+mPtUEq9KoKfBAs0BcxGaRiDttCbZK2/J7CcTlobBGd7KMxJ/dQ4IUonaXsob0BnXBcrlwuw==
+
+"@chainsafe/hashtree@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/hashtree/-/hashtree-1.0.0.tgz#529439fb07299758ca5bbe69a00d1dc4ad83a949"
+  integrity sha512-qft0MZiLl5jbe8omZaSp1vQ2YCO9qCb262+5qD1vsgN6l1ga3ZFKLyNI6xvwbhC7ZnzZd46vr+p+KvdUIgruOw==
+  optionalDependencies:
+    "@chainsafe/hashtree-linux-arm64-gnu" "1.0.0"
+
 "@chainsafe/ssz@^0.15.1":
   version "0.15.1"
   resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.15.1.tgz#008a711c3bcdc0d207cd4be15108870b0b1c60c0"
@@ -11283,7 +11300,7 @@ streamroller@^3.1.5:
     debug "^4.3.4"
     fs-extra "^8.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -11299,15 +11316,6 @@ streamroller@^3.1.5:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
@@ -11387,7 +11395,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -11414,13 +11422,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -12616,7 +12617,7 @@ workerpool@6.1.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.1.0.tgz#a8e038b4c94569596852de7a8ea4228eefdeb37b"
   integrity sha512-toV7q9rWNYha963Pl/qyeZ6wG+3nnsyvolaNUS8+R5Wtw6qJPTxIlOP1ZSvcGhEJw+l3HMMmtiNo9Gl61G4GVg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -12638,15 +12639,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1252,11 +1252,6 @@
     core-js "2.6.10"
     require-resolve "0.0.2"
 
-"@chainsafe/hashtree-darwin-arm64@1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@chainsafe/hashtree-darwin-arm64/-/hashtree-darwin-arm64-1.0.0.tgz#a9fb6b70eaf1f715c14caff22a64152a1903258e"
-  integrity sha512-duJfn57lUXkSedvEisEhXNJcUZAZLKY3D3t5Jx2EUfNS1PpVLM9k5oBG2cjolyNso2n94LJGlyYKFMrPoPig1w==
-
 "@chainsafe/hashtree-linux-arm64-gnu@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@chainsafe/hashtree-linux-arm64-gnu/-/hashtree-linux-arm64-gnu-1.0.0.tgz#168db259636261d9f3612354cad9f730a4be7110"


### PR DESCRIPTION
**Motivation**

__Created on behalf of @twoeths.  Keeping in draft for now but using to store some metrics from different iterations of the changes.__

Update system to allow for batch hashing of trees.  SIMD instruction set allows for parallel processing of hashes when running on a single core. Add the idea of levels to the hashing process to allow deeper sections of a tree to be processed before higher levels and then computes the hashes according to depth of the tree.