### PR TITLE
feat: batch hash ViewDU

### DIFF
--- a/packages/ssz/src/type/bitArray.ts
+++ b/packages/ssz/src/type/bitArray.ts
@@ -1,4 +1,4 @@
-import {concatGindices, Gindex, Node, toGindex, Tree} from "@chainsafe/persistent-merkle-tree";
+import {concatGindices, Gindex, HashComputationGroup, Node, toGindex, Tree} from "@chainsafe/persistent-merkle-tree";
 import {fromHexString, toHexString, byteArrayEquals} from "../util/byteArray";
 import {splitIntoRootChunks} from "../util/merkleize";
 import {CompositeType, LENGTH_GINDEX} from "./composite";
@@ -29,8 +29,8 @@ export abstract class BitArrayType extends CompositeType<BitArray, BitArrayTreeV
     return view.node;
   }
 
-  commitViewDU(view: BitArrayTreeViewDU): Node {
-    view.commit();
+  commitViewDU(view: BitArrayTreeViewDU, hashComps: HashComputationGroup | null = null): Node {
+    view.commit(hashComps);
     return view.node;
   }
 

--- a/packages/ssz/src/type/byteArray.ts
+++ b/packages/ssz/src/type/byteArray.ts
@@ -37,6 +37,7 @@ export abstract class ByteArrayType extends CompositeType<ByteArray, ByteArray, 
     return this.commitViewDU(view);
   }
 
+  // TODO - batch
   commitViewDU(view: ByteArray): Node {
     const uint8Array = new Uint8Array(this.value_serializedSize(view));
     const dataView = new DataView(uint8Array.buffer, uint8Array.byteOffset, uint8Array.byteLength);
@@ -67,6 +68,12 @@ export abstract class ByteArrayType extends CompositeType<ByteArray, ByteArray, 
   value_deserializeFromBytes(data: ByteViews, start: number, end: number): ByteArray {
     this.assertValidSize(end - start);
     return Uint8Array.prototype.slice.call(data.uint8Array, start, end);
+  }
+
+  value_toTree(value: ByteArray): Node {
+    // this saves 1 allocation of Uint8Array
+    const dataView = new DataView(value.buffer, value.byteOffset, value.byteLength);
+    return this.tree_deserializeFromBytes({uint8Array: value, dataView}, 0, value.length);
   }
 
   // Merkleization

--- a/packages/ssz/src/type/byteArray.ts
+++ b/packages/ssz/src/type/byteArray.ts
@@ -1,4 +1,12 @@
-import {concatGindices, getHashComputations, Gindex, HashComputationGroup, Node, toGindex, Tree} from "@chainsafe/persistent-merkle-tree";
+import {
+  concatGindices,
+  getHashComputations,
+  Gindex,
+  HashComputationGroup,
+  Node,
+  toGindex,
+  Tree,
+} from "@chainsafe/persistent-merkle-tree";
 import {fromHexString, toHexString, byteArrayEquals} from "../util/byteArray";
 import {splitIntoRootChunks} from "../util/merkleize";
 import {ByteViews} from "./abstract";

--- a/packages/ssz/src/type/composite.ts
+++ b/packages/ssz/src/type/composite.ts
@@ -3,6 +3,7 @@ import {
   createProof,
   getNode,
   Gindex,
+  HashComputationGroup,
   Node,
   Proof,
   ProofType,
@@ -126,7 +127,7 @@ export abstract class CompositeType<V, TV, TVDU> extends Type<V> {
   /** INTERNAL METHOD: Given a Tree View, returns a `Node` with all its updated data */
   abstract commitView(view: TV): Node;
   /** INTERNAL METHOD: Given a Deferred Update Tree View returns a `Node` with all its updated data */
-  abstract commitViewDU(view: TVDU): Node;
+  abstract commitViewDU(view: TVDU, hashComps?: HashComputationGroup | null): Node;
   /** INTERNAL METHOD: Return the cache of a Deferred Update Tree View. May return `undefined` if this ViewDU has no cache */
   abstract cacheOfViewDU(view: TVDU): unknown;
 

--- a/packages/ssz/src/type/container.ts
+++ b/packages/ssz/src/type/container.ts
@@ -7,6 +7,7 @@ import {
   toGindex,
   concatGindices,
   getNode,
+  HashComputationGroup,
 } from "@chainsafe/persistent-merkle-tree";
 import {maxChunksToDepth} from "../util/merkleize";
 import {Require} from "../util/types";
@@ -162,8 +163,8 @@ export class ContainerType<Fields extends Record<string, Type<unknown>>> extends
     return view.node;
   }
 
-  commitViewDU(view: ContainerTreeViewDUType<Fields>): Node {
-    view.commit();
+  commitViewDU(view: ContainerTreeViewDUType<Fields>, hashComps: HashComputationGroup | null = null): Node {
+    view.commit(hashComps);
     return view.node;
   }
 

--- a/packages/ssz/src/type/listBasic.ts
+++ b/packages/ssz/src/type/listBasic.ts
@@ -153,7 +153,7 @@ export class ListBasicType<ElementType extends BasicType<unknown>>
     rootNode: Node,
     chunksNode: Node,
     newLength: number | null,
-    hashComps: HashComputationGroup | null
+    hashComps: HashComputationGroup | null = null
   ): Node {
     return setChunksNode(rootNode, chunksNode, newLength, hashComps);
   }

--- a/packages/ssz/src/type/listBasic.ts
+++ b/packages/ssz/src/type/listBasic.ts
@@ -1,4 +1,4 @@
-import {LeafNode, Node, Tree} from "@chainsafe/persistent-merkle-tree";
+import {HashComputationGroup, LeafNode, Node, Tree} from "@chainsafe/persistent-merkle-tree";
 import {ValueOf} from "./abstract";
 import {BasicType} from "./basic";
 import {ByteViews} from "./composite";
@@ -93,8 +93,8 @@ export class ListBasicType<ElementType extends BasicType<unknown>>
     return view.node;
   }
 
-  commitViewDU(view: ListBasicTreeViewDU<ElementType>): Node {
-    view.commit();
+  commitViewDU(view: ListBasicTreeViewDU<ElementType>, hashComps: HashComputationGroup | null = null): Node {
+    view.commit(hashComps);
     return view.node;
   }
 
@@ -144,8 +144,18 @@ export class ListBasicType<ElementType extends BasicType<unknown>>
     return node.left;
   }
 
-  tree_setChunksNode(rootNode: Node, chunksNode: Node, newLength?: number): Node {
-    return setChunksNode(rootNode, chunksNode, newLength);
+  tree_chunksNodeOffset(): number {
+    // one more level for length, see setChunksNode below
+    return 1;
+  }
+
+  tree_setChunksNode(
+    rootNode: Node,
+    chunksNode: Node,
+    newLength: number | null,
+    hashComps: HashComputationGroup | null
+  ): Node {
+    return setChunksNode(rootNode, chunksNode, newLength, hashComps);
   }
 
   // Merkleization

--- a/packages/ssz/src/type/listComposite.ts
+++ b/packages/ssz/src/type/listComposite.ts
@@ -1,4 +1,4 @@
-import {Node, Tree} from "@chainsafe/persistent-merkle-tree";
+import {HashComputationGroup, Node, Tree} from "@chainsafe/persistent-merkle-tree";
 import {
   mixInLength,
   maxChunksToDepth,
@@ -97,8 +97,8 @@ export class ListCompositeType<
     return view.node;
   }
 
-  commitViewDU(view: ListCompositeTreeViewDU<ElementType>): Node {
-    view.commit();
+  commitViewDU(view: ListCompositeTreeViewDU<ElementType>, hashComps: HashComputationGroup | null = null): Node {
+    view.commit(hashComps);
     return view.node;
   }
 
@@ -150,8 +150,18 @@ export class ListCompositeType<
     return node.left;
   }
 
-  tree_setChunksNode(rootNode: Node, chunksNode: Node, newLength?: number): Node {
-    return setChunksNode(rootNode, chunksNode, newLength);
+  tree_chunksNodeOffset(): number {
+    // one more level for length, see setChunksNode below
+    return 1;
+  }
+
+  tree_setChunksNode(
+    rootNode: Node,
+    chunksNode: Node,
+    newLength: number | null,
+    hashComps: HashComputationGroup | null
+  ): Node {
+    return setChunksNode(rootNode, chunksNode, newLength, hashComps);
   }
 
   // Merkleization

--- a/packages/ssz/src/type/listComposite.ts
+++ b/packages/ssz/src/type/listComposite.ts
@@ -159,7 +159,7 @@ export class ListCompositeType<
     rootNode: Node,
     chunksNode: Node,
     newLength: number | null,
-    hashComps: HashComputationGroup | null
+    hashComps: HashComputationGroup | null = null
   ): Node {
     return setChunksNode(rootNode, chunksNode, newLength, hashComps);
   }

--- a/packages/ssz/src/type/optional.ts
+++ b/packages/ssz/src/type/optional.ts
@@ -75,6 +75,7 @@ export class OptionalType<ElementType extends Type<unknown>> extends CompositeTy
   }
 
   // TODO add an OptionalViewDU
+  // TODO - batch
   commitViewDU(view: ValueOfType<ElementType>): Node {
     return this.value_toTree(view);
   }

--- a/packages/ssz/src/type/optional.ts
+++ b/packages/ssz/src/type/optional.ts
@@ -74,8 +74,7 @@ export class OptionalType<ElementType extends Type<unknown>> extends CompositeTy
     return this.value_toTree(view);
   }
 
-  // TODO add an OptionalViewDU
-  // TODO - batch
+  // TODO add an OptionalViewDU, handle HashComputationGroup
   commitViewDU(view: ValueOfType<ElementType>): Node {
     return this.value_toTree(view);
   }

--- a/packages/ssz/src/type/uint.ts
+++ b/packages/ssz/src/type/uint.ts
@@ -133,6 +133,12 @@ export class UintNumberType extends BasicType<number> {
     }
   }
 
+  value_toTree(value: number): Node {
+    const node = LeafNode.fromZero();
+    node.setUint(this.byteLength, 0, value, this.clipInfinity);
+    return node;
+  }
+
   tree_serializeToBytes(output: ByteViews, offset: number, node: Node): number {
     const value = (node as LeafNode).getUint(this.byteLength, 0, this.clipInfinity);
     this.value_serializeToBytes(output, offset, value);

--- a/packages/ssz/src/type/union.ts
+++ b/packages/ssz/src/type/union.ts
@@ -106,7 +106,7 @@ export class UnionType<Types extends Type<unknown>[]> extends CompositeType<
     return this.value_toTree(view);
   }
 
-   // TODO add a UnionViewDU, handle HashComputationGroup
+  // TODO add a UnionViewDU, handle HashComputationGroup
   commitViewDU(view: ValueOfTypes<Types>): Node {
     return this.value_toTree(view);
   }

--- a/packages/ssz/src/type/union.ts
+++ b/packages/ssz/src/type/union.ts
@@ -106,7 +106,7 @@ export class UnionType<Types extends Type<unknown>[]> extends CompositeType<
     return this.value_toTree(view);
   }
 
