### PR TITLE
feat: implement ViewDU.batchHashTreeRoot()

### DIFF
--- a/packages/persistent-merkle-tree/test/perf/hasher.test.ts
+++ b/packages/persistent-merkle-tree/test/perf/hasher.test.ts
@@ -79,7 +79,7 @@ describe("hashtree", function () {
   });
 
   itBench({
-    id: `executeHashComputations - hashtree`,
+    id: `executeHashComputations`,
     beforeEach: () => {
       const [tree] = buildComparisonTrees(16);
       return tree;
@@ -92,7 +92,7 @@ describe("hashtree", function () {
   });
 
   itBench({
-    id: `root - hashtree`,
+    id: `get root`,
     beforeEach: () => {
       const [tree] = buildComparisonTrees(16);
       setHasher(hashtreeHasher);

--- a/packages/persistent-merkle-tree/test/perf/hasher.test.ts
+++ b/packages/persistent-merkle-tree/test/perf/hasher.test.ts
@@ -1,10 +1,10 @@
 import {itBench} from "@dapplion/benchmark";
-import {HashObject, uint8ArrayToHashObject} from "../../src/hasher";
+import {HashObject, setHasher, uint8ArrayToHashObject} from "../../src/hasher";
 import {hasher as asShaHasher} from "../../src/hasher/as-sha256";
 import {hasher as nobleHasher} from "../../src/hasher/noble";
 import {hasher as hashtreeHasher} from "../../src/hasher/hashtree";
 import {buildComparisonTrees} from "../utils/tree";
-import { HashComputationLevel, getHashComputations } from "../../src";
+import {HashComputationLevel, getHashComputations} from "../../src";
 
 describe("hasher", function () {
   this.timeout(0);
@@ -65,4 +65,41 @@ describe("hasher", function () {
   }
 });
 
-// TODO - batch: test more methods
+describe.only("hashtree", function () {
+  itBench({
+    id: `getHashComputations`,
+    beforeEach: () => {
+      const [tree] = buildComparisonTrees(16);
+      return tree;
+    },
+    fn: (tree) => {
+      const hcByLevel: HashComputationLevel[] = [];
+      getHashComputations(tree, 0, hcByLevel);
+    },
+  });
+
+  itBench({
+    id: `executeHashComputations - hashtree`,
+    beforeEach: () => {
+      const [tree] = buildComparisonTrees(16);
+      return tree;
+    },
+    fn: (tree) => {
+      const hcByLevel: HashComputationLevel[] = [];
+      getHashComputations(tree, 0, hcByLevel);
+      hashtreeHasher.executeHashComputations(hcByLevel);
+    },
+  });
+
+  itBench({
+    id: `root - hashtree`,
+    beforeEach: () => {
+      const [tree] = buildComparisonTrees(16);
+      setHasher(hashtreeHasher);
+      return tree;
+    },
+    fn: (tree) => {
+     tree.root;
+    },
+  });
+});

--- a/packages/persistent-merkle-tree/test/perf/hasher.test.ts
+++ b/packages/persistent-merkle-tree/test/perf/hasher.test.ts
@@ -65,7 +65,7 @@ describe("hasher", function () {
   }
 });
 
-describe.only("hashtree", function () {
+describe("hashtree", function () {
   itBench({
     id: `getHashComputations`,
     beforeEach: () => {

--- a/packages/ssz/src/type/arrayBasic.ts
+++ b/packages/ssz/src/type/arrayBasic.ts
@@ -5,6 +5,8 @@ import {
   getNodesAtDepth,
   packedNodeRootsToBytes,
   packedRootsBytesToNode,
+  HashComputationLevel,
+  levelAtIndex,
 } from "@chainsafe/persistent-merkle-tree";
 import {Type, ValueOf, ByteViews} from "./abstract";
 import {BasicType} from "./basic";
@@ -39,14 +41,24 @@ export function addLengthNode(chunksNode: Node, length: number): Node {
   return new BranchNode(chunksNode, LeafNode.fromUint32(length));
 }
 
-export function setChunksNode(rootNode: Node, chunksNode: Node, newLength?: number): Node {
+export function setChunksNode(
+  rootNode: Node,
+  chunksNode: Node,
+  newLength: number | null,
+  hcOffset = 0,
+  hcByLevel: HashComputationLevel[] | null = null
+): Node {
   const lengthNode =
-    newLength !== undefined
+    newLength !== null
       ? // If newLength is set, create a new node for length
         LeafNode.fromUint32(newLength)
       : // else re-use existing node
         (rootNode.right as LeafNode);
-  return new BranchNode(chunksNode, lengthNode);
+  const branchNode = new BranchNode(chunksNode, lengthNode);
+  if (hcByLevel !== null) {
+    levelAtIndex(hcByLevel, hcOffset).push(chunksNode, lengthNode, branchNode);
+  }
+  return branchNode;
 }
 
 export type ArrayProps = {isList: true; limit: number} | {isList: false; length: number};

--- a/packages/ssz/src/type/bitArray.ts
+++ b/packages/ssz/src/type/bitArray.ts
@@ -1,4 +1,4 @@
-import {concatGindices, Gindex, Node, toGindex, Tree} from "@chainsafe/persistent-merkle-tree";
+import {concatGindices, Gindex, Node, toGindex, Tree, HashComputationLevel} from "@chainsafe/persistent-merkle-tree";
 import {fromHexString, toHexString, byteArrayEquals} from "../util/byteArray";
 import {splitIntoRootChunks} from "../util/merkleize";
 import {CompositeType, LENGTH_GINDEX} from "./composite";
@@ -29,8 +29,8 @@ export abstract class BitArrayType extends CompositeType<BitArray, BitArrayTreeV
     return view.node;
   }
 
-  commitViewDU(view: BitArrayTreeViewDU): Node {
-    view.commit();
+  commitViewDU(view: BitArrayTreeViewDU, hcOffset = 0, hcByLevel: HashComputationLevel[] | null = null): Node {
+    view.commit(hcOffset, hcByLevel);
     return view.node;
   }
 

--- a/packages/ssz/src/type/byteArray.ts
+++ b/packages/ssz/src/type/byteArray.ts
@@ -1,4 +1,12 @@
-import {concatGindices, Gindex, Node, toGindex, Tree} from "@chainsafe/persistent-merkle-tree";
+import {
+  concatGindices,
+  Gindex,
+  Node,
+  toGindex,
+  Tree,
+  HashComputationLevel,
+  getHashComputations,
+} from "@chainsafe/persistent-merkle-tree";
 import {fromHexString, toHexString, byteArrayEquals} from "../util/byteArray";
 import {splitIntoRootChunks} from "../util/merkleize";
 import {ByteViews} from "./abstract";
@@ -37,11 +45,16 @@ export abstract class ByteArrayType extends CompositeType<ByteArray, ByteArray, 
     return this.commitViewDU(view);
   }
 
-  commitViewDU(view: ByteArray): Node {
+  // there is no respective ViewDU for this type
+  commitViewDU(view: ByteArray, hcOffset = 0, hcByLevel: HashComputationLevel[] | null = null): Node {
     const uint8Array = new Uint8Array(this.value_serializedSize(view));
     const dataView = new DataView(uint8Array.buffer, uint8Array.byteOffset, uint8Array.byteLength);
     this.value_serializeToBytes({uint8Array, dataView}, 0, view);
-    return this.tree_deserializeFromBytes({uint8Array, dataView}, 0, uint8Array.length);
+    const node = this.tree_deserializeFromBytes({uint8Array, dataView}, 0, uint8Array.length);
+    if (hcByLevel !== null && node.h0 === null) {
+      getHashComputations(node, hcOffset, hcByLevel);
+    }
+    return node;
   }
 
   cacheOfViewDU(): unknown {

--- a/packages/ssz/src/type/composite.ts
+++ b/packages/ssz/src/type/composite.ts
@@ -7,6 +7,7 @@ import {
   Proof,
   ProofType,
   Tree,
+  HashComputationLevel,
 } from "@chainsafe/persistent-merkle-tree";
 import {byteArrayEquals} from "../util/byteArray";
 import {merkleize, symbolCachedPermanentRoot, ValueWithCachedPermanentRoot} from "../util/merkleize";
@@ -126,7 +127,7 @@ export abstract class CompositeType<V, TV, TVDU> extends Type<V> {
   /** INTERNAL METHOD: Given a Tree View, returns a `Node` with all its updated data */
   abstract commitView(view: TV): Node;
   /** INTERNAL METHOD: Given a Deferred Update Tree View returns a `Node` with all its updated data */
-  abstract commitViewDU(view: TVDU): Node;
+  abstract commitViewDU(view: TVDU, hcOffset?: number, hcByLevel?: HashComputationLevel[] | null): Node;
   /** INTERNAL METHOD: Return the cache of a Deferred Update Tree View. May return `undefined` if this ViewDU has no cache */
   abstract cacheOfViewDU(view: TVDU): unknown;
 

--- a/packages/ssz/src/type/container.ts
+++ b/packages/ssz/src/type/container.ts
@@ -7,6 +7,7 @@ import {
   toGindex,
   concatGindices,
   getNode,
+  HashComputationLevel,
 } from "@chainsafe/persistent-merkle-tree";
 import {maxChunksToDepth} from "../util/merkleize";
 import {Require} from "../util/types";
@@ -162,8 +163,12 @@ export class ContainerType<Fields extends Record<string, Type<unknown>>> extends
     return view.node;
   }
 
-  commitViewDU(view: ContainerTreeViewDUType<Fields>): Node {
-    view.commit();
+  commitViewDU(
+    view: ContainerTreeViewDUType<Fields>,
+    hcOffset = 0,
+    hcByLevel: HashComputationLevel[] | null = null
+  ): Node {
+    view.commit(hcOffset, hcByLevel);
     return view.node;
   }
 

--- a/packages/ssz/src/type/listBasic.ts
+++ b/packages/ssz/src/type/listBasic.ts
@@ -1,4 +1,4 @@
-import {LeafNode, Node, Tree} from "@chainsafe/persistent-merkle-tree";
+import {LeafNode, Node, Tree, HashComputationLevel} from "@chainsafe/persistent-merkle-tree";
 import {ValueOf} from "./abstract";
 import {BasicType} from "./basic";
 import {ByteViews} from "./composite";
@@ -93,8 +93,12 @@ export class ListBasicType<ElementType extends BasicType<unknown>>
     return view.node;
   }
 
-  commitViewDU(view: ListBasicTreeViewDU<ElementType>): Node {
-    view.commit();
+  commitViewDU(
+    view: ListBasicTreeViewDU<ElementType>,
+    hcOffset = 0,
+    hcByLevel: HashComputationLevel[] | null = null
+  ): Node {
+    view.commit(hcOffset, hcByLevel);
     return view.node;
   }
 
@@ -144,8 +148,19 @@ export class ListBasicType<ElementType extends BasicType<unknown>>
     return node.left;
   }
 
-  tree_setChunksNode(rootNode: Node, chunksNode: Node, newLength?: number): Node {
-    return setChunksNode(rootNode, chunksNode, newLength);
+  tree_chunksNodeOffset(): number {
+    // one more level for length, see setChunksNode below
+    return 1;
+  }
+
+  tree_setChunksNode(
+    rootNode: Node,
+    chunksNode: Node,
+    newLength: number | null,
+    hcOffset = 0,
+    hcByLevel: HashComputationLevel[] | null = null
+  ): Node {
+    return setChunksNode(rootNode, chunksNode, newLength, hcOffset, hcByLevel);
   }
 
   // Merkleization

--- a/packages/ssz/src/type/listComposite.ts
+++ b/packages/ssz/src/type/listComposite.ts
@@ -1,4 +1,4 @@
-import {Node, Tree} from "@chainsafe/persistent-merkle-tree";
+import {Node, Tree, HashComputationLevel} from "@chainsafe/persistent-merkle-tree";
 import {
   mixInLength,
   maxChunksToDepth,
@@ -97,8 +97,12 @@ export class ListCompositeType<
     return view.node;
   }
 
-  commitViewDU(view: ListCompositeTreeViewDU<ElementType>): Node {
-    view.commit();
+  commitViewDU(
+    view: ListCompositeTreeViewDU<ElementType>,
+    hcOffset = 0,
+    hcByLevel: HashComputationLevel[] | null = null
+  ): Node {
+    view.commit(hcOffset, hcByLevel);
     return view.node;
   }
 
@@ -150,8 +154,19 @@ export class ListCompositeType<
     return node.left;
   }
 
-  tree_setChunksNode(rootNode: Node, chunksNode: Node, newLength?: number): Node {
-    return setChunksNode(rootNode, chunksNode, newLength);
+  tree_chunksNodeOffset(): number {
+    // one more level for length, see setChunksNode below
+    return 1;
+  }
+
+  tree_setChunksNode(
+    rootNode: Node,
+    chunksNode: Node,
+    newLength: number | null,
+    hcOffset = 0,
+    hcByLevel: HashComputationLevel[] | null = null
+  ): Node {
+    return setChunksNode(rootNode, chunksNode, newLength, hcOffset, hcByLevel);
   }
 
   // Merkleization

--- a/packages/ssz/src/type/optional.ts
+++ b/packages/ssz/src/type/optional.ts
@@ -1,4 +1,12 @@
-import {concatGindices, Gindex, Node, Tree, zeroNode} from "@chainsafe/persistent-merkle-tree";
+import {
+  concatGindices,
+  Gindex,
+  Node,
+  Tree,
+  zeroNode,
+  HashComputationLevel,
+  getHashComputations,
+} from "@chainsafe/persistent-merkle-tree";
 import {mixInLength} from "../util/merkleize";
 import {Require} from "../util/types";
 import {namedClass} from "../util/named";
@@ -75,8 +83,12 @@ export class OptionalType<ElementType extends Type<unknown>> extends CompositeTy
   }
 
   // TODO add an OptionalViewDU
-  commitViewDU(view: ValueOfType<ElementType>): Node {
-    return this.value_toTree(view);
+  commitViewDU(view: ValueOfType<ElementType>, hcOffset = 0, hcByLevel: HashComputationLevel[] | null = null): Node {
+    const node = this.value_toTree(view);
+    if (hcByLevel !== null && node.h0 === null) {
+      getHashComputations(node, hcOffset, hcByLevel);
+    }
+    return node;
   }
 
   // TODO add an OptionalViewDU

--- a/packages/ssz/src/type/union.ts
+++ b/packages/ssz/src/type/union.ts
@@ -1,4 +1,12 @@
-import {concatGindices, getNode, Gindex, Node, Tree} from "@chainsafe/persistent-merkle-tree";
+import {
+  concatGindices,
+  getNode,
+  Gindex,
+  Node,
+  Tree,
+  HashComputationLevel,
+  getHashComputations,
+} from "@chainsafe/persistent-merkle-tree";
 import {mixInLength} from "../util/merkleize";
 import {Require} from "../util/types";
 import {namedClass} from "../util/named";
@@ -106,8 +114,12 @@ export class UnionType<Types extends Type<unknown>[]> extends CompositeType<
     return this.value_toTree(view);
   }
 
-  commitViewDU(view: ValueOfTypes<Types>): Node {
-    return this.value_toTree(view);
+  commitViewDU(view: ValueOfTypes<Types>, hcOffset = 0, hcByLevel: HashComputationLevel[] | null = null): Node {
+    const node = this.value_toTree(view);
+    if (hcByLevel !== null && node.h0 === null) {
+      getHashComputations(node, hcOffset, hcByLevel);
+    }
+    return node;
   }
 
   value_serializedSize(value: ValueOfTypes<Types>): number {

--- a/packages/ssz/src/type/vectorBasic.ts
+++ b/packages/ssz/src/type/vectorBasic.ts
@@ -1,4 +1,4 @@
-import {Node, Tree} from "@chainsafe/persistent-merkle-tree";
+import {Node, Tree, HashComputationLevel} from "@chainsafe/persistent-merkle-tree";
 import {maxChunksToDepth, splitIntoRootChunks} from "../util/merkleize";
 import {Require} from "../util/types";
 import {namedClass} from "../util/named";
@@ -83,8 +83,12 @@ export class VectorBasicType<ElementType extends BasicType<unknown>>
     return view.node;
   }
 
-  commitViewDU(view: ArrayBasicTreeViewDU<ElementType>): Node {
-    view.commit();
+  commitViewDU(
+    view: ArrayBasicTreeViewDU<ElementType>,
+    hcOffset = 0,
+    hcByLevel: HashComputationLevel[] | null = null
+  ): Node {
+    view.commit(hcOffset, hcByLevel);
     return view.node;
   }
 
@@ -130,6 +134,10 @@ export class VectorBasicType<ElementType extends BasicType<unknown>>
 
   tree_getChunksNode(node: Node): Node {
     return node;
+  }
+
+  tree_chunksNodeOffset(): number {
+    return 0;
   }
 
   tree_setChunksNode(rootNode: Node, chunksNode: Node): Node {

--- a/packages/ssz/src/type/vectorComposite.ts
+++ b/packages/ssz/src/type/vectorComposite.ts
@@ -1,4 +1,4 @@
-import {Node, Tree} from "@chainsafe/persistent-merkle-tree";
+import {Node, Tree, HashComputationLevel} from "@chainsafe/persistent-merkle-tree";
 import {maxChunksToDepth} from "../util/merkleize";
 import {Require} from "../util/types";
 import {namedClass} from "../util/named";
@@ -90,8 +90,12 @@ export class VectorCompositeType<
     return view.node;
   }
 
-  commitViewDU(view: ArrayCompositeTreeViewDU<ElementType>): Node {
-    view.commit();
+  commitViewDU(
+    view: ArrayCompositeTreeViewDU<ElementType>,
+    hcOffset = 0,
+    hcByLevel: HashComputationLevel[] | null = null
+  ): Node {
+    view.commit(hcOffset, hcByLevel);
     return view.node;
   }
 
@@ -137,6 +141,10 @@ export class VectorCompositeType<
 
   tree_getChunksNode(node: Node): Node {
     return node;
+  }
+
+  tree_chunksNodeOffset(): number {
+    return 0;
   }
 
   tree_setChunksNode(rootNode: Node, chunksNode: Node): Node {

--- a/packages/ssz/src/view/arrayBasic.ts
+++ b/packages/ssz/src/view/arrayBasic.ts
@@ -1,4 +1,4 @@
-import {getNodesAtDepth, LeafNode, Node, Tree} from "@chainsafe/persistent-merkle-tree";
+import {getNodesAtDepth, LeafNode, Node, Tree, HashComputationLevel} from "@chainsafe/persistent-merkle-tree";
 import {ValueOf} from "../type/abstract";
 import {BasicType} from "../type/basic";
 import {CompositeType} from "../type/composite";
@@ -21,8 +21,16 @@ export type ArrayBasicType<ElementType extends BasicType<unknown>> = CompositeTy
   tree_setLength(tree: Tree, length: number): void;
   /** INTERNAL METHOD: Return the chunks node from a root node */
   tree_getChunksNode(rootNode: Node): Node;
+  /** INTERNAL METHOD: Return the offset from root for HashComputation */
+  tree_chunksNodeOffset(): number;
   /** INTERNAL METHOD: Return a new root node with changed chunks node and length */
-  tree_setChunksNode(rootNode: Node, chunksNode: Node, newLength?: number): Node;
+  tree_setChunksNode(
+    rootNode: Node,
+    chunksNode: Node,
+    newLength: number | null,
+    hcOffset?: number,
+    hcByLevel?: HashComputationLevel[] | null
+  ): Node;
 };
 
 export class ArrayBasicTreeView<ElementType extends BasicType<unknown>> extends TreeView<ArrayBasicType<ElementType>> {

--- a/packages/ssz/src/view/arrayComposite.ts
+++ b/packages/ssz/src/view/arrayComposite.ts
@@ -1,4 +1,4 @@
-import {getNodesAtDepth, Node, toGindexBitstring, Tree} from "@chainsafe/persistent-merkle-tree";
+import {getNodesAtDepth, Node, toGindexBitstring, Tree, HashComputationLevel} from "@chainsafe/persistent-merkle-tree";
 import {ValueOf} from "../type/abstract";
 import {CompositeType, CompositeView, CompositeViewDU} from "../type/composite";
 import {TreeView} from "./abstract";
@@ -16,8 +16,16 @@ export type ArrayCompositeType<
   tree_setLength(tree: Tree, length: number): void;
   /** INTERNAL METHOD: Return the chunks node from a root node */
   tree_getChunksNode(rootNode: Node): Node;
+  /** INTERNAL METHOD: Return the offset from root for HashComputation */
+  tree_chunksNodeOffset(): number;
   /** INTERNAL METHOD: Return a new root node with changed chunks node and length */
-  tree_setChunksNode(rootNode: Node, chunksNode: Node, newLength?: number): Node;
+  tree_setChunksNode(
+    rootNode: Node,
+    chunksNode: Node,
+    newLength: number | null,
+    hcOffset?: number,
+    hcByLevel?: HashComputationLevel[] | null
+  ): Node;
 };
 
 export class ArrayCompositeTreeView<

--- a/packages/ssz/src/viewDU/abstract.ts
+++ b/packages/ssz/src/viewDU/abstract.ts
@@ -1,5 +1,16 @@
+import {HashComputationLevel, executeHashComputations, HashComputationGroup} from "@chainsafe/persistent-merkle-tree";
 import {ByteViews, CompositeType} from "../type/composite";
 import {TreeView} from "../view/abstract";
+
+/**
+ * Always allocating a new HashComputationGroup for each hashTreeRoot() is not great for gc
+ * because a lot of ViewDUs are not changed and computed root already.
+ */
+const symbolCachedTreeRoot = Symbol("ssz_cached_tree_root");
+
+export type NodeWithCachedTreeRoot = {
+  [symbolCachedTreeRoot]?: Uint8Array;
+};
 
 /* eslint-disable @typescript-eslint/member-ordering  */
 
@@ -19,7 +30,7 @@ export abstract class TreeViewDU<T extends CompositeType<unknown, unknown, unkno
   /**
    * Applies any deferred updates that may be pending in this ViewDU instance and updates its internal `Node`.
    */
-  abstract commit(): void;
+  abstract commit(hcOffset?: number, hcByLevel?: HashComputationLevel[] | null): void;
 
   /**
    * Returns arbitrary data that is useful for this ViewDU instance to optimize data manipulation. This caches MUST
@@ -53,8 +64,34 @@ export abstract class TreeViewDU<T extends CompositeType<unknown, unknown, unkno
   }
 
   /**
+   * The same to hashTreeRoot() but with batch hash computation.
+   * Consumer can allocate and reuse a HashComputationGroup() if needed.
+   */
+  batchHashTreeRoot(hcGroup: HashComputationGroup = new HashComputationGroup()): Uint8Array {
+    // in ethereum consensus, the only type goes with TVDU is BeaconState and it's really more efficient to hash the tree in batch
+    const offset = 0;
+    hcGroup.reset();
+    this.commit(offset, hcGroup.byLevel);
+    hcGroup.clean();
+    const cachedRoot = (this.node as NodeWithCachedTreeRoot)[symbolCachedTreeRoot];
+    if (cachedRoot) {
+      return cachedRoot;
+    }
+    executeHashComputations(hcGroup.byLevel);
+    // This makes sure the root node is computed by batch
+    if (this.node.h0 === null) {
+      throw Error("Root is not computed by batch");
+    }
+
+    const root = this.node.root;
+    (this.node as NodeWithCachedTreeRoot)[symbolCachedTreeRoot] = root;
+    return root;
+  }
+
+  /**
    * Serialize view to binary data.
    * Commits any pending changes before computing the root.
+   * This calls commit() which evict all pending HashComputations. Consider calling hashTreeRoot() before this
    */
   serialize(): Uint8Array {
     this.commit();

--- a/packages/ssz/src/viewDU/abstract.ts
+++ b/packages/ssz/src/viewDU/abstract.ts
@@ -29,6 +29,9 @@ export type NodeWithCachedTreeRoot = {
 export abstract class TreeViewDU<T extends CompositeType<unknown, unknown, unknown>> extends TreeView<T> {
   /**
    * Applies any deferred updates that may be pending in this ViewDU instance and updates its internal `Node`.
+   * @param hcOffset The offset of the current node from root
+   * @param hcByLevel The global HashComputationLevel array, this is output parameter
+   * These are optional parameters that are used to compute hashTreeRoot() in batch if they are provided.
    */
   abstract commit(hcOffset?: number, hcByLevel?: HashComputationLevel[] | null): void;
 

--- a/packages/ssz/src/viewDU/bitArray.ts
+++ b/packages/ssz/src/viewDU/bitArray.ts
@@ -1,4 +1,4 @@
-import {Node} from "@chainsafe/persistent-merkle-tree";
+import {HashComputationLevel, Node, getHashComputations} from "@chainsafe/persistent-merkle-tree";
 import {BitArray} from "../value/bitArray";
 import {CompositeType} from "../type/composite";
 import {TreeViewDU} from "./abstract";
@@ -22,9 +22,13 @@ export class BitArrayTreeViewDU extends TreeViewDU<CompositeType<BitArray, unkno
     return;
   }
 
-  commit(): void {
+  commit(hcOffset = 0, hcByLevel: HashComputationLevel[] | null = null): void {
     if (this._bitArray !== null) {
       this._rootNode = this.type.value_toTree(this._bitArray);
+    }
+
+    if (hcByLevel !== null && this._rootNode.h0 === null) {
+      getHashComputations(this._rootNode, hcOffset, hcByLevel);
     }
   }
 

--- a/packages/ssz/test/perf/eth2/beaconState.test.ts
+++ b/packages/ssz/test/perf/eth2/beaconState.test.ts
@@ -1,0 +1,214 @@
+import {itBench, setBenchOpts} from "@dapplion/benchmark";
+import {HashComputationLevel, executeHashComputations, HashComputationGroup} from "@chainsafe/persistent-merkle-tree";
+import {BeaconState} from "../../lodestarTypes/altair/sszTypes";
+import {BitArray, CompositeViewDU, toHexString} from "../../../src";
+import {preset} from "../../lodestarTypes/params";
+const {SLOTS_PER_HISTORICAL_ROOT, EPOCHS_PER_ETH1_VOTING_PERIOD, SLOTS_PER_EPOCH} = preset;
+
+const vc = 200_000;
+const numModified = vc / 20;
+// every we increase vc, need to change this value from "recursive hash" test
+const expectedRoot = "0x759d635af161ac1e4f4af11aa7721fd4996253af50f8a81e5003bbb4cbcaae42";
+
+/**
+ * This simulates a BeaconState being modified after an epoch transition in lodestar
+ * The fresh tree batch hash bechmark is in packages/persistent-merkle-tree/test/perf/node.test.ts
+ * Note that this benchmark is not very stable because we cannot apply runsFactor as once commit() we
+ * cannot compute HashComputationGroup again.
+ * Increasing number of validators could be OOM since we have to create BeaconState every time
+ */
+describe(`BeaconState ViewDU partially modified tree vc=${vc} numModified=${numModified}`, function () {
+  setBenchOpts({
+    minMs: 20_000,
+  });
+
+  itBench({
+    id: `BeaconState ViewDU hashTreeRoot() vc=${vc}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      state.hashTreeRoot();
+      if (toHexString(state.node.root) !== expectedRoot) {
+        throw new Error("hashTreeRoot does not match expectedRoot");
+      }
+    },
+  });
+
+  itBench({
+    id: `BeaconState ViewDU recursive hash - commit step vc=${vc}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      state.commit();
+    },
+  });
+
+  itBench({
+    id: `BeaconState ViewDU validator tree creation vc=${numModified}`,
+    beforeEach: () => {
+      const state = createPartiallyModifiedDenebState();
+      state.commit();
+      return state;
+    },
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      const validators = state.validators;
+      for (let i = 0; i < numModified; i++) {
+        validators.getReadonly(i).node.left;
+      }
+    },
+  });
+
+  const hc = new HashComputationGroup();
+  itBench({
+    id: `BeaconState ViewDU batchHashTreeRoot vc=${vc}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      // commit() step is inside hashTreeRoot(), reuse HashComputationGroup
+      if (toHexString(state.batchHashTreeRoot(hc)) !== expectedRoot) {
+        throw new Error("batchHashTreeRoot does not match expectedRoot");
+      }
+      state.batchHashTreeRoot(hc);
+    },
+  });
+
+  itBench({
+    id: `BeaconState ViewDU hashTreeRoot - commit step vc=${vc}`,
+    beforeEach: () => createPartiallyModifiedDenebState(),
+    fn: (state: CompositeViewDU<typeof BeaconState>) => {
+      state.commit(0, []);
+    },
+  });
+
+  itBench({
+    id: `BeaconState ViewDU hashTreeRoot - hash step vc=${vc}`,
+    beforeEach: () => {
+      const state = createPartiallyModifiedDenebState();
+      const hcByLevel: HashComputationLevel[] = [];
+      state.commit(0, hcByLevel);
+      return hcByLevel;
+    },
+    fn: (hcByLevel) => {
+      executeHashComputations(hcByLevel);
+    },
+  });
+});
+
+let originalState: CompositeViewDU<typeof BeaconState> | null = null;
+function createPartiallyModifiedDenebState(): CompositeViewDU<typeof BeaconState> {
+  if (originalState === null) {
+    originalState = createDenebState(vc);
+    // cache all roots
+    // the original state is huge, do not call hashTreeRoot() here
+    originalState.commit();
+    originalState.node.root;
+  }
+
+  const state = originalState.clone();
+  state.slot++;
+  state.latestBlockHeader = BeaconState.fields.latestBlockHeader.toViewDU({
+    slot: 1000,
+    proposerIndex: 1,
+    parentRoot: Buffer.alloc(32, 0xac),
+    stateRoot: Buffer.alloc(32, 0xed),
+    bodyRoot: Buffer.alloc(32, 0x32),
+  });
+  state.blockRoots.set(0, Buffer.alloc(32, 0x01));
+  state.stateRoots.set(0, Buffer.alloc(32, 0x01));
+  state.historicalRoots.set(0, Buffer.alloc(32, 0x01));
+  for (let i = 0; i < numModified; i++) {
+    state.validators.get(i).effectiveBalance += 1e9;
+  }
+  state.balances = BeaconState.fields.balances.toViewDU(Array.from({length: vc}, () => 32e9));
+
+  state.eth1Data = BeaconState.fields.eth1Data.toViewDU({
+    depositRoot: Buffer.alloc(32, 0x02),
+    depositCount: 1000,
+    blockHash: Buffer.alloc(32, 0x03),
+  });
+  state.eth1DataVotes.set(0, state.eth1Data);
+  state.eth1DepositIndex++;
+  state.randaoMixes.set(0, Buffer.alloc(32, 0x02));
+  state.slashings.set(0, BigInt(1e9));
+
+  state.justificationBits = BeaconState.fields.justificationBits.toViewDU(
+    BitArray.fromBoolArray([true, false, true, true])
+  );
+  state.previousJustifiedCheckpoint = BeaconState.fields.previousJustifiedCheckpoint.toViewDU({
+    epoch: 1000,
+    root: Buffer.alloc(32, 0x01),
+  });
+  state.currentJustifiedCheckpoint = BeaconState.fields.currentJustifiedCheckpoint.toViewDU({
+    epoch: 1000,
+    root: Buffer.alloc(32, 0x01),
+  });
+  state.finalizedCheckpoint = BeaconState.fields.finalizedCheckpoint.toViewDU({
+    epoch: 1000,
+    root: Buffer.alloc(32, 0x01),
+  });
+  return state;
+}
+
+function createDenebState(vc: number): CompositeViewDU<typeof BeaconState> {
+  const state = BeaconState.defaultViewDU();
+  state.genesisTime = 1e9;
+  state.genesisValidatorsRoot = Buffer.alloc(32, 1);
+  state.slot = 1_000_000;
+  state.fork = BeaconState.fields.fork.toViewDU({
+    epoch: 1000,
+    previousVersion: Buffer.alloc(4, 0x03),
+    currentVersion: Buffer.alloc(4, 0x04),
+  });
+  state.latestBlockHeader = BeaconState.fields.latestBlockHeader.toViewDU({
+    slot: 1000,
+    proposerIndex: 1,
+    parentRoot: Buffer.alloc(32, 0xac),
+    stateRoot: Buffer.alloc(32, 0xed),
+    bodyRoot: Buffer.alloc(32, 0x32),
+  });
+  state.blockRoots = BeaconState.fields.blockRoots.toViewDU(
+    Array.from({length: 1_000_000}, () => Buffer.alloc(32, 0x01))
+  );
+  state.stateRoots = BeaconState.fields.stateRoots.toViewDU(
+    Array.from({length: 1_000_000}, () => Buffer.alloc(32, 0x01))
+  );
+  state.historicalRoots = BeaconState.fields.historicalRoots.toViewDU(
+    Array.from({length: 1_000_000}, () => Buffer.alloc(32, 0x01))
+  );
+  state.eth1DataVotes = BeaconState.fields.eth1DataVotes.toViewDU(
+    Array.from({length: EPOCHS_PER_ETH1_VOTING_PERIOD * SLOTS_PER_EPOCH}, () => {
+      return {
+        depositRoot: Buffer.alloc(32, 0x04),
+        depositCount: 1000,
+        blockHash: Buffer.alloc(32, 0x05),
+      };
+    })
+  );
+  state.eth1DepositIndex = 1000;
+  const validators = Array.from({length: vc}, () => {
+    return {
+      pubkey: Buffer.alloc(48, 0xaa),
+      withdrawalCredentials: Buffer.alloc(32, 0xbb),
+      effectiveBalance: 32e9,
+      slashed: false,
+      activationEligibilityEpoch: 1_000_000,
+      activationEpoch: 2_000_000,
+      exitEpoch: 3_000_000,
+      withdrawableEpoch: 4_000_000,
+    };
+  });
+  state.validators = BeaconState.fields.validators.toViewDU(validators);
+  state.balances = BeaconState.fields.balances.toViewDU(Array.from({length: vc}, () => 32e9));
+  // randomMixes
+  state.randaoMixes = BeaconState.fields.randaoMixes.toViewDU(
+    Array.from({length: SLOTS_PER_HISTORICAL_ROOT}, () => Buffer.alloc(32, 0x01))
+  );
+  // slashings
+  state.slashings = BeaconState.fields.slashings.toViewDU(
+    Array.from({length: SLOTS_PER_HISTORICAL_ROOT}, () => BigInt(1e9))
+  );
+  state.previousEpochParticipation = BeaconState.fields.previousEpochParticipation.toViewDU(
+    Array.from({length: vc}, () => 7)
+  );
+  state.currentEpochParticipation = BeaconState.fields.previousEpochParticipation.toViewDU(
+    Array.from({length: vc}, () => 7)
+  );
+  return state;
+}

--- a/packages/ssz/test/perf/eth2/hashTreeRoot.test.ts
+++ b/packages/ssz/test/perf/eth2/hashTreeRoot.test.ts
@@ -1,5 +1,5 @@
 import {itBench} from "@dapplion/benchmark";
-import {hasher, uint8ArrayToHashObject} from "@chainsafe/persistent-merkle-tree";
+import {HashComputationGroup, hasher, uint8ArrayToHashObject} from "@chainsafe/persistent-merkle-tree";
 import * as sszPhase0 from "../../lodestarTypes/phase0/sszTypes";
 import * as sszAltair from "../../lodestarTypes/altair/sszTypes";
 import {
@@ -65,6 +65,16 @@ describe("HashTreeRoot frequent eth2 objects", () => {
       beforeEach: (bytes) => sszAltair.BeaconState.deserializeToViewDU(bytes),
       fn: (state) => {
         state.hashTreeRoot();
+      },
+    });
+
+    const hc = new HashComputationGroup();
+    itBench<CompositeViewDU<typeof sszAltair.BeaconState>, Uint8Array>({
+      id: `BeaconState vc ${validatorCount} - batchHashTreeRoot tree`,
+      before: () => getStateViewDU().serialize(),
+      beforeEach: (bytes) => sszAltair.BeaconState.deserializeToViewDU(bytes),
+      fn: (state) => {
+        state.batchHashTreeRoot(hc);
       },
     });
 

--- a/packages/ssz/test/spec/runValidTest.ts
+++ b/packages/ssz/test/spec/runValidTest.ts
@@ -117,6 +117,20 @@ export function runValidSszTest(type: Type<unknown>, testData: ValidTestCaseData
     assertRoot(root, "type.hashTreeRoot()");
   }
 
+  if (isCompositeType(type)) {
+    // batchHashTreeRoot()
+    const root = wrapErr(() => {
+      const node = type.value_toTree(testDataValue);
+      const viewDU = type.getViewDU(node);
+      if (viewDU instanceof TreeViewDU) {
+        return viewDU.batchHashTreeRoot();
+      } else {
+        return type.hashTreeRoot(testDataValue);
+      }
+    }, "type.hashTreeRoot()");
+    assertRoot(root, "ViewDU.batchHashTreeRoot()");
+  }
+
   // value -> tree - value_toTree()
   const node = wrapErr(() => type.value_toTree(testDataValue), "type.value_toTree()");
   assertNode(node, "type.value_toTree()");

--- a/packages/ssz/test/unit/byType/bitArray/tree.test.ts
+++ b/packages/ssz/test/unit/byType/bitArray/tree.test.ts
@@ -1,3 +1,4 @@
+import {expect} from "chai";
 import {BitVectorType, BitListType, BitArray} from "../../../../src";
 import {runViewTestMutation} from "../runViewTestMutation";
 
@@ -49,6 +50,22 @@ for (const type of [new BitVectorType(4), new BitListType(4)]) {
     ],
   });
 }
+
+describe("BitArray batchHashTreeRoot", () => {
+  const sszType = new BitListType(4);
+  const value = fromNum(4, 0b0010);
+  const expectedRoot = sszType.toView(value).hashTreeRoot();
+
+  it("fresh ViewDU", () => {
+    expect(sszType.toViewDU(value).batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("set then hashTreeRoot", () => {
+    const viewDU = sszType.toViewDU(fromNum(4, 0b0011));
+    viewDU.set(0, false);
+    expect(sszType.toViewDU(value).batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+});
 
 function fromNum(bitLen: number, num: number): BitArray {
   const bitArray = BitArray.fromBitLen(bitLen);

--- a/packages/ssz/test/unit/byType/bitVector/tree.test.ts
+++ b/packages/ssz/test/unit/byType/bitVector/tree.test.ts
@@ -1,3 +1,4 @@
+import {expect} from "chai";
 import {BitVectorType, BitArray} from "../../../../src";
 import {runViewTestMutation} from "../runViewTestMutation";
 
@@ -46,6 +47,22 @@ runViewTestMutation({
       },
     },
   ],
+});
+
+describe("BitVector batchHashTreeRoot", () => {
+  const sszType = new BitVectorType(4);
+  const value = fromNum(4, 0b0010);
+  const expectedRoot = sszType.toView(value).hashTreeRoot();
+
+  it("fresh ViewDU", () => {
+    expect(sszType.toViewDU(value).batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("set then batchHashTreeRoot", () => {
+    const viewDU = sszType.toViewDU(fromNum(4, 0b0011));
+    viewDU.set(0, false);
+    expect(sszType.toViewDU(value).batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
 });
 
 function fromNum(bitLen: number, num: number): BitArray {

--- a/packages/ssz/test/unit/byType/container/tree.test.ts
+++ b/packages/ssz/test/unit/byType/container/tree.test.ts
@@ -1,5 +1,10 @@
 import {expect} from "chai";
 import {
+  BitArray,
+  BitListType,
+  BitVectorType,
+  BooleanType,
+  ByteListType,
   ByteVectorType,
   ContainerNodeStructType,
   ContainerType,
@@ -7,8 +12,11 @@ import {
   ListCompositeType,
   NoneType,
   toHexString,
+  UintNumberType,
   UnionType,
   ValueOf,
+  VectorBasicType,
+  VectorCompositeType,
 } from "../../../../src";
 import {uint64NumInfType, uint64NumType} from "../../../utils/primitiveTypes";
 import {runViewTestMutation} from "../runViewTestMutation";
@@ -217,4 +225,413 @@ runViewTestMutation({
       },
     },
   ],
+});
+
+describe("ContainerViewDU batchHashTreeRoot", function () {
+  const childContainerType = new ContainerType({f0: uint64NumInfType, f1: uint64NumInfType});
+  const unionType = new UnionType([new NoneType(), uint64NumType]);
+  const listBasicType = new ListBasicType(uint64NumType, 10);
+  const vectorBasicType = new VectorBasicType(uint64NumType, 2);
+  const listCompositeType = new ListCompositeType(childContainerType, 10);
+  const vectorCompositeType = new VectorCompositeType(childContainerType, 1);
+  const bitVectorType = new BitVectorType(64);
+  const bitListType = new BitListType(4);
+  const childContainerStruct = new ContainerNodeStructType({g0: uint64NumInfType, g1: uint64NumInfType});
+  const parentContainerType = new ContainerType({
+    a: uint64NumType,
+    b: new BooleanType(),
+    c: unionType,
+    d: new ByteListType(64),
+    e: new ByteVectorType(64),
+    // a child container type
+    f: childContainerType,
+    g: childContainerStruct,
+    h: listBasicType,
+    i: vectorBasicType,
+    j: listCompositeType,
+    k: vectorCompositeType,
+    l: bitVectorType,
+    m: bitListType,
+    // TODO: add more tests when OptionalType is implemented
+  });
+
+  const value: ValueOf<typeof parentContainerType> = {
+    a: 10,
+    b: true,
+    c: {selector: 1, value: 100},
+    d: Buffer.alloc(64, 2),
+    e: Buffer.alloc(64, 1),
+    f: {f0: 100, f1: 101},
+    g: {g0: 100, g1: 101},
+    h: [1, 2],
+    i: [1, 2],
+    j: [{f0: 1, f1: 2}],
+    k: [{f0: 1, f1: 2}],
+    l: BitArray.fromSingleBit(64, 5),
+    m: BitArray.fromSingleBit(4, 1),
+  };
+  const expectedRoot = parentContainerType.toView(value).hashTreeRoot();
+
+  it("fresh ViewDU", () => {
+    expect(parentContainerType.toViewDU(value).batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify Number type", () => {
+    const viewDU = parentContainerType.toViewDU({...value, a: 9});
+    viewDU.batchHashTreeRoot();
+    viewDU.a += 1;
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.a = 10;
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify BooleanType", () => {
+    const viewDU = parentContainerType.toViewDU({...value, b: false});
+    viewDU.batchHashTreeRoot();
+    viewDU.b = true;
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.b = true;
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify UnionType", () => {
+    const viewDU = parentContainerType.toViewDU({...value, c: {selector: 1, value: 101}});
+    viewDU.batchHashTreeRoot();
+    viewDU.c = unionType.toViewDU({selector: 1, value: 100});
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.c = unionType.toViewDU({selector: 1, value: 100});
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify ByteVectorType", () => {
+    const viewDU = parentContainerType.toViewDU(value);
+    viewDU.batchHashTreeRoot();
+    // this takes more than 1 chunk so the resulting node is a branch node
+    viewDU.e = viewDU.e.slice();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.e = viewDU.e.slice();
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify ByteListType", () => {
+    const viewDU = parentContainerType.toViewDU(value);
+    viewDU.batchHashTreeRoot();
+    // this takes more than 1 chunk so the resulting node is a branch node
+    viewDU.d = viewDU.d.slice();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.d = viewDU.d.slice();
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify full child container", () => {
+    const viewDU = parentContainerType.toViewDU({...value, f: {f0: 99, f1: 999}});
+    viewDU.batchHashTreeRoot();
+    viewDU.f = childContainerType.toViewDU({f0: 100, f1: 101});
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.f = childContainerType.toViewDU({f0: 100, f1: 101});
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify partial child container", () => {
+    const viewDU = parentContainerType.toViewDU({...value, f: {f0: 99, f1: 999}});
+    viewDU.batchHashTreeRoot();
+    viewDU.f.f0 = 100;
+    viewDU.f.f1 = 101;
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.f.f0 = 100;
+    viewDU.f.f1 = 101;
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify ContainerNodeStructType", () => {
+    const viewDU = parentContainerType.toViewDU({...value, g: {g0: 99, g1: 999}});
+    viewDU.batchHashTreeRoot();
+    viewDU.g = childContainerStruct.toViewDU({g0: 100, g1: 101});
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.g = childContainerStruct.toViewDU({g0: 100, g1: 101});
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify partial ContainerNodeStructType", () => {
+    const viewDU = parentContainerType.toViewDU({...value, g: {g0: 99, g1: 999}});
+    viewDU.batchHashTreeRoot();
+    viewDU.g.g0 = 100;
+    viewDU.g.g1 = 101;
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.g.g0 = 100;
+    viewDU.g.g1 = 101;
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify ListBasicType", () => {
+    const viewDU = parentContainerType.toViewDU({...value, h: []});
+    viewDU.batchHashTreeRoot();
+    viewDU.h = listBasicType.toViewDU([1, 2]);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.h = listBasicType.toViewDU([1, 2]);
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then push 1 item to ListBasicType", () => {
+    const viewDU = parentContainerType.toViewDU({...value, h: [1]});
+    viewDU.batchHashTreeRoot();
+    viewDU.h.push(2);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.h = listBasicType.toViewDU([1, 2]);
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify 1 item of ListBasicType", () => {
+    const viewDU = parentContainerType.toViewDU({...value, h: [1, 3]});
+    viewDU.batchHashTreeRoot();
+    viewDU.h.set(1, 2);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.h.set(1, 2);
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify VectorBasicType", () => {
+    const viewDU = parentContainerType.toViewDU({...value, i: []});
+    viewDU.batchHashTreeRoot();
+    viewDU.i = vectorBasicType.toViewDU([1, 2]);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.i = vectorBasicType.toViewDU([1, 2]);
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify 1 item of VectorBasicType", () => {
+    const viewDU = parentContainerType.toViewDU({...value, i: [1, 3]});
+    viewDU.batchHashTreeRoot();
+    viewDU.i.set(1, 2);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.i.set(1, 2);
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify ListCompositeType", () => {
+    const viewDU = parentContainerType.toViewDU({...value, j: []});
+    viewDU.batchHashTreeRoot();
+    viewDU.j = listCompositeType.toViewDU([{f0: 1, f1: 2}]);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.j = listCompositeType.toViewDU([{f0: 1, f1: 2}]);
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then push 1 item to ListCompositeType", () => {
+    const viewDU = parentContainerType.toViewDU({...value, j: []});
+    viewDU.batchHashTreeRoot();
+    viewDU.j.push(childContainerType.toViewDU({f0: 1, f1: 2}));
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.j = listCompositeType.toViewDU([{f0: 1, f1: 2}]);
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify 1 item of ListCompositeType", () => {
+    const viewDU = parentContainerType.toViewDU({...value, j: [{f0: 1, f1: 3}]});
+    viewDU.batchHashTreeRoot();
+    viewDU.j.set(0, childContainerType.toViewDU({f0: 1, f1: 2}));
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.j.set(0, childContainerType.toViewDU({f0: 1, f1: 2}));
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify 1 field of 1 item of ListCompositeType", () => {
+    const viewDU = parentContainerType.toViewDU({...value, j: [{f0: 1, f1: 3}]});
+    viewDU.batchHashTreeRoot();
+    viewDU.j.get(0).f1 = 2;
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.j.get(0).f1 = 2;
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify VectorCompositeType", () => {
+    const viewDU = parentContainerType.toViewDU({...value, k: [{f0: 9, f1: 9}]});
+    viewDU.batchHashTreeRoot();
+    viewDU.k = vectorCompositeType.toViewDU([{f0: 1, f1: 2}]);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.k = vectorCompositeType.toViewDU([{f0: 1, f1: 2}]);
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify 1 item of VectorCompositeType", () => {
+    const viewDU = parentContainerType.toViewDU({...value, k: [{f0: 1, f1: 3}]});
+    viewDU.batchHashTreeRoot();
+    viewDU.k.set(0, childContainerType.toViewDU({f0: 1, f1: 2}));
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.k.set(0, childContainerType.toViewDU({f0: 1, f1: 2}));
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify 1 field 1 item of VectorCompositeType", () => {
+    const viewDU = parentContainerType.toViewDU({...value, k: [{f0: 1, f1: 3}]});
+    viewDU.batchHashTreeRoot();
+    viewDU.k.get(0).f1 = 2;
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.k.get(0).f1 = 2;
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify BitVectorType", () => {
+    const viewDU = parentContainerType.toViewDU({...value, l: BitArray.fromSingleBit(64, 4)});
+    viewDU.batchHashTreeRoot();
+    viewDU.l = bitVectorType.toViewDU(BitArray.fromSingleBit(64, 5));
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.l = bitVectorType.toViewDU(BitArray.fromSingleBit(64, 5));
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify BitVectorType bit", () => {
+    const viewDU = parentContainerType.toViewDU({...value, l: BitArray.fromSingleBit(64, 4)});
+    viewDU.batchHashTreeRoot();
+    viewDU.l.set(4, false);
+    viewDU.l.set(5, true);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.l.set(4, false);
+    viewDU.l.set(5, true);
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify BitListType", () => {
+    const viewDU = parentContainerType.toViewDU({...value, m: BitArray.fromSingleBit(4, 0)});
+    viewDU.batchHashTreeRoot();
+    viewDU.m = bitListType.toViewDU(BitArray.fromSingleBit(4, 1));
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.m = bitListType.toViewDU(BitArray.fromSingleBit(4, 1));
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify BitListType bit", () => {
+    const viewDU = parentContainerType.toViewDU({...value, m: BitArray.fromSingleBit(4, 0)});
+    viewDU.batchHashTreeRoot();
+    viewDU.m.set(0, false);
+    viewDU.m.set(1, true);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign again but commit before batchHashTreeRoot()
+    viewDU.m.set(0, false);
+    viewDU.m.set(1, true);
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+});
+
+describe("ContainerNodeStruct batchHashTreeRoot", function () {
+  const EpochInf = new UintNumberType(8, {clipInfinity: true});
+
+  // Ethereum consensus validator type
+  const containerType = new ContainerNodeStructType({
+    pubkey: new ByteVectorType(48),
+    withdrawalCredentials: new ByteVectorType(32),
+    effectiveBalance: new UintNumberType(8),
+    slashed: new BooleanType(),
+    activationEligibilityEpoch: EpochInf,
+    activationEpoch: EpochInf,
+    exitEpoch: EpochInf,
+    withdrawableEpoch: EpochInf,
+  });
+  const value = {
+    pubkey: Buffer.alloc(48, 0xaa),
+    withdrawalCredentials: Buffer.alloc(32, 0xbb),
+    effectiveBalance: 32e9,
+    slashed: false,
+    activationEligibilityEpoch: 1_000_000,
+    activationEpoch: 2_000_000,
+    exitEpoch: 3_000_000,
+    withdrawableEpoch: 4_000_000,
+  };
+  const expectedRoot = containerType.toView(value).hashTreeRoot();
+
+  it("fresh ViewDU", () => {
+    expect(containerType.toViewDU(value).batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify basic type", () => {
+    const viewDU = containerType.toViewDU({...value, exitEpoch: 3});
+    viewDU.batchHashTreeRoot();
+    viewDU.exitEpoch *= 1_000_000;
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("modify basic type", () => {
+    const viewDU = containerType.toViewDU({
+      ...value,
+      exitEpoch: value.exitEpoch + 1,
+      withdrawableEpoch: value.withdrawableEpoch + 1,
+    });
+    viewDU.exitEpoch -= 1;
+    viewDU.withdrawableEpoch -= 1;
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
 });

--- a/packages/ssz/test/unit/byType/listBasic/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listBasic/tree.test.ts
@@ -240,3 +240,78 @@ describe("ListBasicType.sliceTo", () => {
     });
   }
 });
+
+describe("ListBasicType batchHashTreeRoot", function () {
+  const value = [1, 2, 3, 4];
+  const expectedRoot = ListN64Uint64NumberType.toView(value).hashTreeRoot();
+
+  it("fresh ViewDU", () => {
+    expect(ListN64Uint64NumberType.toViewDU(value).batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("push then batchHashTreeRoot()", () => {
+    const viewDU = ListN64Uint64NumberType.defaultViewDU();
+    viewDU.push(1);
+    viewDU.push(2);
+    viewDU.push(3);
+    viewDU.push(4);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign the same value again, commit() then batchHashTreeRoot()
+    viewDU.set(0, 1);
+    viewDU.set(1, 2);
+    viewDU.set(2, 3);
+    viewDU.set(3, 4);
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("push then modify then batchHashTreeRoot()", () => {
+    const viewDU = ListN64Uint64NumberType.defaultViewDU();
+    viewDU.push(1);
+    viewDU.push(2);
+    viewDU.push(3);
+    viewDU.push(44);
+    viewDU.set(3, 4);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign the same value again, commit() then batchHashTreeRoot()
+    viewDU.set(3, 44);
+    viewDU.set(3, 4);
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify", () => {
+    const viewDU = ListN64Uint64NumberType.defaultViewDU();
+    viewDU.push(1);
+    viewDU.push(2);
+    viewDU.push(33);
+    viewDU.push(44);
+    viewDU.batchHashTreeRoot();
+    viewDU.set(2, 3);
+    viewDU.set(3, 4);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign the same value again, commit() then batchHashTreeRoot()
+    viewDU.set(2, 33);
+    viewDU.set(3, 44);
+    viewDU.commit();
+    viewDU.set(2, 3);
+    viewDU.set(3, 4);
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  // similar to a fresh ViewDU but it's good to test
+  it("sliceTo()", () => {
+    const viewDU = ListN64Uint64NumberType.defaultViewDU();
+    viewDU.push(1);
+    viewDU.push(2);
+    viewDU.push(3);
+    viewDU.push(4);
+    viewDU.push(5);
+    viewDU.batchHashTreeRoot();
+    expect(viewDU.sliceTo(3).batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+});

--- a/packages/ssz/test/unit/byType/optional/tree.test.ts
+++ b/packages/ssz/test/unit/byType/optional/tree.test.ts
@@ -8,7 +8,7 @@ const SimpleObject = new ContainerType({
 });
 
 describe("Optional view tests", () => {
-  // unimplemented
+  // TODO: implement
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call
   it.skip("optional simple type", () => {
     const type = new OptionalType(byteType);
@@ -22,7 +22,7 @@ describe("Optional view tests", () => {
     expect(toHexString(type.commitViewDU(viewDU).root)).equals(toHexString(root));
   });
 
-  // unimplemented
+  // TODO: implement
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call
   it.skip("optional composite type", () => {
     const type = new OptionalType(SimpleObject);

--- a/packages/ssz/test/unit/byType/vectorBasic/tree.test.ts
+++ b/packages/ssz/test/unit/byType/vectorBasic/tree.test.ts
@@ -1,0 +1,67 @@
+import {expect} from "chai";
+import {UintNumberType, VectorBasicType} from "../../../../src";
+import {runViewTestMutation} from "../runViewTestMutation";
+
+const uint64NumInf = new UintNumberType(8, {clipInfinity: true});
+const vectorType = new VectorBasicType(uint64NumInf, 8);
+
+runViewTestMutation({
+  type: vectorType,
+  mutations: [
+    {
+      id: "set basic",
+      valueBefore: [1, 2, 3, 4, 5, 6, 7, 8],
+      valueAfter: [0, 1, 2, 3, 4, 5, 6, 7],
+      fn: (tv) => {
+        tv.set(0, 0);
+        tv.set(1, 1);
+        tv.set(2, 2);
+        tv.set(3, 3);
+        tv.set(4, 4);
+        tv.set(5, 5);
+        tv.set(6, 6);
+        tv.set(7, 7);
+      },
+    },
+    {
+      id: "swap two indices",
+      valueBefore: [1, 2, 3, 4, 5, 6, 7, 8],
+      valueAfter: [8, 2, 3, 4, 5, 6, 7, 1],
+      fn: (tv) => {
+        const i0 = tv.get(0);
+        const i7 = tv.get(7);
+        tv.set(0, i7);
+        tv.set(7, i0);
+      },
+    },
+  ],
+});
+
+describe("VectorBasicType batchHashTreeRoot", () => {
+  const value = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+  const expectedRoot = vectorType.hashTreeRoot(value);
+
+  it("fresh ViewDU", () => {
+    expect(vectorType.toViewDU(value).batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+
+  it("full hash then modify", () => {
+    const viewDU = vectorType.defaultViewDU();
+    viewDU.hashTreeRoot();
+    viewDU.set(0, 0);
+    viewDU.set(1, 1);
+    viewDU.set(2, 2);
+    viewDU.set(3, 3);
+    viewDU.set(4, 4);
+    viewDU.set(5, 5);
+    viewDU.set(6, 6);
+    viewDU.set(7, 7);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+    // assign the same value again, commit() then batchHashTreeRoot()
+    viewDU.set(0, 0);
+    viewDU.set(7, 7);
+    viewDU.commit();
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+  });
+});

--- a/packages/ssz/test/unit/byType/vectorComposite/tree.test.ts
+++ b/packages/ssz/test/unit/byType/vectorComposite/tree.test.ts
@@ -1,0 +1,121 @@
+import {expect} from "chai";
+import {ContainerNodeStructType, ContainerType, UintNumberType, ValueOf, VectorCompositeType} from "../../../../src";
+import {runViewTestMutation} from "../runViewTestMutation";
+
+const uint64NumInfType = new UintNumberType(8, {clipInfinity: true});
+const containerUintsType = new ContainerType(
+  {a: uint64NumInfType, b: uint64NumInfType},
+  {typeName: "Container(uint64)"}
+);
+const vectorOfContainersType = new VectorCompositeType(containerUintsType, 2, {typeName: "VectorComposite(Container)"});
+
+runViewTestMutation({
+  type: vectorOfContainersType,
+  treeViewToStruct: (tv) => {
+    const arr: ValueOf<typeof vectorOfContainersType> = [];
+    for (let i = 0; i < tv.length; i++) {
+      const item = tv.get(i);
+      arr.push({a: item.a, b: item.b});
+    }
+    return arr;
+  },
+  mutations: [
+    {
+      id: "set",
+      valueBefore: [
+        {a: 1, b: 2},
+        {a: 3, b: 4},
+      ],
+      valueAfter: [
+        {a: 5, b: 6},
+        {a: 7, b: 8},
+      ],
+      fn: (tv) => {
+        tv.set(0, containerUintsType.toViewDU({a: 5, b: 6}));
+        tv.set(1, containerUintsType.toViewDU({a: 7, b: 8}));
+      },
+    },
+    {
+      id: "set child properties",
+      valueBefore: [
+        {a: 1, b: 2},
+        {a: 3, b: 4},
+      ],
+      valueAfter: [
+        {a: 5, b: 2},
+        {a: 3, b: 8},
+      ],
+      fn: (tv) => {
+        tv.get(0).a = 5;
+        tv.get(1).b = 8;
+      },
+    },
+    {
+      id: "swap indices",
+      valueBefore: [
+        {a: 1, b: 2},
+        {a: 3, b: 4},
+      ],
+      valueAfter: [
+        {a: 3, b: 4},
+        {a: 1, b: 2},
+      ],
+      fn: (tv) => {
+        const item0 = tv.get(0);
+        const item1 = tv.get(1);
+        tv.set(0, item1);
+        tv.set(1, item0);
+      },
+    },
+  ],
+});
+
+describe("VectorCompositeType batchHashTreeRoot", () => {
+  const value = [
+    {a: 1, b: 2},
+    {a: 3, b: 4},
+  ];
+  const containerUintsType = new ContainerNodeStructType(
+    {a: uint64NumInfType, b: uint64NumInfType},
+    {typeName: "ContainerNodeStruct(uint64)"}
+  );
+  const vectorOfContainersType2 = new VectorCompositeType(containerUintsType, 2, {
+    typeName: "VectorComposite(ContainerNodeStruct)",
+  });
+  for (const vector of [vectorOfContainersType, vectorOfContainersType2]) {
+    const typeName = vector.typeName;
+    const expectedRoot = vectorOfContainersType.toView(value).hashTreeRoot();
+
+    it(`${typeName} - fresh ViewDU`, () => {
+      expect(vectorOfContainersType.toViewDU(value).batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+    });
+
+    it(`${typeName} - modify 1 full element`, () => {
+      const viewDU = vectorOfContainersType.toViewDU([
+        {a: 1, b: 2},
+        {a: 0, b: 0},
+      ]);
+      viewDU.set(1, containerUintsType.toViewDU({a: 3, b: 4}));
+      expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+      // assign the same value again, commit() then batchHashTreeRoot();
+      viewDU.set(1, containerUintsType.toViewDU({a: 3, b: 4}));
+      viewDU.commit();
+      expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+    });
+
+    it(`${typeName} - modify 1 property of 1 element`, () => {
+      const viewDU = vectorOfContainersType.toViewDU([
+        {a: 1, b: 2},
+        {a: 3, b: 0},
+      ]);
+      viewDU.get(1).b = 4;
+      expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+      // assign the same value again, commit() then batchHashTreeRoot();
+      viewDU.get(1).b = 4;
+      viewDU.commit();
+      expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+    });
+  }
+});

--- a/packages/ssz/test/unit/eth2/beaconState.test.ts
+++ b/packages/ssz/test/unit/eth2/beaconState.test.ts
@@ -1,0 +1,200 @@
+import {expect} from "chai";
+import {BeaconState} from "../../lodestarTypes/deneb/sszTypes";
+import {ListUintNum64Type} from "../../../src/type/listUintNum64";
+import {altair, phase0, ssz} from "../../lodestarTypes";
+import {BitArray, fromHexString} from "../../../src";
+
+const VALIDATOR_REGISTRY_LIMIT = 1099511627776;
+export const Balances = new ListUintNum64Type(VALIDATOR_REGISTRY_LIMIT);
+
+describe("BeaconState ViewDU batchHashTreeRoot", function () {
+  const view = BeaconState.defaultView();
+  const viewDU = BeaconState.defaultViewDU();
+
+  it("BeaconState ViewDU should have same hashTreeRoot() to View", () => {
+    // genesisTime
+    viewDU.genesisTime = view.genesisTime = 1e9;
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // genesisValidatorsRoot
+    viewDU.genesisValidatorsRoot = view.genesisValidatorsRoot = Buffer.alloc(32, 1);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // fork
+    const fork: phase0.Fork = {
+      epoch: 1000,
+      previousVersion: fromHexString("0x03001020"),
+      currentVersion: fromHexString("0x04001020"),
+    };
+    view.fork = BeaconState.fields.fork.toView(fork);
+    viewDU.fork = BeaconState.fields.fork.toViewDU(fork);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // latestBlockHeader
+    const latestBlockHeader: phase0.BeaconBlockHeader = {
+      slot: 1000,
+      proposerIndex: 1,
+      parentRoot: fromHexString("0xac80c66f413218e2c9c7bcb2408ccdceacf3bcd7e7df58474e0c6aa9d7f328a0"),
+      stateRoot: fromHexString("0xed29eed3dbee72caf3b13df84d01ebda1482dbd0ce084e1ce8862b4acb740ed8"),
+      bodyRoot: fromHexString("0x32c644ca1b5d1583d445e9d41c81b3e98465fefad4f0db16084cbce7f1b7b849"),
+    };
+    view.latestBlockHeader = BeaconState.fields.latestBlockHeader.toView(latestBlockHeader);
+    viewDU.latestBlockHeader = BeaconState.fields.latestBlockHeader.toViewDU(latestBlockHeader);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // blockRoots
+    const blockRoots = ssz.phase0.HistoricalBlockRoots.defaultValue();
+    blockRoots[0] = fromHexString("0x1234");
+    view.blockRoots = ssz.phase0.HistoricalBlockRoots.toView(blockRoots);
+    viewDU.blockRoots = ssz.phase0.HistoricalBlockRoots.toViewDU(blockRoots);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // stateRoots
+    const stateRoots = ssz.phase0.HistoricalStateRoots.defaultValue();
+    stateRoots[0] = fromHexString("0x5678");
+    view.stateRoots = ssz.phase0.HistoricalStateRoots.toView(stateRoots);
+    viewDU.stateRoots = ssz.phase0.HistoricalStateRoots.toViewDU(stateRoots);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // historical_roots Frozen in Capella, replaced by historical_summaries
+    // Eth1
+    const eth1Data: phase0.Eth1Data = {
+      depositRoot: fromHexString("0x1234"),
+      depositCount: 1000,
+      blockHash: fromHexString("0x5678"),
+    };
+    view.eth1Data = BeaconState.fields.eth1Data.toView(eth1Data);
+    viewDU.eth1Data = BeaconState.fields.eth1Data.toViewDU(eth1Data);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // Eth1DataVotes
+    const eth1DataVotes = ssz.phase0.Eth1DataVotes.defaultValue();
+    eth1DataVotes[0] = eth1Data;
+    view.eth1DataVotes = ssz.phase0.Eth1DataVotes.toView(eth1DataVotes);
+    viewDU.eth1DataVotes = ssz.phase0.Eth1DataVotes.toViewDU(eth1DataVotes);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // Eth1DepositIndex
+    view.eth1DepositIndex = 1000;
+    viewDU.eth1DepositIndex = 1000;
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // validators
+    const validator = {
+      pubkey: Buffer.alloc(48, 0xaa),
+      withdrawalCredentials: Buffer.alloc(32, 0xbb),
+      effectiveBalance: 32e9,
+      slashed: false,
+      activationEligibilityEpoch: 1_000_000,
+      activationEpoch: 2_000_000,
+      exitEpoch: 3_000_000,
+      withdrawableEpoch: 4_000_000,
+    };
+    view.validators = BeaconState.fields.validators.toView([validator]);
+    viewDU.validators = BeaconState.fields.validators.toViewDU([validator]);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // balances
+    view.balances = BeaconState.fields.balances.toView([1000, 2000, 3000]);
+    viewDU.balances = Balances.toViewDU([1000, 2000, 3000]);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // randaoMixes
+    const randaoMixes = ssz.phase0.RandaoMixes.defaultValue();
+    randaoMixes[0] = fromHexString("0x1234");
+    view.randaoMixes = ssz.phase0.RandaoMixes.toView(randaoMixes);
+    viewDU.randaoMixes = ssz.phase0.RandaoMixes.toViewDU(randaoMixes);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // slashings
+    view.slashings = BeaconState.fields.slashings.toView(Array.from({length: 64}, () => BigInt(1000)));
+    viewDU.slashings = BeaconState.fields.slashings.toViewDU(Array.from({length: 64}, () => BigInt(1000)));
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // previousEpochAttestations
+    view.previousEpochParticipation = BeaconState.fields.previousEpochParticipation.toView([1, 2, 3]);
+    viewDU.previousEpochParticipation = BeaconState.fields.previousEpochParticipation.toViewDU([1, 2, 3]);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // currentEpochAttestations
+    view.currentEpochParticipation = BeaconState.fields.currentEpochParticipation.toView([1, 2, 3]);
+    viewDU.currentEpochParticipation = BeaconState.fields.currentEpochParticipation.toViewDU([1, 2, 3]);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // justificationBits
+    view.justificationBits = BeaconState.fields.justificationBits.toView(
+      BitArray.fromBoolArray([true, false, true, true])
+    );
+    viewDU.justificationBits = BeaconState.fields.justificationBits.toViewDU(
+      BitArray.fromBoolArray([true, false, true, true])
+    );
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // previousJustifiedCheckpoint
+    const checkpoint: phase0.Checkpoint = {
+      epoch: 1000,
+      root: fromHexString("0x1234"),
+    };
+    view.previousJustifiedCheckpoint = BeaconState.fields.previousJustifiedCheckpoint.toView(checkpoint);
+    viewDU.previousJustifiedCheckpoint = BeaconState.fields.previousJustifiedCheckpoint.toViewDU(checkpoint);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // currentJustifiedCheckpoint
+    view.currentJustifiedCheckpoint = BeaconState.fields.currentJustifiedCheckpoint.toView(checkpoint);
+    viewDU.currentJustifiedCheckpoint = BeaconState.fields.currentJustifiedCheckpoint.toViewDU(checkpoint);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // finalizedCheckpoint
+    view.finalizedCheckpoint = BeaconState.fields.finalizedCheckpoint.toView(checkpoint);
+    viewDU.finalizedCheckpoint = BeaconState.fields.finalizedCheckpoint.toViewDU(checkpoint);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // inactivityScores
+    view.inactivityScores = BeaconState.fields.inactivityScores.toView([1, 2, 3]);
+    viewDU.inactivityScores = BeaconState.fields.inactivityScores.toViewDU([1, 2, 3]);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // currentSyncCommittee
+    const syncCommittee: altair.SyncCommittee = {
+      pubkeys: Array.from({length: 32}, () => Buffer.alloc(48, 0xaa)),
+      aggregatePubkey: fromHexString("0x1234"),
+    };
+    view.currentSyncCommittee = BeaconState.fields.currentSyncCommittee.toView(syncCommittee);
+    viewDU.currentSyncCommittee = BeaconState.fields.currentSyncCommittee.toViewDU(syncCommittee);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // nextSyncCommittee
+    view.nextSyncCommittee = BeaconState.fields.nextSyncCommittee.toView(syncCommittee);
+    viewDU.nextSyncCommittee = BeaconState.fields.nextSyncCommittee.toViewDU(syncCommittee);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // latestExecutionPayloadHeader
+    const latestExecutionPayloadHeader = BeaconState.fields.latestExecutionPayloadHeader.defaultValue();
+    latestExecutionPayloadHeader.blockNumber = 1000;
+    latestExecutionPayloadHeader.parentHash = fromHexString(
+      "0xac80c66f413218e2c9c7bcb2408ccdceacf3bcd7e7df58474e0c6aa9d7f328a0"
+    );
+    view.latestExecutionPayloadHeader =
+      BeaconState.fields.latestExecutionPayloadHeader.toView(latestExecutionPayloadHeader);
+    viewDU.latestExecutionPayloadHeader =
+      BeaconState.fields.latestExecutionPayloadHeader.toViewDU(latestExecutionPayloadHeader);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // nextWithdrawalIndex
+    viewDU.nextWithdrawalIndex = view.nextWithdrawalIndex = 1000;
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // nextWithdrawalValidatorIndex
+    viewDU.nextWithdrawalValidatorIndex = view.nextWithdrawalValidatorIndex = 1000;
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+
+    // historicalSummaries
+    const historicalSummaries = {
+      blockSummaryRoot: fromHexString("0xac80c66f413218e2c9c7bcb2408ccdceacf3bcd7e7df58474e0c6aa9d7f328a0"),
+      stateSummaryRoot: fromHexString("0x32c644ca1b5d1583d445e9d41c81b3e98465fefad4f0db16084cbce7f1b7b849"),
+    };
+    view.historicalSummaries = BeaconState.fields.historicalSummaries.toView([historicalSummaries]);
+    viewDU.historicalSummaries = BeaconState.fields.historicalSummaries.toViewDU([historicalSummaries]);
+    expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(view.hashTreeRoot());
+  });
+});

--- a/packages/ssz/test/unit/eth2/validators.test.ts
+++ b/packages/ssz/test/unit/eth2/validators.test.ts
@@ -3,21 +3,20 @@ import {describe, it} from "mocha";
 import {toHexString, ListCompositeType, ValueOf, CompositeViewDU} from "../../../src";
 import {ValidatorContainer, ValidatorNodeStruct} from "../../lodestarTypes/phase0/sszTypes";
 
+type Validator = ValueOf<typeof ValidatorContainer>;
+const validator: Validator = {
+  pubkey: Buffer.alloc(48, 0xaa),
+  withdrawalCredentials: Buffer.alloc(32, 0xbb),
+  effectiveBalance: 32e9,
+  slashed: false,
+  activationEligibilityEpoch: 1_000_000,
+  activationEpoch: 2_000_000,
+  exitEpoch: 3_000_000,
+  withdrawableEpoch: 4_000_000,
+};
+
 describe("Container with BranchNodeStruct", function () {
   this.timeout(0);
-
-  type Validator = ValueOf<typeof ValidatorContainer>;
-
-  const validator: Validator = {
-    pubkey: Buffer.alloc(48, 0xaa),
-    withdrawalCredentials: Buffer.alloc(32, 0xbb),
-    effectiveBalance: 32e9,
-    slashed: false,
-    activationEligibilityEpoch: 1_000_000,
-    activationEpoch: 2_000_000,
-    exitEpoch: 3_000_000,
-    withdrawableEpoch: 4_000_000,
-  };
 
   const validatorViewDU = ValidatorContainer.toViewDU(validator);
   const validatorNodeStructViewDU = ValidatorNodeStruct.toViewDU(validator);
@@ -34,6 +33,7 @@ describe("Container with BranchNodeStruct", function () {
     getExitEpoch: (treeBacked) => treeBacked.exitEpoch,
     getPubkey: (treeBacked) => toHexString(treeBacked.pubkey),
     hashTreeRoot: (treeBacked) => treeBacked.hashTreeRoot(),
+    batchHashTreeRoot: (treeBacked) => treeBacked.batchHashTreeRoot(),
     getProof: (treeBacked) => treeBacked.createProof(validatorProofJsonPaths),
     serialize: (treeBacked) => treeBacked.serialize(),
   };

--- a/packages/ssz/test/unit/regressions.test.ts
+++ b/packages/ssz/test/unit/regressions.test.ts
@@ -32,6 +32,8 @@ describe("Regressions / known issues", () => {
     const bytes = SyncCommitteeBits.serialize(bitArray);
     const rootByTreeBacked = SyncCommitteeBits.deserializeToViewDU(bytes).hashTreeRoot();
     expect(toHexString(rootByStruct)).to.be.equal(toHexString(rootByTreeBacked), "Inconsistent hashTreeRoot");
+    const rootByBatch = SyncCommitteeBits.deserializeToViewDU(bytes).batchHashTreeRoot();
+    expect(toHexString(rootByStruct)).to.be.equal(toHexString(rootByBatch), "Inconsistent hashTreeRoot");
   });
 
   it("converts bit arrays to tree", function () {

--- a/packages/ssz/test/unit/unchangedViewDUs.test.ts
+++ b/packages/ssz/test/unit/unchangedViewDUs.test.ts
@@ -1,0 +1,29 @@
+import {expect} from "chai";
+import * as sszAltair from "../lodestarTypes/altair/sszTypes";
+import {getRandomState} from "../utils/generateEth2Objs";
+
+describe("Unchanged ViewDUs", () => {
+  const state = sszAltair.BeaconState.toViewDU(getRandomState(100));
+
+  it.skip("should not recompute batchHashTreeRoot() when no fields is changed", () => {
+    const root = state.batchHashTreeRoot();
+    // this causes viewsChanged inside BeaconState container
+    state.validators.length;
+    state.balances.length;
+    // but we should not recompute root, should get from cache instead
+    const root2 = state.batchHashTreeRoot();
+    expect(root2).to.equal(root, "should not recompute batchHashTreeRoot() when no fields are changed");
+  });
+
+  it("handle childViewDU.batchHashTreeRoot()", () => {
+    const state2 = state.clone();
+    state2.latestBlockHeader.stateRoot = Buffer.alloc(32, 3);
+    const root2 = state2.batchHashTreeRoot();
+    const state3 = state.clone();
+    state3.latestBlockHeader.stateRoot = Buffer.alloc(32, 3);
+    // batchHashTreeRoot() also does the commit()
+    state3.latestBlockHeader.commit();
+    const root3 = state3.batchHashTreeRoot();
+    expect(root3).to.be.deep.equal(root2);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1244,6 +1244,11 @@
     "@babel/helper-validator-identifier" "^7.24.5"
     to-fast-properties "^2.0.0"
 
+"@chainsafe/as-sha256@^0.4.1", "@chainsafe/as-sha256@^0.4.2":
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/@chainsafe/as-sha256/-/as-sha256-0.4.2.tgz#21ad1371e2245e430c1a554a05f10d333c6f42cc"
+  integrity sha512-HJ8GZBRjLeWtRsAXf3EbNsNzmTGpzTFjfpSf4yHkLYC+E52DhT6hwz+7qpj6I/EmFzSUm5tYYvT9K8GZokLQCQ==
+
 "@chainsafe/babel-plugin-inline-binary-import@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@chainsafe/babel-plugin-inline-binary-import/-/babel-plugin-inline-binary-import-1.0.3.tgz#08dde20d91cf5d18f2c253edf32547943a16e409"
@@ -1275,6 +1280,22 @@
     "@chainsafe/hashtree-darwin-arm64" "1.0.1"
     "@chainsafe/hashtree-linux-arm64-gnu" "1.0.1"
     "@chainsafe/hashtree-linux-x64-gnu" "1.0.1"
+
+"@chainsafe/persistent-merkle-tree@^0.7.1", "@chainsafe/persistent-merkle-tree@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@chainsafe/persistent-merkle-tree/-/persistent-merkle-tree-0.7.2.tgz#f0ef91daf36752f827432333cbc965f4bf6e750e"
+  integrity sha512-BUAqrmSUmy6bZhXxnhpR+aYoEDdCeS1dQvq/aje0CDEB14ZHF9UVN2mL9MolOD0ANUiP1OaPG3KfVBxvuW8aTg==
+  dependencies:
+    "@chainsafe/as-sha256" "^0.4.2"
+    "@noble/hashes" "^1.3.0"
+
+"@chainsafe/ssz@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@chainsafe/ssz/-/ssz-0.16.0.tgz#262c491ac037777a16e8d8db479da2ba27539b8d"
+  integrity sha512-CgTDyrkbAKvrKwHxPT5rerXAHP3NB+uOvpnN9Gn8aJ/4TGOKhOboj4131bSFUZ679uPJ6pu6391cvInuOdrglw==
+  dependencies:
+    "@chainsafe/as-sha256" "^0.4.2"
+    "@chainsafe/persistent-merkle-tree" "^0.7.2"
 
 "@chainsafe/ssz@^0.15.1":
   version "0.15.1"


### PR DESCRIPTION
**Motivation**

- Implement `batchHashTreeRoot()` for ViewDU type based on `HashComputation`

**Description**
- `hashTreeRoot()` is still great because it does not allocate any memory so we need a new method to compute batch
- in `packages/ssz/src/viewDU/abstract.ts`, add `batchHashTreeRoot()` method
  - param is `HashComputationGroup` in previous PR [389](https://github.com/ChainSafe/ssz/pull/389/files#diff-60bb8e753e65c883c3183feb604cb9e9f9a1ae2c5be4aa0f0add8706ca7c907cR174)
  - param is designed to be reused
- add new params to `commit()` method:
  - hcOffset: offset from the top level
  - hcByLevel: an array of HashComputationLevel[] or null. 
  - when `hcByLevel` is null, it means it was called from `hashTreeRoot()`, `commit()` method should be backward compatible in this case
  - ContainerNodeStructTreeViewDU:
    - when commit(), it's unchanged
    - if there is a not null `hcByLevel`, it should compute root because this ViewDU does not support `HashComputation`
 
cherry picked from #378

**Unit Tests**
- I added a bunch of tests to make sure `batchHashTreeRoot()` returns the same value to `hashTreeRoot`, please suggest if we need more

part of #355