### PR TITLE
feat: ReuseListIterator for getAll() api

### DIFF
--- a/packages/persistent-merkle-tree/src/hashComputation.ts
+++ b/packages/persistent-merkle-tree/src/hashComputation.ts
@@ -55,7 +55,10 @@ export class HashComputationLevel {
    * run before every run
    */
   reset(): void {
-    // keep this.head
+    // keep this.head object, only release the data
+    this.head.src0 = null as unknown as Node;
+    this.head.src1 = null as unknown as Node;
+    this.head.dest = null as unknown as Node;
     this.tail = null;
     this._length = 0;
     // totalLength is not reset

--- a/packages/ssz/src/index.ts
+++ b/packages/ssz/src/index.ts
@@ -37,6 +37,7 @@ export {BitArray, getUint8ByteToBitBooleanArray} from "./value/bitArray";
 
 // Utils
 export {fromHexString, toHexString, byteArrayEquals} from "./util/byteArray";
+export {ReusableListIterator} from "./util/reusableListIterator";
 
 export {hash64, symbolCachedPermanentRoot} from "./util/merkleize";
 

--- a/packages/ssz/src/interface.ts
+++ b/packages/ssz/src/interface.ts
@@ -16,6 +16,12 @@ export interface List<T> extends ArrayLike<T> {
   pop(): T | undefined;
 }
 
+export interface ListIterator<T> {
+  readonly length: number;
+  push(...values: T[]): void;
+  [Symbol.iterator](): Iterator<T>;
+}
+
 export type Container<T extends Record<string, unknown>> = T;
 
 export type ByteVector = Vector<number>;

--- a/packages/ssz/src/util/reusableListIterator.ts
+++ b/packages/ssz/src/util/reusableListIterator.ts
@@ -1,0 +1,139 @@
+import {ListIterator} from "../interface";
+
+class LinkedNode<T> {
+  data: T;
+  next: LinkedNode<T> | null = null;
+
+  constructor(data: T) {
+    this.data = data;
+  }
+}
+
+/**
+ * A LinkedList that's designed to be reused overtime.
+ * Before every run, reset() should be called.
+ * After every run, clean() should be called.
+ */
+export class ReusableListIterator<T> implements ListIterator<T> {
+  private head: LinkedNode<T>;
+  private tail: LinkedNode<T> | null;
+  private _length = 0;
+  private _totalLength = 0;
+  private pointer: LinkedNode<T> | null;
+
+  constructor() {
+    this.head = {
+      data: null as unknown as T,
+      next: null,
+    };
+    this.tail = null;
+    this.pointer = null;
+  }
+
+  get length(): number {
+    return this._length;
+  }
+
+  get totalLength(): number {
+    return this._totalLength;
+  }
+
+  /**
+   * run before every run
+   */
+  reset(): void {
+    // keep this.head object, only release the data
+    this.head.data = null as unknown as T;
+    this.tail = null;
+    this._length = 0;
+    // totalLength is not reset
+    this.pointer = null;
+  }
+
+  /**
+   * Append new data to the tail
+   * This will overwrite the existing data if it is not null, or grow the list if needed.
+   */
+  push(value: T): void {
+    if (this.tail !== null) {
+      let newTail = this.tail.next;
+      if (newTail !== null) {
+        newTail.data = value;
+      } else {
+        // grow the list
+        newTail = {data: value, next: null};
+        this.tail.next = newTail;
+        this._totalLength++;
+      }
+      this.tail = newTail;
+      this._length++;
+      return;
+    }
+
+    // first item
+    this.head.data = value;
+    this.tail = this.head;
+    this._length = 1;
+    if (this._totalLength === 0) {
+      this._totalLength = 1;
+    }
+    // else _totalLength > 0, do not set
+  }
+
+  /**
+   * run after every run
+   * hashComps may still refer to the old Nodes, we should release them to avoid memory leak.
+   */
+  clean(): void {
+    let node = this.tail?.next ?? null;
+    while (node !== null && node.data !== null) {
+      node.data = null as unknown as T;
+      node = node.next;
+    }
+  }
+
+  /**
+   * Implement Iterator for this class
+   */
+  next(): IteratorResult<T> {
+    if (!this.pointer || this.tail === null) {
+      return {done: true, value: undefined};
+    }
+
+    // never yield value beyond the tail
+    const value = this.pointer.data;
+    const isNull = value === null;
+    this.pointer = this.pointer.next;
+
+    return isNull ? {done: true, value: undefined} : {done: false, value};
+  }
+
+  /**
+   * This is convenient method to consume HashComputationLevel with for-of loop
+   * See "next" method above for the actual implementation
+   */
+  [Symbol.iterator](): IterableIterator<T> {
+    this.pointer = this.head;
+    return this;
+  }
+
+  toArray(): T[] {
+    const result: T[] = [];
+    for (const data of this) {
+      result.push(data);
+    }
+    return result;
+  }
+
+  /**
+   * For testing only
+   */
+  dump(): T[] {
+    const result: T[] = [];
+    let node: LinkedNode<T> | null = this.head;
+    for (; node !== null; node = node.next) {
+      result.push(node.data);
+    }
+    return result;
+  }
+}

--- a/packages/ssz/src/util/reusableListIterator.ts
+++ b/packages/ssz/src/util/reusableListIterator.ts
@@ -20,6 +20,8 @@ export class ReusableListIterator<T> implements ListIterator<T> {
   private _length = 0;
   private _totalLength = 0;
   private pointer: LinkedNode<T> | null;
+  // this avoids memory allocation
+  private iteratorResult: IteratorResult<T>;
 
   constructor() {
     this.head = {
@@ -28,6 +30,7 @@ export class ReusableListIterator<T> implements ListIterator<T> {
     };
     this.tail = null;
     this.pointer = null;
+    this.iteratorResult = {} as IteratorResult<T>;
   }
 
   get length(): number {
@@ -48,6 +51,7 @@ export class ReusableListIterator<T> implements ListIterator<T> {
     this._length = 0;
     // totalLength is not reset
     this.pointer = null;
+    this.iteratorResult = {} as IteratorResult<T>;
   }
 
   /**
@@ -102,10 +106,12 @@ export class ReusableListIterator<T> implements ListIterator<T> {
 
     // never yield value beyond the tail
     const value = this.pointer.data;
-    const isNull = value === null;
     this.pointer = this.pointer.next;
-
-    return isNull ? {done: true, value: undefined} : {done: false, value};
+    // should not allocate new object here
+    const isNull = value === null;
+    this.iteratorResult.done = isNull;
+    this.iteratorResult.value = isNull ? undefined: value;
+    return this.iteratorResult;
   }
 
   /**

--- a/packages/ssz/src/util/reusableListIterator.ts
+++ b/packages/ssz/src/util/reusableListIterator.ts
@@ -51,7 +51,7 @@ export class ReusableListIterator<T> implements ListIterator<T> {
     this._length = 0;
     // totalLength is not reset
     this.pointer = null;
-    this.iteratorResult = {} as IteratorResult<T>;
+    // no need to reset iteratorResult
   }
 
   /**
@@ -110,7 +110,7 @@ export class ReusableListIterator<T> implements ListIterator<T> {
     // should not allocate new object here
     const isNull = value === null;
     this.iteratorResult.done = isNull;
-    this.iteratorResult.value = isNull ? undefined: value;
+    this.iteratorResult.value = isNull ? undefined : value;
     return this.iteratorResult;
   }
 

--- a/packages/ssz/src/view/arrayComposite.ts
+++ b/packages/ssz/src/view/arrayComposite.ts
@@ -2,6 +2,7 @@ import {getNodesAtDepth, HashComputationLevel, Node, toGindexBitstring, Tree} fr
 import {ValueOf} from "../type/abstract";
 import {CompositeType, CompositeView, CompositeViewDU} from "../type/composite";
 import {TreeView} from "./abstract";
+import {ListIterator} from "../interface";
 
 /** Expected API of this View's type. This interface allows to break a recursive dependency between types and views */
 export type ArrayCompositeType<
@@ -105,6 +106,22 @@ export class ArrayCompositeTreeView<
   }
 
   /**
+   * Similar to getAllReadonly but support ListIterator interface.
+   * Use ReusableListIterator to reuse over multiple calls.
+   */
+  getAllReadonlyIter(views?: ListIterator<CompositeView<ElementType>>): ListIterator<CompositeView<ElementType>> {
+    const length = this.length;
+    const chunksNode = this.type.tree_getChunksNode(this.node);
+    const nodes = getNodesAtDepth(chunksNode, this.type.chunkDepth, 0, length);
+    views = views ?? new Array<CompositeView<ElementType>>();
+    for (let i = 0; i < length; i++) {
+      // TODO: Optimize
+      views.push(this.type.elementType.getView(new Tree(nodes[i])));
+    }
+    return views;
+  }
+
+  /**
    * Returns an array of values of all elements in the array, from index zero to `this.length - 1`.
    * The returned values are not Views so any changes won't be propagated upwards.
    * To get linked element Views use `this.get()`
@@ -119,6 +136,21 @@ export class ArrayCompositeTreeView<
     values = values ?? new Array<ValueOf<ElementType>>(length);
     for (let i = 0; i < length; i++) {
       values[i] = this.type.elementType.tree_toValue(nodes[i]);
+    }
+    return values;
+  }
+
+  /**
+   * Similar to getAllReadonlyValues but support ListIterator interface.
+   * Use ReusableListIterator to reuse over multiple calls.
+   */
+  getAllReadonlyValuesIter(values?: ListIterator<ValueOf<ElementType>>): ListIterator<ValueOf<ElementType>> {
+    const length = this.length;
+    const chunksNode = this.type.tree_getChunksNode(this.node);
+    const nodes = getNodesAtDepth(chunksNode, this.type.chunkDepth, 0, length);
+    values = values ?? new Array<ValueOf<ElementType>>();
+    for (let i = 0; i < length; i++) {
+      values.push(this.type.elementType.tree_toValue(nodes[i]));
     }
     return values;
   }

--- a/packages/ssz/src/viewDU/arrayComposite.ts
+++ b/packages/ssz/src/viewDU/arrayComposite.ts
@@ -162,12 +162,13 @@ export class ArrayCompositeTreeViewDU<
   }
 
   /**
-   * Similar to getAllReadonly but support returning a LiaIterator that could be reused
+   * Similar to getAllReadonly but support ListIterator interface.
+   * Use ReusableListIterator to reuse over multiple calls.
    */
   getAllReadonlyIter(views?: ListIterator<CompositeViewDU<ElementType>>): ListIterator<CompositeViewDU<ElementType>> {
     this.populateAllNodes();
 
-    views = views ?? new Array<CompositeViewDU<ElementType>>(this._length);
+    views = views ?? new Array<CompositeViewDU<ElementType>>();
     for (let i = 0; i < this._length; i++) {
       const view = this.type.elementType.getViewDU(this.nodes[i], this.caches[i]);
       views.push(view);
@@ -192,12 +193,13 @@ export class ArrayCompositeTreeViewDU<
   }
 
   /**
-   * WARNING: Returns all commited changes, if there are any pending changes commit them beforehand
+   * Similar to getAllReadonlyValues but support ListIterator interface.
+   * Use ReusableListIterator to reuse over multiple calls.
    */
   getAllReadonlyValuesIter(values?: ListIterator<ValueOf<ElementType>>): ListIterator<ValueOf<ElementType>> {
     this.populateAllNodes();
 
-    values = values ?? new Array<ValueOf<ElementType>>(this._length);
+    values = values ?? new Array<ValueOf<ElementType>>();
     for (let i = 0; i < this._length; i++) {
       const value = this.type.elementType.tree_toValue(this.nodes[i]);
       values.push(value);

--- a/packages/ssz/src/viewDU/arrayComposite.ts
+++ b/packages/ssz/src/viewDU/arrayComposite.ts
@@ -10,6 +10,7 @@ import {ValueOf} from "../type/abstract";
 import {CompositeType, CompositeView, CompositeViewDU} from "../type/composite";
 import {ArrayCompositeType} from "../view/arrayComposite";
 import {TreeViewDU} from "./abstract";
+import {ListIterator} from "../interface";
 
 export type ArrayCompositeTreeViewDUCache = {
   nodes: Node[];
@@ -161,6 +162,20 @@ export class ArrayCompositeTreeViewDU<
   }
 
   /**
+   * Similar to getAllReadonly but support returning a LiaIterator that could be reused
+   */
+  getAllReadonlyIter(views?: ListIterator<CompositeViewDU<ElementType>>): ListIterator<CompositeViewDU<ElementType>> {
+    this.populateAllNodes();
+
+    views = views ?? new Array<CompositeViewDU<ElementType>>(this._length);
+    for (let i = 0; i < this._length; i++) {
+      const view = this.type.elementType.getViewDU(this.nodes[i], this.caches[i]);
+      views.push(view);
+    }
+    return views;
+  }
+
+  /**
    * WARNING: Returns all commited changes, if there are any pending changes commit them beforehand
    */
   getAllReadonlyValues(values?: ValueOf<ElementType>[]): ValueOf<ElementType>[] {
@@ -172,6 +187,20 @@ export class ArrayCompositeTreeViewDU<
     values = values ?? new Array<ValueOf<ElementType>>(this._length);
     for (let i = 0; i < this._length; i++) {
       values[i] = this.type.elementType.tree_toValue(this.nodes[i]);
+    }
+    return values;
+  }
+
+  /**
+   * WARNING: Returns all commited changes, if there are any pending changes commit them beforehand
+   */
+  getAllReadonlyValuesIter(values?: ListIterator<ValueOf<ElementType>>): ListIterator<ValueOf<ElementType>> {
+    this.populateAllNodes();
+
+    values = values ?? new Array<ValueOf<ElementType>>(this._length);
+    for (let i = 0; i < this._length; i++) {
+      const value = this.type.elementType.tree_toValue(this.nodes[i]);
+      values.push(value);
     }
     return values;
   }

--- a/packages/ssz/test/perf/iterate.test.ts
+++ b/packages/ssz/test/perf/iterate.test.ts
@@ -1,6 +1,6 @@
 import {itBench, setBenchOpts} from "@dapplion/benchmark";
-import {ListBasicType, UintNumberType} from "../../src";
-import {Validators} from "../lodestarTypes/phase0/sszTypes";
+import {CompositeViewDU, ListBasicType, ReusableListIterator, UintNumberType} from "../../src";
+import {Validators, Validator} from "../lodestarTypes/phase0/sszTypes";
 
 describe("iterate", () => {
   setBenchOpts({noThreshold: true});
@@ -51,6 +51,22 @@ describe("readonly values - iterator vs array", () => {
     const validatorsArray = validators.getAllReadonly();
     for (let i = 0; i < validatorsArray.length; i++) {
       validatorsArray[i];
+    }
+  });
+
+  const viewDUs = new ReusableListIterator<CompositeViewDU<typeof Validator>>();
+  itBench("compositeListValue.getAllReadonlyIter()", () => {
+    viewDUs.reset();
+    validators.getAllReadonlyIter(viewDUs);
+    viewDUs.clean();
+  });
+
+  itBench("compositeListValue.getAllReadonlyIter() + loop all", () => {
+    viewDUs.reset();
+    validators.getAllReadonlyIter(viewDUs);
+    viewDUs.clean();
+    for (const viewDU of viewDUs) {
+      viewDU;
     }
   });
 });

--- a/packages/ssz/test/perf/util/reusableListIterator.test.ts
+++ b/packages/ssz/test/perf/util/reusableListIterator.test.ts
@@ -1,0 +1,50 @@
+import { itBench, setBenchOpts } from "@dapplion/benchmark";
+import { ReusableListIterator } from "../../../src";
+
+class A {
+  constructor(private readonly x: number, private readonly y: string, private readonly z: Uint8Array) {}
+}
+
+/**
+ * ReusableListIterator is 2x slower than using Array in this benchmark, however it does not allocate new array every time.
+    ✓ ReusableListIterator 2000000 items                                  70.00170 ops/s    14.28537 ms/op        -        105 runs   2.01 s
+    ✓ Array 2000000 items                                                 156.8627 ops/s    6.375003 ms/op        -        114 runs   1.23 s
+ */
+describe("ReusableListIterator", function () {
+  setBenchOpts({
+    minRuns: 100
+  });
+
+  const pool = Array.from({length: 1024}, (_, i) => new A(i, String(i), Buffer.alloc(32, 1)));
+
+  const length = 2_000_000;
+  const list = new ReusableListIterator();
+  itBench({
+    id: `ReusableListIterator ${length} items`,
+    fn: () => {
+      // reusable, just reset
+      list.reset();
+      for (let i = 0; i < length; i++) {
+        list.push(pool[i % 1024]);
+      }
+      for (const a of list) {
+        a;
+      }
+    }
+  });
+
+  itBench({
+    id: `Array ${length} items`,
+    fn: () => {
+      // allocate every time
+      const arr = new Array<A>(length);
+      for (let i = 0; i < length; i++) {
+        arr[i] = pool[i % 1024]
+      }
+      for (const a of arr) {
+        a;
+      }
+    }
+  })
+});
+

--- a/packages/ssz/test/unit/byType/listComposite/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listComposite/tree.test.ts
@@ -1,5 +1,13 @@
 import {expect} from "chai";
-import {CompositeView, ContainerType, ListCompositeType, toHexString, UintNumberType, ValueOf} from "../../../../src";
+import {
+  CompositeView,
+  ContainerType,
+  ListCompositeType,
+  ReusableListIterator,
+  toHexString,
+  UintNumberType,
+  ValueOf,
+} from "../../../../src";
 import {ArrayCompositeTreeViewDU} from "../../../../src/viewDU/arrayComposite";
 import {ssz} from "../../../lodestarTypes/primitive";
 import {runViewTestMutation} from "../runViewTestMutation";
@@ -112,11 +120,21 @@ describe("ListCompositeType tree reads", () => {
       // Only for viewDU
       if (view instanceof ArrayCompositeTreeViewDU) {
         expect(() => view.getAllReadonly()).to.throw("Must commit changes before reading all nodes");
+        expect(() => view.getAllReadonlyIter()).to.throw("Must commit changes before reading all nodes");
         view.commit();
       }
 
       expect(view.getAllReadonly().map(elementToValue)).deep.equals(values, "Wrong getAllReadonly()");
+      (view.getAllReadonlyIter() as CompositeView<typeof containerUintsType>[]).map(elementToValue);
       expect(view.getAllReadonlyValues()).deep.equals(values, "Wrong getAllReadonlyValues()");
+      const result = new ReusableListIterator<ValueOf<typeof containerUintsType>>();
+      view.getAllReadonlyValuesIter(result);
+      expect(result.toArray()).deep.equals(values, "Wrong getAllReadonlyValues()");
+      // reuse ReusableListIterator
+      result.reset();
+      view.getAllReadonlyValuesIter(result);
+      result.clean();
+      expect(result.toArray()).deep.equals(values, "Wrong getAllReadonlyValues()");
 
       // Only for viewDU
       if (view instanceof ArrayCompositeTreeViewDU) {

--- a/packages/ssz/test/unit/util/reusableListIterator.test.ts
+++ b/packages/ssz/test/unit/util/reusableListIterator.test.ts
@@ -1,0 +1,64 @@
+import {expect} from "chai";
+import {ReusableListIterator} from "../../../src/util/reusableListIterator";
+
+describe("ReusableListIterator", () => {
+  let list: ReusableListIterator<number>;
+
+  beforeEach(() => {
+    list = new ReusableListIterator<number>();
+    list.push(0);
+  });
+
+  it("should reset", () => {
+    list.reset();
+    expect(list.length).to.be.equal(0);
+    expect(list.totalLength).to.be.equal(1);
+    expect(list.toArray()).to.be.deep.equal([]);
+  });
+
+  it("should push", () => {
+    list.push(1);
+    expect(list.length).to.be.equal(2);
+    expect(list.totalLength).to.be.equal(2);
+    const arr = list.toArray();
+    expect(arr.length).to.be.equal(2);
+    expect(arr).to.be.deep.equal([0, 1]);
+  });
+
+  it("reset then push full", () => {
+    list.push(1);
+    list.reset();
+    list.push(1);
+    list.push(2);
+    list.clean();
+    expect(list.length).to.be.equal(2);
+    expect(list.totalLength).to.be.equal(2);
+    const arr = list.toArray();
+    expect(arr).to.be.deep.equal([1, 2]);
+  });
+
+  it("reset then push partial", () => {
+    list.push(1);
+    // totalLength = 2 now
+    list.reset();
+    list.push(1);
+    list.clean();
+    expect(list.length).to.be.equal(1);
+    expect(list.totalLength).to.be.equal(2);
+    const arr = list.toArray();
+    expect(arr).to.be.deep.equal([1]);
+  });
+
+  it("clean", () => {
+    list.push(1);
+    list.reset();
+    list.push(1);
+    list.clean();
+    expect(list.length).to.be.equal(1);
+    expect(list.totalLength).to.be.equal(2);
+    const arr = list.toArray();
+    expect(arr).to.be.deep.equal([1]);
+    const all = list.dump();
+    expect(all).to.be.deep.equal([1, null]);
+  });
+});


### PR DESCRIPTION
**Motivation**

- avoid possible array allocation with getAll() api

#383 make it possible to provide an Array for getAll() api, however it could still spike due to array allocation

**Description**
- Implement ReusableListIterator which is a LinkedList, when it grows it only append some more items instead of allocating a big array
- Implement getAll*Iter()  api to View and ViewDU to allow consumer to use `ReusableListIterator`
- On average, ReusableListIterator is only a bit faster than Array however the key thing is to reduce any spikes as much as possible due to gc

**Testing**
- This branch (lg1k) in the last 24h, 10m rate interval, there are ~3 spikes

<img width="1330" alt="Screenshot 2024-07-31 at 11 20 18" src="https://github.com/user-attachments/assets/2933a6aa-31b4-458c-825c-5c7b8bba6e30">

- `te/batch_hash_tree_root`, md64, 10m rate interval, there are ~18 spikes

<img width="1326" alt="Screenshot 2024-07-31 at 11 20 59" src="https://github.com/user-attachments/assets/412749f0-6e01-4ae0-8763-e74ef630f272">

- This branch (lg1k) in the last 24h, 12h rate interval. It's only a little bit faster than `te/batch_hash_tree_root`

<img width="1339" alt="Screenshot 2024-07-31 at 11 24 35" src="https://github.com/user-attachments/assets/8ce451f7-d5bf-44b4-9ac2-0e9b150b8328">

- `te/batch_hash_tree_root`, md64, 12h rate interval

<img width="1328" alt="Screenshot 2024-07-31 at 11 25 16" src="https://github.com/user-attachments/assets/58a47781-cd77-4700-9327-98361bc3e553">