-  // TODO - batch
+   // TODO add a UnionViewDU, handle HashComputationGroup
   commitViewDU(view: ValueOfTypes<Types>): Node {
     return this.value_toTree(view);
   }

--- a/packages/ssz/src/type/union.ts
+++ b/packages/ssz/src/type/union.ts
@@ -106,6 +106,7 @@ export class UnionType<Types extends Type<unknown>[]> extends CompositeType<
     return this.value_toTree(view);
   }
 
+  // TODO - batch
   commitViewDU(view: ValueOfTypes<Types>): Node {
     return this.value_toTree(view);
   }

--- a/packages/ssz/src/type/vectorBasic.ts
+++ b/packages/ssz/src/type/vectorBasic.ts
@@ -1,4 +1,4 @@
-import {Node, Tree} from "@chainsafe/persistent-merkle-tree";
+import {HashComputationGroup, Node, Tree} from "@chainsafe/persistent-merkle-tree";
 import {maxChunksToDepth, splitIntoRootChunks} from "../util/merkleize";
 import {Require} from "../util/types";
 import {namedClass} from "../util/named";
@@ -83,8 +83,8 @@ export class VectorBasicType<ElementType extends BasicType<unknown>>
     return view.node;
   }
 
-  commitViewDU(view: ArrayBasicTreeViewDU<ElementType>): Node {
-    view.commit();
+  commitViewDU(view: ArrayBasicTreeViewDU<ElementType>, hashComps: HashComputationGroup | null = null): Node {
+    view.commit(hashComps);
     return view.node;
   }
 
@@ -130,6 +130,10 @@ export class VectorBasicType<ElementType extends BasicType<unknown>>
 
   tree_getChunksNode(node: Node): Node {
     return node;
+  }
+
+  tree_chunksNodeOffset(): number {
+    return 0;
   }
 
   tree_setChunksNode(rootNode: Node, chunksNode: Node): Node {

--- a/packages/ssz/src/type/vectorComposite.ts
+++ b/packages/ssz/src/type/vectorComposite.ts
@@ -1,4 +1,4 @@
-import {Node, Tree} from "@chainsafe/persistent-merkle-tree";
+import {HashComputationGroup, Node, Tree} from "@chainsafe/persistent-merkle-tree";
 import {maxChunksToDepth} from "../util/merkleize";
 import {Require} from "../util/types";
 import {namedClass} from "../util/named";
@@ -90,8 +90,8 @@ export class VectorCompositeType<
     return view.node;
   }
 
-  commitViewDU(view: ArrayCompositeTreeViewDU<ElementType>): Node {
-    view.commit();
+  commitViewDU(view: ArrayCompositeTreeViewDU<ElementType>, hashComps: HashComputationGroup | null = null): Node {
+    view.commit(hashComps);
     return view.node;
   }
 
@@ -137,6 +137,10 @@ export class VectorCompositeType<
 
   tree_getChunksNode(node: Node): Node {
     return node;
+  }
+
+  tree_chunksNodeOffset(): number {
+    return 0;
   }
 
   tree_setChunksNode(rootNode: Node, chunksNode: Node): Node {

--- a/packages/ssz/src/view/arrayBasic.ts
+++ b/packages/ssz/src/view/arrayBasic.ts
@@ -28,7 +28,7 @@ export type ArrayBasicType<ElementType extends BasicType<unknown>> = CompositeTy
     rootNode: Node,
     chunksNode: Node,
     newLength: number | null,
-    hashComps: HashComputationGroup | null
+    hashComps?: HashComputationGroup | null
   ): Node;
 };
 

--- a/packages/ssz/src/view/arrayBasic.ts
+++ b/packages/ssz/src/view/arrayBasic.ts
@@ -1,4 +1,4 @@
-import {getNodesAtDepth, LeafNode, Node, Tree} from "@chainsafe/persistent-merkle-tree";
+import {getNodesAtDepth, HashComputationGroup, LeafNode, Node, Tree} from "@chainsafe/persistent-merkle-tree";
 import {ValueOf} from "../type/abstract";
 import {BasicType} from "../type/basic";
 import {CompositeType} from "../type/composite";
@@ -21,8 +21,15 @@ export type ArrayBasicType<ElementType extends BasicType<unknown>> = CompositeTy
   tree_setLength(tree: Tree, length: number): void;
   /** INTERNAL METHOD: Return the chunks node from a root node */
   tree_getChunksNode(rootNode: Node): Node;
+  /** INTERNAL METHOD: Return the offset from root for HashComputation */
+  tree_chunksNodeOffset(): number;
   /** INTERNAL METHOD: Return a new root node with changed chunks node and length */
-  tree_setChunksNode(rootNode: Node, chunksNode: Node, newLength?: number): Node;
+  tree_setChunksNode(
+    rootNode: Node,
+    chunksNode: Node,
+    newLength: number | null,
+    hashComps: HashComputationGroup | null
+  ): Node;
 };
 
 export class ArrayBasicTreeView<ElementType extends BasicType<unknown>> extends TreeView<ArrayBasicType<ElementType>> {

--- a/packages/ssz/src/view/arrayComposite.ts
+++ b/packages/ssz/src/view/arrayComposite.ts
@@ -23,7 +23,7 @@ export type ArrayCompositeType<
     rootNode: Node,
     chunksNode: Node,
     newLength: number | null,
-    hashComps: HashComputationGroup | null
+    hashComps?: HashComputationGroup | null
   ): Node;
 };
 

--- a/packages/ssz/src/view/arrayComposite.ts
+++ b/packages/ssz/src/view/arrayComposite.ts
@@ -1,4 +1,4 @@
-import {getNodesAtDepth, Node, toGindexBitstring, Tree} from "@chainsafe/persistent-merkle-tree";
+import {getNodesAtDepth, HashComputationGroup, Node, toGindexBitstring, Tree} from "@chainsafe/persistent-merkle-tree";
 import {ValueOf} from "../type/abstract";
 import {CompositeType, CompositeView, CompositeViewDU} from "../type/composite";
 import {TreeView} from "./abstract";
@@ -16,8 +16,15 @@ export type ArrayCompositeType<
   tree_setLength(tree: Tree, length: number): void;
   /** INTERNAL METHOD: Return the chunks node from a root node */
   tree_getChunksNode(rootNode: Node): Node;
+  /** INTERNAL METHOD: Return the offset from root for HashComputation */
+  tree_chunksNodeOffset(): number;
   /** INTERNAL METHOD: Return a new root node with changed chunks node and length */
-  tree_setChunksNode(rootNode: Node, chunksNode: Node, newLength?: number): Node;
+  tree_setChunksNode(
+    rootNode: Node,
+    chunksNode: Node,
+    newLength: number | null,
+    hashComps: HashComputationGroup | null
+  ): Node;
 };
 
 export class ArrayCompositeTreeView<

