### PR TITLE
fix: optimize commit() for Container and ArrayComposite ViewDUs

### DIFF
--- a/packages/ssz/src/viewDU/arrayComposite.ts
+++ b/packages/ssz/src/viewDU/arrayComposite.ts
@@ -184,7 +184,6 @@ export class ArrayCompositeTreeViewDU<
       return;
     }
 
-    const nodesChanged: {index: number; node: Node}[] = [];
     // each view may mutate HashComputationGroup at offset + depth
     const hashCompsView =
       hashComps != null && isOldRootHashed
@@ -195,24 +194,30 @@ export class ArrayCompositeTreeViewDU<
           }
         : null;
 
-    for (const [index, view] of this.viewsChanged) {
+    const indexesChanged = Array.from(this.viewsChanged.keys()).sort((a, b) => a - b);
+    const indexes: number[] = [];
+    const nodes: Node[] = [];
+    for (const index of indexesChanged) {
+      const view = this.viewsChanged.get(index);
+      if (!view) {
+        // should not happen
+        throw Error("View not found in viewsChanged, index=" + index);
+      }
+
       const node = this.type.elementType.commitViewDU(view, hashCompsView);
       // there's a chance the view is not changed, no need to rebind nodes in that case
       if (this.nodes[index] !== node) {
         // Set new node in nodes array to ensure data represented in the tree and fast nodes access is equal
         this.nodes[index] = node;
-        nodesChanged.push({index, node});
+        // nodesChanged.push({index, node});
+        indexes.push(index);
+        nodes.push(node);
       }
 
       // Cache the view's caches to preserve it's data after 'this.viewsChanged.clear()'
       const cache = this.type.elementType.cacheOfViewDU(view);
       if (cache) this.caches[index] = cache;
     }
-
-    // TODO: Optimize to loop only once, Numerical sort ascending
-    const nodesChangedSorted = nodesChanged.sort((a, b) => a.index - b.index);
-    const indexes = nodesChangedSorted.map((entry) => entry.index);
-    const nodes = nodesChangedSorted.map((entry) => entry.node);
 
     const chunksNode = this.type.tree_getChunksNode(this._rootNode);
     const hashCompsThis =


### PR DESCRIPTION
**Motivation**

resolve this `TODO` https://github.com/ChainSafe/ssz/blob/3a1c8dc54a571dfed4cc426810472627b334e9b9/packages/ssz/src/viewDU/container.ts#L94

**Description**

- sort changed nodes before the loop

- this branch

<img width="1388" alt="Screenshot 2024-07-11 at 17 57 32" src="https://github.com/ChainSafe/ssz/assets/10568965/e79ab9c1-a37e-47bf-b1f6-72963dd5f74b">

- `te/batch_hash_tree_root`

<img width="1465" alt="Screenshot 2024-07-11 at 17 58 10" src="https://github.com/ChainSafe/ssz/assets/10568965/0cc16068-7d66-481a-99e5-1f98ebafd36b">