--- a/packages/ssz/src/viewDU/abstract.ts
+++ b/packages/ssz/src/viewDU/abstract.ts
@@ -64,8 +64,7 @@ export abstract class TreeViewDU<T extends CompositeType<unknown, unknown, unkno
    * https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#merkleization
    */
   hashTreeRoot(): Uint8Array {
-    // remember not to do a commit() before calling this function
-    // in ethereum consensus, the only type goes with TVDU is BeaconState and it's really more efficient to hash the tree in batch
+    // if calling commit() before this function, it'll traverse down the tree to get HashComputations
     // if consumers don't want to batch hash, just go with `this.node.root` similar to what View.hashTreeRoot() does
     // there should not be another ViewDU.hashTreeRoot() during this flow so it's safe to reuse nextHashComps
     const hashComps = nextHashComps;

--- a/packages/ssz/src/viewDU/abstract.ts
+++ b/packages/ssz/src/viewDU/abstract.ts
@@ -1,5 +1,21 @@
+import {HashComputationGroup, executeHashComputations} from "@chainsafe/persistent-merkle-tree";
 import {ByteViews, CompositeType} from "../type/composite";
 import {TreeView} from "../view/abstract";
+
+/**
+ * Always allocating a new HashComputationGroup for each hashTreeRoot() is not great for gc
+ * because a lot of ViewDUs are not changed and computed root already.
+ */
+let nextHashComps: HashComputationGroup = {
+  byLevel: [],
+  offset: 0,
+};
+
+const symbolCachedTreeRoot = Symbol("ssz_cached_tree_root");
+
+export type NodeWithCachedTreeRoot = {
+  [symbolCachedTreeRoot]?: Uint8Array;
+};
 
 /* eslint-disable @typescript-eslint/member-ordering  */
 
@@ -19,7 +35,7 @@ export abstract class TreeViewDU<T extends CompositeType<unknown, unknown, unkno
   /**
    * Applies any deferred updates that may be pending in this ViewDU instance and updates its internal `Node`.
    */
-  abstract commit(): void;
+  abstract commit(hashComps?: HashComputationGroup | null): void;
 
   /**
    * Returns arbitrary data that is useful for this ViewDU instance to optimize data manipulation. This caches MUST
@@ -48,13 +64,39 @@ export abstract class TreeViewDU<T extends CompositeType<unknown, unknown, unkno
    * https://github.com/ethereum/consensus-specs/blob/dev/ssz/simple-serialize.md#merkleization
    */
   hashTreeRoot(): Uint8Array {
-    this.commit();
-    return super.hashTreeRoot();
+    // remember not to do a commit() before calling this function
+    // in ethereum consensus, the only type goes with TVDU is BeaconState and it's really more efficient to hash the tree in batch
+    // if consumers don't want to batch hash, just go with `this.node.root` similar to what View.hashTreeRoot() does
+    // there should not be another ViewDU.hashTreeRoot() during this flow so it's safe to reuse nextHashComps
+    const hashComps = nextHashComps;
+    this.commit(hashComps);
+    if (nextHashComps.byLevel.length > 0 || nextHashComps.offset !== 0) {
+      // preallocate for the next time
+      nextHashComps = {
+        byLevel: [],
+        offset: 0,
+      };
+      executeHashComputations(hashComps.byLevel);
+      // This makes sure the root node is computed by batch
+      if (this.node.h0 === null) {
+        throw Error("Root is not computed by batch");
+      }
+    }
+
+    const cachedRoot = (this.node as NodeWithCachedTreeRoot)[symbolCachedTreeRoot];
+    if (cachedRoot) {
+      return cachedRoot;
+    } else {
+      const root = this.node.root;
+      (this.node as NodeWithCachedTreeRoot)[symbolCachedTreeRoot] = root;
+      return root;
+    }
   }
 
   /**
    * Serialize view to binary data.
    * Commits any pending changes before computing the root.
+   * Warning: this calls commit() which evict all pending HashComputations. Consider calling hashTreeRoot() before this
    */
   serialize(): Uint8Array {
     this.commit();

--- a/packages/ssz/src/viewDU/arrayBasic.ts
+++ b/packages/ssz/src/viewDU/arrayBasic.ts
@@ -1,4 +1,12 @@
-import {getNodeAtDepth, getNodesAtDepth, LeafNode, Node, setNodesAtDepth} from "@chainsafe/persistent-merkle-tree";
+import {
+  getHashComputations,
+  getNodeAtDepth,
+  getNodesAtDepth,
+  HashComputationGroup,
+  LeafNode,
+  Node,
+  setNodesAtDepth,
+} from "@chainsafe/persistent-merkle-tree";
 import {ValueOf} from "../type/abstract";
 import {BasicType} from "../type/basic";
 import {ArrayBasicType} from "../view/arrayBasic";
@@ -151,8 +159,17 @@ export class ArrayBasicTreeViewDU<ElementType extends BasicType<unknown>> extend
     return values;
   }
 
-  commit(): void {
+  /**
+   * When we need to compute HashComputations (hashComps != null):
+   *   - if old _rootNode is hashed, then only need to put pending changes to HashComputationGroup
+   *   - if old _rootNode is not hashed, need to traverse and put to HashComputationGroup
+   */
+  commit(hashComps: HashComputationGroup | null = null): void {
+    const isOldRootHashed = this._rootNode.h0 !== null;
     if (this.nodesChanged.size === 0) {
+      if (!isOldRootHashed && hashComps !== null) {
+        getHashComputations(this._rootNode, hashComps.offset, hashComps.byLevel);
+      }
       return;
     }
 
@@ -164,14 +181,25 @@ export class ArrayBasicTreeViewDU<ElementType extends BasicType<unknown>> extend
     }
 
     const chunksNode = this.type.tree_getChunksNode(this._rootNode);
-    // TODO: Ensure fast setNodesAtDepth() method is correct
-    const newChunksNode = setNodesAtDepth(chunksNode, this.type.chunkDepth, indexes, nodes);
+    const hashCompsThis =
+      hashComps != null && isOldRootHashed
+        ? {
+            byLevel: hashComps.byLevel,
+            offset: hashComps.offset + this.type.tree_chunksNodeOffset(),
+          }
+        : null;
+    const newChunksNode = setNodesAtDepth(chunksNode, this.type.chunkDepth, indexes, nodes, hashCompsThis);
 
     this._rootNode = this.type.tree_setChunksNode(
       this._rootNode,
       newChunksNode,
-      this.dirtyLength ? this._length : undefined
+      this.dirtyLength ? this._length : null,
+      isOldRootHashed ? hashComps : null
     );
+
+    if (!isOldRootHashed && hashComps !== null) {
+      getHashComputations(this._rootNode, hashComps.offset, hashComps.byLevel);
+    }
 
     this.nodesChanged.clear();
     this.dirtyLength = false;

--- a/packages/ssz/src/viewDU/bitArray.ts
+++ b/packages/ssz/src/viewDU/bitArray.ts
@@ -1,4 +1,4 @@
-import {Node} from "@chainsafe/persistent-merkle-tree";
+import {HashComputationGroup, Node, getHashComputations} from "@chainsafe/persistent-merkle-tree";
 import {BitArray} from "../value/bitArray";
 import {CompositeType} from "../type/composite";
 import {TreeViewDU} from "./abstract";
@@ -22,9 +22,13 @@ export class BitArrayTreeViewDU extends TreeViewDU<CompositeType<BitArray, unkno
     return;
   }
 
-  commit(): void {
+  commit(hashComps: HashComputationGroup | null = null): void {
     if (this._bitArray !== null) {
       this._rootNode = this.type.value_toTree(this._bitArray);
+    }
+
+    if (hashComps !== null && this._rootNode.h0 === null) {
+      getHashComputations(this._rootNode, hashComps.offset, hashComps.byLevel);
     }
   }
 

--- a/packages/ssz/src/viewDU/container.ts
+++ b/packages/ssz/src/viewDU/container.ts
@@ -152,11 +152,7 @@ class ContainerTreeViewDU<Fields extends Record<string, Type<unknown>>> extends 
    * Same method to `type/container.ts` that call ViewDU.serializeToBytes() of internal fields.
    */
   serializeToBytes(output: ByteViews, offset: number): number {
-    // it's the responsibility of consumer to call commit() before calling this method
-    // if we do the commit() here, it'll lose all HashComputations that we want to batch
-    if (this.nodesChanged.size !== 0 || this.viewsChanged.size !== 0) {
-      throw Error(`Must commit changes before serializeToBytes(Uint8Array(${output.uint8Array.length}, ${offset})`);
-    }
+    this.commit();
 
     let fixedIndex = offset;
     let variableIndex = offset + this.type.fixedEnd;

--- a/packages/ssz/src/viewDU/container.ts
+++ b/packages/ssz/src/viewDU/container.ts
@@ -1,4 +1,11 @@
-import {getNodeAtDepth, LeafNode, Node, setNodesAtDepth} from "@chainsafe/persistent-merkle-tree";
+import {
+  getHashComputations,
+  getNodeAtDepth,
+  HashComputationGroup,
+  LeafNode,
+  Node,
+  setNodesAtDepth,
+} from "@chainsafe/persistent-merkle-tree";
 import {ByteViews, Type} from "../type/abstract";
 import {BasicType, isBasicType} from "../type/basic";
 import {CompositeType, isCompositeType, CompositeTypeAny} from "../type/composite";
@@ -68,16 +75,31 @@ class ContainerTreeViewDU<Fields extends Record<string, Type<unknown>>> extends 
     };
   }
 
-  commit(): void {
+  /**
+   * When we need to compute HashComputations (hashComps != null):
+   *   - if old _rootNode is hashed, then only need to put pending changes to HashComputationGroup
+   *   - if old _rootNode is not hashed, need to traverse and put to HashComputationGroup
+   */
+  commit(hashComps: HashComputationGroup | null = null): void {
+    const isOldRootHashed = this._rootNode.h0 !== null;
     if (this.nodesChanged.size === 0 && this.viewsChanged.size === 0) {
+      if (!isOldRootHashed && hashComps !== null) {
+        getHashComputations(this._rootNode, hashComps.offset, hashComps.byLevel);
+      }
       return;
     }
 
     const nodesChanged: {index: number; node: Node}[] = [];
 
+    let hashCompsView: HashComputationGroup | null = null;
+    // if old root is not hashed, no need to pass HashComputationGroup to child view bc we need to do full traversal here
+    if (hashComps != null && isOldRootHashed) {
+      // each view may mutate HashComputationGroup at offset + depth
+      hashCompsView = {byLevel: hashComps.byLevel, offset: hashComps.offset + this.type.depth};
+    }
     for (const [index, view] of this.viewsChanged) {
       const fieldType = this.type.fieldsEntries[index].fieldType as unknown as CompositeTypeAny;
-      const node = fieldType.commitViewDU(view);
+      const node = fieldType.commitViewDU(view, hashCompsView);
       // Set new node in nodes array to ensure data represented in the tree and fast nodes access is equal
       this.nodes[index] = node;
       nodesChanged.push({index, node});
@@ -96,7 +118,18 @@ class ContainerTreeViewDU<Fields extends Record<string, Type<unknown>>> extends 
     const indexes = nodesChangedSorted.map((entry) => entry.index);
     const nodes = nodesChangedSorted.map((entry) => entry.node);
 
-    this._rootNode = setNodesAtDepth(this._rootNode, this.type.depth, indexes, nodes);
+    this._rootNode = setNodesAtDepth(
+      this._rootNode,
+      this.type.depth,
+      indexes,
+      nodes,
+      isOldRootHashed ? hashComps : null
+    );
+
+    // old root is not hashed, need to traverse and put to HashComputationGroup
+    if (!isOldRootHashed && hashComps !== null) {
+      getHashComputations(this._rootNode, hashComps.offset, hashComps.byLevel);
+    }
 
     this.nodesChanged.clear();
     this.viewsChanged.clear();
@@ -119,7 +152,11 @@ class ContainerTreeViewDU<Fields extends Record<string, Type<unknown>>> extends 
    * Same method to `type/container.ts` that call ViewDU.serializeToBytes() of internal fields.
    */
   serializeToBytes(output: ByteViews, offset: number): number {
-    this.commit();
+    // it's the responsibility of consumer to call commit() before calling this method
+    // if we do the commit() here, it'll lose all HashComputations that we want to batch
+    if (this.nodesChanged.size !== 0 || this.viewsChanged.size !== 0) {
+      throw Error(`Must commit changes before serializeToBytes(Uint8Array(${output.uint8Array.length}, ${offset})`);
+    }
 
     let fixedIndex = offset;
     let variableIndex = offset + this.type.fixedEnd;

--- a/packages/ssz/src/viewDU/listBasic.ts
+++ b/packages/ssz/src/viewDU/listBasic.ts
@@ -49,11 +49,8 @@ export class ListBasicTreeViewDU<ElementType extends BasicType<unknown>> extends
       throw Error(`Does not support sliceTo() with negative index ${index}`);
     }
 
-    // it's the responsibility of consumer to call commit() before calling this method
-    // if we do the commit() here, it'll lose all HashComputations that we want to batch
-    if (this.nodesChanged.size > 0) {
-      throw Error(`Must commit changes before sliceTo(${index})`);
-    }
+    // Commit before getting rootNode to ensure all pending data is in the rootNode
+    this.commit();
 
     // All nodes beyond length are already zero
     if (index >= this._length - 1) {
@@ -87,11 +84,7 @@ export class ListBasicTreeViewDU<ElementType extends BasicType<unknown>> extends
    * Same method to `type/listBasic.ts` leveraging cached nodes.
    */
   serializeToBytes(output: ByteViews, offset: number): number {
-    // it's the responsibility of consumer to call commit() before calling this method
-    // if we do the commit() here, it'll lose all HashComputations that we want to batch
-    if (this.nodesChanged.size > 0) {
-      throw Error(`Must commit changes before serializeToBytes(Uint8Array(${output.uint8Array.length}), ${offset})`);
-    }
+    this.commit();
     const {nodes, nodesPopulated} = this.cache;
     const chunksNode = this.type.tree_getChunksNode(this._rootNode);
     return tree_serializeToBytesArrayBasic(

--- a/packages/ssz/src/viewDU/listComposite.ts
+++ b/packages/ssz/src/viewDU/listComposite.ts
@@ -44,8 +44,11 @@ export class ListCompositeTreeViewDU<
    * Note: Using index = -1, returns an empty list of length 0.
    */
   sliceTo(index: number): this {
-    // Commit before getting rootNode to ensure all pending data is in the rootNode
-    this.commit();
+    // it's the responsibility of consumer to call commit() before calling this method
+    // if we do the commit() here, it'll lose all HashComputations that we want to batch
+    if (this.viewsChanged.size > 0) {
+      throw Error(`Must commit changes before sliceTo(${index})`);
+    }
     const rootNode = this._rootNode;
     const length = this._length;
 
@@ -61,7 +64,7 @@ export class ListCompositeTreeViewDU<
 
     // Must set new length and commit to tree to restore the same tree at that index
     const newLength = index + 1;
-    const newRootNode = this.type.tree_setChunksNode(rootNode, newChunksNode, newLength);
+    const newRootNode = this.type.tree_setChunksNode(rootNode, newChunksNode, newLength, null);
 
     return this.type.getViewDU(newRootNode) as this;
   }
@@ -102,7 +105,7 @@ export class ListCompositeTreeViewDU<
       newLength = nodes.length;
     }
 
-    const newRootNode = this.type.tree_setChunksNode(this._rootNode, newChunksNode, newLength);
+    const newRootNode = this.type.tree_setChunksNode(this._rootNode, newChunksNode, newLength, null);
 
     return this.type.getViewDU(newRootNode) as this;
   }
@@ -111,7 +114,11 @@ export class ListCompositeTreeViewDU<
    * Same method to `type/listComposite.ts` leveraging cached nodes.
    */
   serializeToBytes(output: ByteViews, offset: number): number {
-    this.commit();
+    // it's the responsibility of consumer to call commit() before calling this method
+    // if we do the commit() here, it'll lose all HashComputations that we want to batch
+    if (this.viewsChanged.size > 0) {
+      throw Error(`Must commit changes before serializeToBytes(Uint8Array(${output.uint8Array.length}, ${offset})`);
+    }
     this.populateAllNodes();
     const chunksNode = this.type.tree_getChunksNode(this._rootNode);
     return tree_serializeToBytesArrayComposite(

--- a/packages/ssz/src/viewDU/listComposite.ts
+++ b/packages/ssz/src/viewDU/listComposite.ts
@@ -44,11 +44,8 @@ export class ListCompositeTreeViewDU<
    * Note: Using index = -1, returns an empty list of length 0.
    */
   sliceTo(index: number): this {
-    // it's the responsibility of consumer to call commit() before calling this method
-    // if we do the commit() here, it'll lose all HashComputations that we want to batch
-    if (this.viewsChanged.size > 0) {
-      throw Error(`Must commit changes before sliceTo(${index})`);
-    }
+    // Commit before getting rootNode to ensure all pending data is in the rootNode
+    this.commit();
     const rootNode = this._rootNode;
     const length = this._length;
 
@@ -114,11 +111,7 @@ export class ListCompositeTreeViewDU<
    * Same method to `type/listComposite.ts` leveraging cached nodes.
    */
   serializeToBytes(output: ByteViews, offset: number): number {
-    // it's the responsibility of consumer to call commit() before calling this method
-    // if we do the commit() here, it'll lose all HashComputations that we want to batch
-    if (this.viewsChanged.size > 0) {
-      throw Error(`Must commit changes before serializeToBytes(Uint8Array(${output.uint8Array.length}, ${offset})`);
-    }
+    this.commit();
     this.populateAllNodes();
     const chunksNode = this.type.tree_getChunksNode(this._rootNode);
     return tree_serializeToBytesArrayComposite(

--- a/packages/ssz/test/lodestarTypes/phase0/listValidator.ts
+++ b/packages/ssz/test/lodestarTypes/phase0/listValidator.ts
@@ -1,0 +1,15 @@
+import {ListCompositeType} from "../../../src/type/listComposite";
+import {Node} from "@chainsafe/persistent-merkle-tree";
+import {ListCompositeTreeViewDU} from "../../../src/viewDU/listComposite";
+import {ValidatorNodeStructType} from "./validator";
+import {ListValidatorTreeViewDU} from "./viewDU/listValidator";
+
+export class ListValidatorType extends ListCompositeType<ValidatorNodeStructType> {
+  constructor(limit: number) {
+    super(new ValidatorNodeStructType(), limit);
+  }
+
+  getViewDU(node: Node, cache?: unknown): ListCompositeTreeViewDU<ValidatorNodeStructType> {
+    return new ListValidatorTreeViewDU(this, node, cache as any);
+  }
+}

--- a/packages/ssz/test/lodestarTypes/phase0/sszTypes.ts
+++ b/packages/ssz/test/lodestarTypes/phase0/sszTypes.ts
@@ -2,7 +2,6 @@ import {
   BitListType,
   BitVectorType,
   ContainerType,
-  ContainerNodeStructType,
   ListBasicType,
   ListCompositeType,
   VectorBasicType,
@@ -17,6 +16,10 @@ import {
   ATTESTATION_SUBNET_COUNT,
 } from "../params";
 import * as primitiveSsz from "../primitive/sszTypes";
+import {ListValidatorType} from "./listValidator";
+import {ValidatorNodeStruct} from "./validator";
+
+export {ValidatorNodeStruct};
 
 const {
   EPOCHS_PER_ETH1_VOTING_PERIOD,
@@ -245,12 +248,11 @@ export const ValidatorContainer = new ContainerType(
   {typeName: "Validator", jsonCase: "eth2"}
 );
 
-export const ValidatorNodeStruct = new ContainerNodeStructType(ValidatorContainer.fields, ValidatorContainer.opts);
 // The main Validator type is the 'ContainerNodeStructType' version
 export const Validator = ValidatorNodeStruct;
 
 // Export as stand-alone for direct tree optimizations
-export const Validators = new ListCompositeType(ValidatorNodeStruct, VALIDATOR_REGISTRY_LIMIT);
+export const Validators = new ListValidatorType(VALIDATOR_REGISTRY_LIMIT);
 export const Balances = new ListUintNum64Type(VALIDATOR_REGISTRY_LIMIT);
 export const RandaoMixes = new VectorCompositeType(Bytes32, EPOCHS_PER_HISTORICAL_VECTOR);
 export const Slashings = new VectorBasicType(Gwei, EPOCHS_PER_SLASHINGS_VECTOR);

--- a/packages/ssz/test/lodestarTypes/phase0/validator.ts
+++ b/packages/ssz/test/lodestarTypes/phase0/validator.ts
@@ -1,0 +1,130 @@
+import {ByteViews} from "../../../src/type/abstract";
+import {ContainerNodeStructType} from "../../../src/type/containerNodeStruct";
+import {ValueOfFields} from "../../../src/view/container";
+import * as primitiveSsz from "../primitive/sszTypes";
+
+const {Boolean, Bytes32, UintNum64, BLSPubkey, EpochInf} = primitiveSsz;
+
+// this is to work with uint32, see https://github.com/ChainSafe/ssz/blob/ssz-v0.15.1/packages/ssz/src/type/uint.ts
+const NUMBER_2_POW_32 = 2 ** 32;
+
+/*
+ * Below constants are respective to their ssz type in `ValidatorType`.
+ */
+const UINT32_SIZE = 4;
+const PUBKEY_SIZE = 48;
+const WITHDRAWAL_CREDENTIALS_SIZE = 32;
+const SLASHED_SIZE = 1;
+const CHUNK_SIZE = 32;
+
+export const ValidatorType = {
+  pubkey: BLSPubkey,
+  withdrawalCredentials: Bytes32,
+  effectiveBalance: UintNum64,
+  slashed: Boolean,
+  activationEligibilityEpoch: EpochInf,
+  activationEpoch: EpochInf,
+  exitEpoch: EpochInf,
+  withdrawableEpoch: EpochInf,
+};
+
+/**
+ * Improve serialization performance for state.validators.serialize();
+ */
+export class ValidatorNodeStructType extends ContainerNodeStructType<typeof ValidatorType> {
+  constructor() {
+    super(ValidatorType, {typeName: "Validator", jsonCase: "eth2"});
+  }
+
+  value_serializeToBytes(
+    {uint8Array: output, dataView}: ByteViews,
+    offset: number,
+    validator: ValueOfFields<typeof ValidatorType>
+  ): number {
+    output.set(validator.pubkey, offset);
+    offset += PUBKEY_SIZE;
+    output.set(validator.withdrawalCredentials, offset);
+    offset += WITHDRAWAL_CREDENTIALS_SIZE;
+    const {effectiveBalance, activationEligibilityEpoch, activationEpoch, exitEpoch, withdrawableEpoch} = validator;
+    // effectiveBalance is UintNum64
+    dataView.setUint32(offset, effectiveBalance & 0xffffffff, true);
+    offset += UINT32_SIZE;
+    dataView.setUint32(offset, (effectiveBalance / NUMBER_2_POW_32) & 0xffffffff, true);
+    offset += UINT32_SIZE;
+    output[offset] = validator.slashed ? 1 : 0;
+    offset += SLASHED_SIZE;
+    offset = writeEpochInf(dataView, offset, activationEligibilityEpoch);
+    offset = writeEpochInf(dataView, offset, activationEpoch);
+    offset = writeEpochInf(dataView, offset, exitEpoch);
+    offset = writeEpochInf(dataView, offset, withdrawableEpoch);
+
+    return offset;
+  }
+}
+
+export const ValidatorNodeStruct = new ValidatorNodeStructType();
+
+/**
+ * Write to level3 and level4 bytes to compute merkle root. Note that this is to compute
+ * merkle root and it's different from serialization (which is more compressed).
+ * pub0 + pub1 are at level4, they will be hashed to 1st chunked of level 3
+ * then use 8 chunks of level 3 to compute the root hash.
+ *           reserved     withdr     eff        sla        actElig    act        exit       with
+ * level 3 |----------|----------|----------|----------|----------|----------|----------|----------|
+ *
+ *            pub0       pub1
+ * level4  |----------|----------|
+ *
+ */
+export function validatorToChunkBytes(
+  level3: ByteViews,
+  level4: Uint8Array,
+  value: ValueOfFields<typeof ValidatorType>
+): void {
+  const {
+    pubkey,
+    withdrawalCredentials,
+    effectiveBalance,
+    slashed,
+    activationEligibilityEpoch,
+    activationEpoch,
+    exitEpoch,
+    withdrawableEpoch,
+  } = value;
+  const {uint8Array: outputLevel3, dataView} = level3;
+
+  // pubkey = 48 bytes which is 2 * CHUNK_SIZE
+  level4.set(pubkey, 0);
+  let offset = CHUNK_SIZE;
+  outputLevel3.set(withdrawalCredentials, offset);
+  offset += CHUNK_SIZE;
+  // effectiveBalance is UintNum64
+  dataView.setUint32(offset, effectiveBalance & 0xffffffff, true);
+  dataView.setUint32(offset + 4, (effectiveBalance / NUMBER_2_POW_32) & 0xffffffff, true);
+
+  offset += CHUNK_SIZE;
+  dataView.setUint32(offset, slashed ? 1 : 0, true);
+  offset += CHUNK_SIZE;
+  writeEpochInf(dataView, offset, activationEligibilityEpoch);
+  offset += CHUNK_SIZE;
+  writeEpochInf(dataView, offset, activationEpoch);
+  offset += CHUNK_SIZE;
+  writeEpochInf(dataView, offset, exitEpoch);
+  offset += CHUNK_SIZE;
+  writeEpochInf(dataView, offset, withdrawableEpoch);
+}
+
+function writeEpochInf(dataView: DataView, offset: number, value: number): number {
+  if (value === Infinity) {
+    dataView.setUint32(offset, 0xffffffff, true);
+    offset += UINT32_SIZE;
+    dataView.setUint32(offset, 0xffffffff, true);
+    offset += UINT32_SIZE;
+  } else {
+    dataView.setUint32(offset, value & 0xffffffff, true);
+    offset += UINT32_SIZE;
+    dataView.setUint32(offset, (value / NUMBER_2_POW_32) & 0xffffffff, true);
+    offset += UINT32_SIZE;
+  }
+  return offset;
+}

--- a/packages/ssz/test/lodestarTypes/phase0/viewDU/listValidator.ts
+++ b/packages/ssz/test/lodestarTypes/phase0/viewDU/listValidator.ts
@@ -1,0 +1,151 @@
+import {byteArrayIntoHashObject} from "@chainsafe/as-sha256";
+import {HashComputationGroup, Node, digestNLevel, setNodesAtDepth} from "@chainsafe/persistent-merkle-tree";
+import {ListCompositeType} from "../../../../src/type/listComposite";
+import {ArrayCompositeTreeViewDUCache} from "../../../../src/viewDU/arrayComposite";
+import {ListCompositeTreeViewDU} from "../../../../src/viewDU/listComposite";
+import {ValidatorNodeStructType, ValidatorType, validatorToChunkBytes} from "../validator";
+import {ByteViews} from "../../../../src";
+import {ContainerNodeStructTreeViewDU} from "../../../../src/viewDU/containerNodeStruct";
+
+/**
+ * hashtree has a MAX_SIZE of 1024 bytes = 32 chunks
+ * Given a level3 of validators have 8 chunks, we can hash 4 validators at a time
+ */
+const PARALLEL_FACTOR = 4;
+/**
+ * Allocate memory once for batch hash validators.
+ */
+// each level 3 of validator has 8 chunks, each chunk has 32 bytes
+const batchLevel3Bytes = new Uint8Array(PARALLEL_FACTOR * 8 * 32);
+const level3ByteViewsArr: ByteViews[] = [];
+for (let i = 0; i < PARALLEL_FACTOR; i++) {
+  const uint8Array = batchLevel3Bytes.subarray(i * 8 * 32, (i + 1) * 8 * 32);
+  const dataView = new DataView(uint8Array.buffer, uint8Array.byteOffset, uint8Array.byteLength);
+  level3ByteViewsArr.push({uint8Array, dataView});
+}
+// each level 4 of validator has 2 chunks for pubkey, each chunk has 32 bytes
+const batchLevel4Bytes = new Uint8Array(PARALLEL_FACTOR * 2 * 32);
+const level4BytesArr: Uint8Array[] = [];
+for (let i = 0; i < PARALLEL_FACTOR; i++) {
+  level4BytesArr.push(batchLevel4Bytes.subarray(i * 2 * 32, (i + 1) * 2 * 32));
+}
+const pubkeyRoots: Uint8Array[] = [];
+for (let i = 0; i < PARALLEL_FACTOR; i++) {
+  pubkeyRoots.push(batchLevel4Bytes.subarray(i * 32, (i + 1) * 32));
+}
+
+const validatorRoots: Uint8Array[] = [];
+for (let i = 0; i < PARALLEL_FACTOR; i++) {
+  validatorRoots.push(batchLevel3Bytes.subarray(i * 32, (i + 1) * 32));
+}
+
+export class ListValidatorTreeViewDU extends ListCompositeTreeViewDU<ValidatorNodeStructType> {
+  constructor(
+    readonly type: ListCompositeType<ValidatorNodeStructType>,
+    protected _rootNode: Node,
+    cache?: ArrayCompositeTreeViewDUCache
+  ) {
+    super(type, _rootNode, cache);
+  }
+
+  commit(hashComps: HashComputationGroup | null = null): void {
+    const isOldRootHashed = this._rootNode.h0 !== null;
+    if (this.viewsChanged.size === 0) {
+      if (!isOldRootHashed && hashComps !== null) {
+        // not possible to get HashComputations due to BranchNodeStruct
+        this._rootNode.root;
+      }
+      return;
+    }
+
+    // TODO - batch: remove this type cast
+    const viewsChanged = this.viewsChanged as unknown as Map<
+      number,
+      ContainerNodeStructTreeViewDU<typeof ValidatorType>
+    >;
+    const indicesChanged = Array.from(this.viewsChanged.keys()).sort((a, b) => a - b);
+    const endBatch = indicesChanged.length - (indicesChanged.length % PARALLEL_FACTOR);
+    // nodesChanged is sorted by index
+    const nodesChanged: {index: number; node: Node}[] = [];
+    // commit every 16 validators in batch
+    for (let i = 0; i < endBatch; i++) {
+      if (i % PARALLEL_FACTOR === 0) {
+        batchLevel3Bytes.fill(0);
+        batchLevel4Bytes.fill(0);
+      }
+      const indexInBatch = i % PARALLEL_FACTOR;
+      const viewIndex = indicesChanged[i];
+      const viewChanged = viewsChanged.get(viewIndex);
+      if (viewChanged) {
+        validatorToChunkBytes(level3ByteViewsArr[indexInBatch], level4BytesArr[indexInBatch], viewChanged.value);
+      }
+
+      if (indexInBatch === PARALLEL_FACTOR - 1) {
+        // hash level 4, this is populated to pubkeyRoots
+        digestNLevel(batchLevel4Bytes, 1);
+        for (let j = 0; j < PARALLEL_FACTOR; j++) {
+          level3ByteViewsArr[j].uint8Array.set(pubkeyRoots[j], 0);
+        }
+        // hash level 3, this is populated to validatorRoots
+        digestNLevel(batchLevel3Bytes, 3);
+        // commit all validators in this batch
+        for (let j = PARALLEL_FACTOR - 1; j >= 0; j--) {
+          const viewIndex = indicesChanged[i - j];
+          const indexInBatch = (i - j) % PARALLEL_FACTOR;
+          const viewChanged = viewsChanged.get(viewIndex);
+          if (viewChanged) {
+            viewChanged.commitNoHash();
+            const branchNodeStruct = viewChanged.node;
+            byteArrayIntoHashObject(validatorRoots[indexInBatch], 0, branchNodeStruct);
+            nodesChanged.push({index: viewIndex, node: viewChanged.node});
+            // Set new node in nodes array to ensure data represented in the tree and fast nodes access is equal
+            this.nodes[viewIndex] = viewChanged.node;
+          }
+        }
+      }
+    }
+
+    // commit the remaining validators, we can do in batch too but don't want to create new Uint8Array views
+    // it's not much different to commit one by one
+    for (let i = endBatch; i < indicesChanged.length; i++) {
+      const viewIndex = indicesChanged[i];
+      const viewChanged = viewsChanged.get(viewIndex);
+      if (viewChanged) {
+        // commit and hash
+        viewChanged.commit();
+        nodesChanged.push({index: viewIndex, node: viewChanged.node});
+        // Set new node in nodes array to ensure data represented in the tree and fast nodes access is equal
+        this.nodes[viewIndex] = viewChanged.node;
+      }
+    }
+
+    // do the remaining commit step the same to parent (ArrayCompositeTreeViewDU)
+    const indexes = nodesChanged.map((entry) => entry.index);
+    const nodes = nodesChanged.map((entry) => entry.node);
+    const chunksNode = this.type.tree_getChunksNode(this._rootNode);
+    const hashCompsThis =
+      hashComps != null && isOldRootHashed
+        ? {
+            byLevel: hashComps.byLevel,
+            offset: hashComps.offset + this.type.tree_chunksNodeOffset(),
+          }
+        : null;
+    const newChunksNode = setNodesAtDepth(chunksNode, this.type.chunkDepth, indexes, nodes, hashCompsThis);
+
+    this._rootNode = this.type.tree_setChunksNode(
+      this._rootNode,
+      newChunksNode,
+      this.dirtyLength ? this._length : null,
+      hashComps
+    );
+
+    if (!isOldRootHashed && hashComps !== null) {
+      // should never happen, handle just in case
+      // not possible to get HashComputations due to BranchNodeStruct
+      this._rootNode.root;
+    }
+
+    this.viewsChanged.clear();
+    this.dirtyLength = false;
+  }
+}

--- a/packages/ssz/test/perf/eth2/beaconState.test.ts
+++ b/packages/ssz/test/perf/eth2/beaconState.test.ts
@@ -1,0 +1,208 @@
+import {itBench} from "@dapplion/benchmark";
+import {
+  BranchNode,
+  HashComputationGroup,
+  getHashComputations,
+  executeHashComputations,
+  HashComputation,
+} from "@chainsafe/persistent-merkle-tree";
+import {BeaconState} from "../../lodestarTypes/altair/sszTypes";
+import {BitArray, CompositeViewDU, toHexString} from "../../../src";
+
+const vc = 200_000;
+const numModified = vc / 2;
+// every we increase vc, need to change this value from "recursive hash" test
+const expectedRoot = "0x0bd3c6caecdf5b04e8ac48e41732aa5908019e072aa4e61c5298cf31a643eb70";
+
+/**
+ * This simulates a BeaconState being modified after an epoch transition in lodestar
+ * The fresh tree batch hash bechmark is in packages/persistent-merkle-tree/test/perf/node.test.ts
+ * Note that this benchmark is not very stable because we cannot apply runsFactor as once commit() we
+ * cannot compute HashComputationGroup again.
+ * Increasing number of validators could be OOM since we have to create BeaconState every time
+ */
+describe(`BeaconState ViewDU partially modified tree vc=${vc} numModified=${numModified}`, function () {
+  itBench({
+    id: `BeaconState ViewDU recursive hash vc=${vc}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      state.commit();
+      state.node.root;
+      // console.log("@@@@ root", toHexString(state.node.root));
+      if (toHexString(state.node.root) !== expectedRoot) {
+        throw new Error("hashTreeRoot does not match expectedRoot");
+      }
+    },
+  });
+
+  itBench({
+    id: `BeaconState ViewDU recursive hash - commit step vc=${vc}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      state.commit();
+    },
+  });
+
+  itBench({
+    id: `BeaconState ViewDU validator tree creation vc=${numModified}`,
+    beforeEach: () => {
+      const state = createPartiallyModifiedDenebState();
+      state.commit();
+      return state;
+    },
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      const validators = state.validators;
+      for (let i = 0; i < numModified; i++) {
+        validators.getReadonly(i).node.left;
+      }
+    },
+  });
+
+  itBench({
+    id: `BeaconState ViewDU batchHash vc=${vc}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      state.commit();
+      (state.node as BranchNode).batchHash();
+      if (toHexString(state.node.root) !== expectedRoot) {
+        throw new Error("hashTreeRoot does not match expectedRoot");
+      }
+    },
+  });
+
+  itBench({
+    id: `BeaconState ViewDU batchHash - commit & getHashComputation vc=${vc}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      state.commit();
+      getHashComputations(state.node, 0, []);
+    },
+  });
+
+  itBench({
+    id: `BeaconState ViewDU batchHash - hash step vc=${vc}`,
+    beforeEach: () => {
+      const state = createPartiallyModifiedDenebState();
+      state.commit();
+      const hashComputations: HashComputation[][] = [];
+      getHashComputations(state.node, 0, hashComputations);
+      return hashComputations;
+    },
+    fn: (hashComputations: HashComputation[][]) => {
+      executeHashComputations(hashComputations);
+    },
+  });
+
+  itBench({
+    id: `BeaconState ViewDU hashTreeRoot vc=${vc}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      // commit() step is inside hashTreeRoot()
+      if (toHexString(state.hashTreeRoot()) !== expectedRoot) {
+        throw new Error("hashTreeRoot does not match expectedRoot");
+      }
+    },
+  });
+
+  itBench({
+    id: `BeaconState ViewDU hashTreeRoot - commit step vc=${vc}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      const hashComps: HashComputationGroup = {
+        byLevel: [],
+        offset: 0,
+      };
+      state.commit(hashComps);
+    },
+  });
+
+  itBench({
+    id: `BeaconState ViewDU hashTreeRoot - hash step vc=${vc}`,
+    beforeEach: () => {
+      const state = createPartiallyModifiedDenebState();
+      const hashComps: HashComputationGroup = {
+        byLevel: [],
+        offset: 0,
+      };
+      state.commit(hashComps);
+      return hashComps;
+    },
+    fn: (hashComps) => {
+      executeHashComputations(hashComps.byLevel);
+    },
+  });
+
+  itBench.skip({
+    id: `BeaconState ViewDU hashTreeRoot - commit step each validator vc=${vc}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      const hashComps: HashComputationGroup = {
+        byLevel: [],
+        offset: 0,
+      };
+      for (let i = 0; i < numModified; i++) {
+        state.validators.get(i).commit(hashComps);
+      }
+    },
+  });
+});
+
+let originalState: CompositeViewDU<typeof BeaconState> | null = null;
+function createPartiallyModifiedDenebState(): CompositeViewDU<typeof BeaconState> {
+  if (originalState === null) {
+    originalState = createDenebState(vc);
+    // cache all roots
+    originalState.hashTreeRoot();
+  }
+
+  const state = originalState.clone();
+  for (let i = 0; i < numModified; i++) {
+    state.validators.get(i).effectiveBalance += 1e9;
+    state.balances.set(i, state.balances.get(i) + 1e9);
+  }
+  return state;
+}
+
+function createDenebState(vc: number): CompositeViewDU<typeof BeaconState> {
+  const state = BeaconState.defaultViewDU();
+  state.genesisTime = 1e9;
+  state.genesisValidatorsRoot = Buffer.alloc(32, 1);
+  state.fork = BeaconState.fields.fork.toViewDU({
+    epoch: 1000,
+    previousVersion: Buffer.alloc(4, 0x03),
+    currentVersion: Buffer.alloc(4, 0x04),
+  });
+  state.latestBlockHeader = BeaconState.fields.latestBlockHeader.toViewDU({
+    slot: 1000,
+    proposerIndex: 1,
+    parentRoot: Buffer.alloc(32, 0xac),
+    stateRoot: Buffer.alloc(32, 0xed),
+    bodyRoot: Buffer.alloc(32, 0x32),
+  });
+  const validators = Array.from({length: vc}, () => {
+    return {
+      pubkey: Buffer.alloc(48, 0xaa),
+      withdrawalCredentials: Buffer.alloc(32, 0xbb),
+      effectiveBalance: 32e9,
+      slashed: false,
+      activationEligibilityEpoch: 1_000_000,
+      activationEpoch: 2_000_000,
+      exitEpoch: 3_000_000,
+      withdrawableEpoch: 4_000_000,
+    };
+  });
+  state.validators = BeaconState.fields.validators.toViewDU(validators);
+  state.balances = BeaconState.fields.balances.toViewDU(Array.from({length: vc}, () => 32e9));
+  // randomMixes
+  // slashings
+  state.previousEpochParticipation = BeaconState.fields.previousEpochParticipation.toViewDU(
+    Array.from({length: vc}, () => 7)
+  );
+  state.currentEpochParticipation = BeaconState.fields.previousEpochParticipation.toViewDU(
+    Array.from({length: vc}, () => 7)
+  );
+  state.justificationBits = BeaconState.fields.justificationBits.toViewDU(
+    BitArray.fromBoolArray([true, false, true, true])
+  );
+  return state;
+}

--- a/packages/ssz/test/unit/byType/bitArray/tree.test.ts
+++ b/packages/ssz/test/unit/byType/bitArray/tree.test.ts
@@ -1,3 +1,4 @@
+import {expect} from "chai";
 import {BitVectorType, BitListType, BitArray} from "../../../../src";
 import {runViewTestMutation} from "../runViewTestMutation";
 
@@ -49,6 +50,22 @@ for (const type of [new BitVectorType(4), new BitListType(4)]) {
     ],
   });
 }
+
+describe("BitArray batchHash", () => {
+  const sszType = new BitListType(4);
+  const value = fromNum(4, 0b0010);
+  const expectedRoot = sszType.toView(value).hashTreeRoot();
+
+  it("fresh ViewDU", () => {
+    expect(sszType.toViewDU(value).hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("set then hashTreeRoot", () => {
+    const viewDU = sszType.toViewDU(fromNum(4, 0b0011));
+    viewDU.set(0, false);
+    expect(sszType.toViewDU(value).hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+});
 
 function fromNum(bitLen: number, num: number): BitArray {
   const bitArray = BitArray.fromBitLen(bitLen);

--- a/packages/ssz/test/unit/byType/bitVector/tree.test.ts
+++ b/packages/ssz/test/unit/byType/bitVector/tree.test.ts
@@ -1,3 +1,4 @@
+import {expect} from "chai";
 import {BitVectorType, BitArray} from "../../../../src";
 import {runViewTestMutation} from "../runViewTestMutation";
 
@@ -46,6 +47,22 @@ runViewTestMutation({
       },
     },
   ],
+});
+
+describe("BitVector batchHash", () => {
+  const sszType = new BitVectorType(4);
+  const value = fromNum(4, 0b0010);
+  const expectedRoot = sszType.toView(value).hashTreeRoot();
+
+  it("fresh ViewDU", () => {
+    expect(sszType.toViewDU(value).hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("set then hashTreeRoot", () => {
+    const viewDU = sszType.toViewDU(fromNum(4, 0b0011));
+    viewDU.set(0, false);
+    expect(sszType.toViewDU(value).hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
 });
 
 function fromNum(bitLen: number, num: number): BitArray {

--- a/packages/ssz/test/unit/byType/container/tree.test.ts
+++ b/packages/ssz/test/unit/byType/container/tree.test.ts
@@ -222,7 +222,7 @@ runViewTestMutation({
   ],
 });
 
-describe.only("ContainerViewDU batchHash", function () {
+describe("ContainerViewDU batchHash", function () {
   const childContainerType = new ContainerType({b0: uint64NumInfType, b1: uint64NumInfType});
   // 2 chunks
   const byteListType = new ByteListType(64);
@@ -262,7 +262,7 @@ describe.only("ContainerViewDU batchHash", function () {
     expect(viewDU.hashTreeRoot()).to.be.deep.equal(expectedRoot);
   });
 
-  it.only("full hash then modify full byte list", () => {
+  it("full hash then modify full byte list", () => {
     const viewDU = parentContainerType.toViewDU({a: 10, b: {b0: 100, b1: 101}, c: Buffer.alloc(64, 0)});
     viewDU.hashTreeRoot();
     viewDU.c = Buffer.alloc(64, 1);

--- a/packages/ssz/test/unit/byType/listBasic/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listBasic/tree.test.ts
@@ -240,3 +240,55 @@ describe("ListBasicType.sliceTo", () => {
     });
   }
 });
+
+describe("ListBasicType batchHash", function () {
+  const value = [1, 2, 3, 4];
+  const expectedRoot = ListN64Uint64NumberType.toView(value).hashTreeRoot();
+
+  it("fresh ViewDU", () => {
+    expect(ListN64Uint64NumberType.toViewDU(value).hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("push then hashTreeRoot()", () => {
+    const viewDU = ListN64Uint64NumberType.defaultViewDU();
+    viewDU.push(1);
+    viewDU.push(2);
+    viewDU.push(3);
+    viewDU.push(4);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("push then modify then hashTreeRoot()", () => {
+    const viewDU = ListN64Uint64NumberType.defaultViewDU();
+    viewDU.push(1);
+    viewDU.push(2);
+    viewDU.push(3);
+    viewDU.push(44);
+    viewDU.set(3, 4);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify", () => {
+    const viewDU = ListN64Uint64NumberType.defaultViewDU();
+    viewDU.push(1);
+    viewDU.push(2);
+    viewDU.push(33);
+    viewDU.push(44);
+    viewDU.hashTreeRoot();
+    viewDU.set(2, 3);
+    viewDU.set(3, 4);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  // similar to a fresh ViewDU but it's good to test
+  it("sliceTo()", () => {
+    const viewDU = ListN64Uint64NumberType.defaultViewDU();
+    viewDU.push(1);
+    viewDU.push(2);
+    viewDU.push(3);
+    viewDU.push(4);
+    viewDU.push(5);
+    viewDU.hashTreeRoot();
+    expect(viewDU.sliceTo(3).hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+});

--- a/packages/ssz/test/unit/byType/listComposite/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listComposite/tree.test.ts
@@ -213,3 +213,74 @@ describe("ListCompositeType.sliceFrom", () => {
     }
   });
 });
+
+describe("ListCompositeType batchHash", () => {
+  const value = [
+    {a: 1, b: 2},
+    {a: 3, b: 4},
+  ];
+  const expectedRoot = listOfContainersType.toView(value).hashTreeRoot();
+
+  it("fresh ViewDU", () => {
+    expect(listOfContainersType.toViewDU(value).hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("push then hashTreeRoot()", () => {
+    const viewDU = listOfContainersType.defaultViewDU();
+    viewDU.push(containerUintsType.toViewDU({a: 1, b: 2}));
+    viewDU.push(containerUintsType.toViewDU({a: 3, b: 4}));
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify full non-hashed child element", () => {
+    const viewDU = listOfContainersType.defaultViewDU();
+    viewDU.push(containerUintsType.toViewDU({a: 1, b: 2}));
+    viewDU.push(containerUintsType.toViewDU({a: 33, b: 44}));
+    viewDU.hashTreeRoot();
+    viewDU.set(1, containerUintsType.toViewDU({a: 3, b: 4}));
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify partially hashed child element", () => {
+    const viewDU = listOfContainersType.defaultViewDU();
+    viewDU.push(containerUintsType.toViewDU({a: 1, b: 2}));
+    viewDU.push(containerUintsType.toViewDU({a: 33, b: 44}));
+    viewDU.hashTreeRoot();
+    const item1 = containerUintsType.toViewDU({a: 3, b: 44});
+    item1.hashTreeRoot();
+    item1.b = 4;
+    viewDU.set(1, item1);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify full hashed child element", () => {
+    const viewDU = listOfContainersType.defaultViewDU();
+    viewDU.push(containerUintsType.toViewDU({a: 1, b: 2}));
+    viewDU.push(containerUintsType.toViewDU({a: 33, b: 44}));
+    viewDU.hashTreeRoot();
+    const item1 = containerUintsType.toViewDU({a: 3, b: 4});
+    item1.hashTreeRoot();
+    viewDU.set(1, item1);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify partial child element", () => {
+    const viewDU = listOfContainersType.defaultViewDU();
+    viewDU.push(containerUintsType.toViewDU({a: 1, b: 2}));
+    viewDU.push(containerUintsType.toViewDU({a: 33, b: 44}));
+    viewDU.hashTreeRoot();
+    viewDU.get(1).a = 3;
+    viewDU.get(1).b = 4;
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  // similar to a fresh ViewDU but it's good to test
+  it("sliceTo()", () => {
+    const viewDU = listOfContainersType.defaultViewDU();
+    viewDU.push(containerUintsType.toViewDU({a: 1, b: 2}));
+    viewDU.push(containerUintsType.toViewDU({a: 3, b: 4}));
+    viewDU.push(containerUintsType.toViewDU({a: 5, b: 6}));
+    viewDU.hashTreeRoot();
+    expect(viewDU.sliceTo(1).hashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+});

--- a/packages/ssz/test/unit/eth2/beaconState.test.ts
+++ b/packages/ssz/test/unit/eth2/beaconState.test.ts
@@ -1,0 +1,201 @@
+import {expect} from "chai";
+import {BeaconState} from "../../lodestarTypes/deneb/sszTypes";
+import {ListUintNum64Type} from "../../../src/type/listUintNum64";
+import {altair, phase0, ssz} from "../../lodestarTypes";
+import {BitArray, fromHexString} from "../../../src";
+
+const VALIDATOR_REGISTRY_LIMIT = 1099511627776;
+export const Balances = new ListUintNum64Type(VALIDATOR_REGISTRY_LIMIT);
+
+// TODO - batch: mix the commit() or hashTreeRoot()?
+describe("BeaconState ViewDU batch hash", function () {
+  const view = BeaconState.defaultView();
+  const viewDU = BeaconState.defaultViewDU();
+
+  it("BeaconState ViewDU should have same hashTreeRoot() to View", () => {
+    // genesisTime
+    viewDU.genesisTime = view.genesisTime = 1e9;
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // genesisValidatorsRoot
+    viewDU.genesisValidatorsRoot = view.genesisValidatorsRoot = Buffer.alloc(32, 1);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // fork
+    const fork: phase0.Fork = {
+      epoch: 1000,
+      previousVersion: fromHexString("0x03001020"),
+      currentVersion: fromHexString("0x04001020"),
+    };
+    view.fork = BeaconState.fields.fork.toView(fork);
+    viewDU.fork = BeaconState.fields.fork.toViewDU(fork);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // latestBlockHeader
+    const latestBlockHeader: phase0.BeaconBlockHeader = {
+      slot: 1000,
+      proposerIndex: 1,
+      parentRoot: fromHexString("0xac80c66f413218e2c9c7bcb2408ccdceacf3bcd7e7df58474e0c6aa9d7f328a0"),
+      stateRoot: fromHexString("0xed29eed3dbee72caf3b13df84d01ebda1482dbd0ce084e1ce8862b4acb740ed8"),
+      bodyRoot: fromHexString("0x32c644ca1b5d1583d445e9d41c81b3e98465fefad4f0db16084cbce7f1b7b849"),
+    };
+    view.latestBlockHeader = BeaconState.fields.latestBlockHeader.toView(latestBlockHeader);
+    viewDU.latestBlockHeader = BeaconState.fields.latestBlockHeader.toViewDU(latestBlockHeader);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // blockRoots
+    const blockRoots = ssz.phase0.HistoricalBlockRoots.defaultValue();
+    blockRoots[0] = fromHexString("0x1234");
+    view.blockRoots = ssz.phase0.HistoricalBlockRoots.toView(blockRoots);
+    viewDU.blockRoots = ssz.phase0.HistoricalBlockRoots.toViewDU(blockRoots);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // stateRoots
+    const stateRoots = ssz.phase0.HistoricalStateRoots.defaultValue();
+    stateRoots[0] = fromHexString("0x5678");
+    view.stateRoots = ssz.phase0.HistoricalStateRoots.toView(stateRoots);
+    viewDU.stateRoots = ssz.phase0.HistoricalStateRoots.toViewDU(stateRoots);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // historical_roots Frozen in Capella, replaced by historical_summaries
+    // Eth1
+    const eth1Data: phase0.Eth1Data = {
+      depositRoot: fromHexString("0x1234"),
+      depositCount: 1000,
+      blockHash: fromHexString("0x5678"),
+    };
+    view.eth1Data = BeaconState.fields.eth1Data.toView(eth1Data);
+    viewDU.eth1Data = BeaconState.fields.eth1Data.toViewDU(eth1Data);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // Eth1DataVotes
+    const eth1DataVotes = ssz.phase0.Eth1DataVotes.defaultValue();
+    eth1DataVotes[0] = eth1Data;
+    view.eth1DataVotes = ssz.phase0.Eth1DataVotes.toView(eth1DataVotes);
+    viewDU.eth1DataVotes = ssz.phase0.Eth1DataVotes.toViewDU(eth1DataVotes);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // Eth1DepositIndex
+    view.eth1DepositIndex = 1000;
+    viewDU.eth1DepositIndex = 1000;
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // validators
+    const validator = {
+      pubkey: Buffer.alloc(48, 0xaa),
+      withdrawalCredentials: Buffer.alloc(32, 0xbb),
+      effectiveBalance: 32e9,
+      slashed: false,
+      activationEligibilityEpoch: 1_000_000,
+      activationEpoch: 2_000_000,
+      exitEpoch: 3_000_000,
+      withdrawableEpoch: 4_000_000,
+    };
+    view.validators = BeaconState.fields.validators.toView([validator]);
+    viewDU.validators = BeaconState.fields.validators.toViewDU([validator]);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // balances
+    view.balances = BeaconState.fields.balances.toView([1000, 2000, 3000]);
+    viewDU.balances = Balances.toViewDU([1000, 2000, 3000]);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // randaoMixes
+    const randaoMixes = ssz.phase0.RandaoMixes.defaultValue();
+    randaoMixes[0] = fromHexString("0x1234");
+    view.randaoMixes = ssz.phase0.RandaoMixes.toView(randaoMixes);
+    viewDU.randaoMixes = ssz.phase0.RandaoMixes.toViewDU(randaoMixes);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // slashings
+    view.slashings = BeaconState.fields.slashings.toView(Array.from({length: 64}, () => BigInt(1000)));
+    viewDU.slashings = BeaconState.fields.slashings.toViewDU(Array.from({length: 64}, () => BigInt(1000)));
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // previousEpochAttestations
+    view.previousEpochParticipation = BeaconState.fields.previousEpochParticipation.toView([1, 2, 3]);
+    viewDU.previousEpochParticipation = BeaconState.fields.previousEpochParticipation.toViewDU([1, 2, 3]);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // currentEpochAttestations
+    view.currentEpochParticipation = BeaconState.fields.currentEpochParticipation.toView([1, 2, 3]);
+    viewDU.currentEpochParticipation = BeaconState.fields.currentEpochParticipation.toViewDU([1, 2, 3]);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // justificationBits
+    view.justificationBits = BeaconState.fields.justificationBits.toView(
+      BitArray.fromBoolArray([true, false, true, true])
+    );
+    viewDU.justificationBits = BeaconState.fields.justificationBits.toViewDU(
+      BitArray.fromBoolArray([true, false, true, true])
+    );
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // previousJustifiedCheckpoint
+    const checkpoint: phase0.Checkpoint = {
+      epoch: 1000,
+      root: fromHexString("0x1234"),
+    };
+    view.previousJustifiedCheckpoint = BeaconState.fields.previousJustifiedCheckpoint.toView(checkpoint);
+    viewDU.previousJustifiedCheckpoint = BeaconState.fields.previousJustifiedCheckpoint.toViewDU(checkpoint);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // currentJustifiedCheckpoint
+    view.currentJustifiedCheckpoint = BeaconState.fields.currentJustifiedCheckpoint.toView(checkpoint);
+    viewDU.currentJustifiedCheckpoint = BeaconState.fields.currentJustifiedCheckpoint.toViewDU(checkpoint);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // finalizedCheckpoint
+    view.finalizedCheckpoint = BeaconState.fields.finalizedCheckpoint.toView(checkpoint);
+    viewDU.finalizedCheckpoint = BeaconState.fields.finalizedCheckpoint.toViewDU(checkpoint);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // inactivityScores
+    view.inactivityScores = BeaconState.fields.inactivityScores.toView([1, 2, 3]);
+    viewDU.inactivityScores = BeaconState.fields.inactivityScores.toViewDU([1, 2, 3]);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // currentSyncCommittee
+    const syncCommittee: altair.SyncCommittee = {
+      pubkeys: Array.from({length: 32}, () => Buffer.alloc(48, 0xaa)),
+      aggregatePubkey: fromHexString("0x1234"),
+    };
+    view.currentSyncCommittee = BeaconState.fields.currentSyncCommittee.toView(syncCommittee);
+    viewDU.currentSyncCommittee = BeaconState.fields.currentSyncCommittee.toViewDU(syncCommittee);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // nextSyncCommittee
+    view.nextSyncCommittee = BeaconState.fields.nextSyncCommittee.toView(syncCommittee);
+    viewDU.nextSyncCommittee = BeaconState.fields.nextSyncCommittee.toViewDU(syncCommittee);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // latestExecutionPayloadHeader
+    const latestExecutionPayloadHeader = BeaconState.fields.latestExecutionPayloadHeader.defaultValue();
+    latestExecutionPayloadHeader.blockNumber = 1000;
+    latestExecutionPayloadHeader.parentHash = fromHexString(
+      "0xac80c66f413218e2c9c7bcb2408ccdceacf3bcd7e7df58474e0c6aa9d7f328a0"
+    );
+    view.latestExecutionPayloadHeader =
+      BeaconState.fields.latestExecutionPayloadHeader.toView(latestExecutionPayloadHeader);
+    viewDU.latestExecutionPayloadHeader =
+      BeaconState.fields.latestExecutionPayloadHeader.toViewDU(latestExecutionPayloadHeader);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // nextWithdrawalIndex
+    viewDU.nextWithdrawalIndex = view.nextWithdrawalIndex = 1000;
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // nextWithdrawalValidatorIndex
+    viewDU.nextWithdrawalValidatorIndex = view.nextWithdrawalValidatorIndex = 1000;
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // historicalSummaries
+    const historicalSummaries = {
+      blockSummaryRoot: fromHexString("0xac80c66f413218e2c9c7bcb2408ccdceacf3bcd7e7df58474e0c6aa9d7f328a0"),
+      stateSummaryRoot: fromHexString("0x32c644ca1b5d1583d445e9d41c81b3e98465fefad4f0db16084cbce7f1b7b849"),
+    };
+    view.historicalSummaries = BeaconState.fields.historicalSummaries.toView([historicalSummaries]);
+    viewDU.historicalSummaries = BeaconState.fields.historicalSummaries.toViewDU([historicalSummaries]);
+    expect(viewDU.hashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+  });
+});

--- a/packages/ssz/test/unit/lodestarTypes/phase0/listValidator.test.ts
+++ b/packages/ssz/test/unit/lodestarTypes/phase0/listValidator.test.ts
@@ -1,0 +1,89 @@
+import {ListCompositeType} from "../../../../src/type/listComposite";
+import {ValidatorType} from "../../../lodestarTypes/phase0/validator";
+import {preset} from "../../../lodestarTypes/params";
+import {ssz} from "../../../lodestarTypes";
+import {expect} from "chai";
+import {ContainerType} from "../../../../src/type/container";
+import {Validator} from "../../../lodestarTypes/phase0";
+const {VALIDATOR_REGISTRY_LIMIT} = preset;
+
+describe("ListValidator ssz type", function () {
+  const seedValidator = {
+    activationEligibilityEpoch: 10,
+    activationEpoch: 11,
+    exitEpoch: Infinity,
+    slashed: false,
+    withdrawableEpoch: 13,
+    pubkey: Buffer.alloc(48, 100),
+    withdrawalCredentials: Buffer.alloc(32, 100),
+    effectiveBalance: 32000000000,
+  };
+
+  const testCases = [32, 33, 34, 35];
+  const ValidatorContainer = new ContainerType(ValidatorType, {typeName: "Validator", jsonCase: "eth2"});
+  const oldValidatorsType = new ListCompositeType(ValidatorContainer, VALIDATOR_REGISTRY_LIMIT);
+  for (const numValidators of testCases) {
+    it(`should commit ${numValidators} validators`, () => {
+      const validators = Array.from({length: numValidators}, (_, i) => ({
+        ...seedValidator,
+        withdrawableEpoch: seedValidator.withdrawableEpoch + i,
+      }));
+      const oldViewDU = oldValidatorsType.toViewDU(validators);
+      const newViewDU = ssz.phase0.Validators.toViewDU(validators);
+      // modify all validators
+      for (let i = 0; i < numValidators; i++) {
+        oldViewDU.get(i).activationEpoch = 2024;
+        newViewDU.get(i).activationEpoch = 2024;
+      }
+      expect(newViewDU.hashTreeRoot()).to.be.deep.equal(oldViewDU.hashTreeRoot());
+      expect(newViewDU.serialize()).to.be.deep.equal(oldViewDU.serialize());
+    });
+  }
+
+  const testCases2 = [[1], [3, 5], [1, 9, 7]];
+  const numValidator = 33;
+  for (const modifiedIndices of testCases2) {
+    it(`should modify ${modifiedIndices.length} validators`, () => {
+      const validators = Array.from({length: numValidator}, (_, i) => ({
+        ...seedValidator,
+        withdrawableEpoch: seedValidator.withdrawableEpoch + i,
+      }));
+      const oldViewDU = oldValidatorsType.toViewDU(validators);
+      const newViewDU = ssz.phase0.Validators.toViewDU(validators);
+      for (const index of modifiedIndices) {
+        oldViewDU.get(index).activationEpoch = 2024;
+        newViewDU.get(index).activationEpoch = 2024;
+      }
+      expect(newViewDU.hashTreeRoot()).to.be.deep.equal(oldViewDU.hashTreeRoot());
+      expect(newViewDU.serialize()).to.be.deep.equal(oldViewDU.serialize());
+    });
+  }
+
+  const testCases3 = [1, 3, 5, 7];
+  for (const numPush of testCases3) {
+    it(`should push ${numPush} validators`, () => {
+      const validators = Array.from({length: numValidator}, (_, i) => ({
+        ...seedValidator,
+        withdrawableEpoch: seedValidator.withdrawableEpoch + i,
+      }));
+      const oldViewDU = oldValidatorsType.toViewDU(validators);
+      const newViewDU = ssz.phase0.Validators.toViewDU(validators);
+      const newValidators: Validator[] = [];
+      // this ensure the commit() should update nodes array
+      newViewDU.getAllReadonlyValues();
+      for (let i = 0; i < numPush; i++) {
+        const validator = {...seedValidator, withdrawableEpoch: seedValidator.withdrawableEpoch + numValidator + i};
+        newValidators.push(validator);
+        oldViewDU.push(ValidatorContainer.toViewDU(validator));
+        newViewDU.push(ssz.phase0.Validator.toViewDU(validator));
+      }
+      oldViewDU.commit();
+      expect(newViewDU.hashTreeRoot()).to.be.deep.equal(oldViewDU.node.root);
+      expect(newViewDU.serialize()).to.be.deep.equal(oldViewDU.serialize());
+      const allValidators = newViewDU.getAllReadonlyValues();
+      for (let i = 0; i < numPush; i++) {
+        expect(allValidators[numValidator + i]).to.be.deep.equal(newValidators[i]);
+      }
+    });
+  }
+});

--- a/packages/ssz/test/unit/lodestarTypes/phase0/validator.test.ts
+++ b/packages/ssz/test/unit/lodestarTypes/phase0/validator.test.ts
@@ -1,0 +1,78 @@
+import {digestNLevel} from "@chainsafe/persistent-merkle-tree";
+import {ContainerType} from "../../../../../ssz/src/type/container";
+import {ssz} from "../../../lodestarTypes";
+import {ValidatorNodeStruct, ValidatorType, validatorToChunkBytes} from "../../../lodestarTypes/phase0/validator";
+import {expect} from "chai";
+import {Validator} from "../../../lodestarTypes/phase0/sszTypes";
+
+const ValidatorContainer = new ContainerType(ValidatorType, {typeName: "Validator", jsonCase: "eth2"});
+
+describe("Validator ssz types", function () {
+  const seedValidator = {
+    activationEligibilityEpoch: 10,
+    activationEpoch: 11,
+    exitEpoch: Infinity,
+    slashed: false,
+    withdrawableEpoch: 13,
+    pubkey: Buffer.alloc(48, 100),
+    withdrawalCredentials: Buffer.alloc(32, 100),
+    effectiveBalance: 32000000000,
+  };
+
+  const validators = [
+    {...seedValidator, effectiveBalance: 31000000000, slashed: false},
+    {...seedValidator, effectiveBalance: 32000000000, slashed: true},
+  ];
+
+  it("should serialize and hash to the same value", () => {
+    for (const validator of validators) {
+      const serialized = ValidatorContainer.serialize(validator);
+      const serialized2 = ssz.phase0.Validator.serialize(validator);
+      const serialized3 = ssz.phase0.Validator.toViewDU(validator).serialize();
+      expect(serialized2).to.be.deep.equal(serialized);
+      expect(serialized3).to.be.deep.equal(serialized);
+
+      const root = ValidatorContainer.hashTreeRoot(validator);
+      const root2 = ssz.phase0.Validator.hashTreeRoot(validator);
+      const root3 = ssz.phase0.Validator.toViewDU(validator).hashTreeRoot();
+      expect(root2).to.be.deep.equal(root);
+      expect(root3).to.be.deep.equal(root);
+    }
+  });
+});
+
+describe("validatorToChunkBytes", function () {
+  const seedValidator = {
+    activationEligibilityEpoch: 10,
+    activationEpoch: 11,
+    exitEpoch: Infinity,
+    slashed: false,
+    withdrawableEpoch: 13,
+    pubkey: Buffer.alloc(48, 100),
+    withdrawalCredentials: Buffer.alloc(32, 100),
+  };
+
+  const validators = [
+    {...seedValidator, effectiveBalance: 31000000000, slashed: false},
+    {...seedValidator, effectiveBalance: 32000000000, slashed: true},
+  ];
+
+  it("should populate validator value to merkle bytes", () => {
+    for (const validator of validators) {
+      const expectedRoot0 = ValidatorNodeStruct.hashTreeRoot(validator);
+      // validator has 8 fields
+      const level3 = new Uint8Array(32 * 8);
+      const dataView = new DataView(level3.buffer, level3.byteOffset, level3.byteLength);
+      // pubkey takes 2 chunks, has to go to another level
+      const level4 = new Uint8Array(32 * 2);
+      validatorToChunkBytes({uint8Array: level3, dataView}, level4, validator);
+      // additional slice() call make it easier to debug
+      const pubkeyRoot = digestNLevel(level4, 1).slice();
+      level3.set(pubkeyRoot, 0);
+      const root = digestNLevel(level3, 3).slice();
+      const expectedRootNode2 = Validator.value_toTree(validator);
+      expect(root).to.be.deep.equals(expectedRoot0);
+      expect(root).to.be.deep.equals(expectedRootNode2.root);
+    }
+  });
+});

--- a/setHasher.mjs
+++ b/setHasher.mjs
@@ -1,5 +1,5 @@
-// Set the hasher to as-sha256
-// Used to run benchmarks with with visibility into as-sha256 performance, useful for Lodestar
+// Set the hasher to hashtree
+// Used to run benchmarks with with visibility into hashtree performance, useful for Lodestar
 import {setHasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/index.js";
-import {hasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/as-sha256.js";
+import {hasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/hashtree.js";
 setHasher(hasher);


### PR DESCRIPTION
**Motivation**

- BeaconState in lodestar is modeled as a ViewDU, implement batch hash to speed up `hashTreeRoot()` time there
- part of #378 

**Description**
- In `TreeViewDU.hashTreeRoot()`, during `commit()` phase also compute HashComputations using `setNodesAtDepth()` in the previous PR #384, then finally call `executeHashComputations()` in the previous PR #384
  - add optional parameter `hashComps?: HashComputationGroup | null` to `ViewDU.commit()` method. If calling from `hashTreeRoot()`, pass a `HashComputationGroup` there, else null
- Right now lodestar validator is modeled as a ContainerNodeStructViewDU that make it impossible to compute HashComputations there because it's not tree backed. So I came up a solution to also compute validator roots in batch in `ListValidatorTreeViewDU.commit()`
  - one key improvement is not to create validator tree (which takes a lot of memory) when computing its root
  - computing (ContainerNodeStruct) validators in `commit()` seems a bit abnormal but:
    - it does not break the current design: we still can change data multiple times before the commit(), we can also do multiple commit() calls
    - we always have to do `hashTreeRoot()` per state transition
- benchmark in `packages/ssz/test/perf/eth2/beaconState.test.ts` showed ~7x improvement in my Mac M1 compared to the previous release

**Implementation Notes for lodestar**
- need to sync `ListValidatorTreeViewDU` and `ListValidatorType` and define validators as this new type there

**Note for reviewers**
- start from `packages/ssz/src/viewDU/abstract.ts`, `hashTreeRoot()` method
- review `packages/ssz/test/lodestarTypes/phase0/viewDU/listValidator.ts` on the way to hash multiple validators in batch using single memory allocation
