### PR TITLE
fix: do not change hashTreeRoot()

### DIFF
--- a/packages/ssz/src/branchNodeStruct.ts
+++ b/packages/ssz/src/branchNodeStruct.ts
@@ -9,18 +9,15 @@ import {hashObjectToUint8Array, Node} from "@chainsafe/persistent-merkle-tree";
  * expensive because the tree has to be recreated every time.
  */
 export class BranchNodeStruct<T> extends Node {
-  constructor(
-    private readonly valueToNode: (value: T) => Node,
-    private readonly hashTreeRootInto: (value: T, node: Node) => void,
-    readonly value: T
-  ) {
+  constructor(private readonly valueToNode: (value: T) => Node, readonly value: T) {
     // First null value is to save an extra variable to check if a node has a root or not
     super(null as unknown as number, 0, 0, 0, 0, 0, 0, 0);
   }
 
   get rootHashObject(): HashObject {
     if (this.h0 === null) {
-      this.hashTreeRootInto(this.value, this);
+      const node = this.valueToNode(this.value);
+      super.applyHash(node.rootHashObject);
     }
     return this;
   }

--- a/packages/ssz/src/type/containerNodeStruct.ts
+++ b/packages/ssz/src/type/containerNodeStruct.ts
@@ -1,5 +1,4 @@
 import {Node} from "@chainsafe/persistent-merkle-tree";
-import {byteArrayIntoHashObject} from "@chainsafe/as-sha256";
 import {Type, ByteViews} from "./abstract";
 import {isCompositeType} from "./composite";
 import {ContainerType, ContainerOptions, renderContainerTypeName} from "./container";
@@ -74,7 +73,7 @@ export class ContainerNodeStructType<Fields extends Record<string, Type<unknown>
 
   tree_deserializeFromBytes(data: ByteViews, start: number, end: number): Node {
     const value = this.value_deserializeFromBytes(data, start, end);
-    return new BranchNodeStruct(this.valueToTree.bind(this), this.computeRootInto.bind(this), value);
+    return new BranchNodeStruct(this.valueToTree.bind(this), value);
   }
 
   // Proofs
@@ -95,7 +94,7 @@ export class ContainerNodeStructType<Fields extends Record<string, Type<unknown>
     super.tree_serializeToBytes({uint8Array, dataView}, 0, node);
     const value = this.value_deserializeFromBytes({uint8Array, dataView}, 0, uint8Array.length);
     return {
-      node: new BranchNodeStruct(this.valueToTree.bind(this), this.computeRootInto.bind(this), value),
+      node: new BranchNodeStruct(this.valueToTree.bind(this), value),
       done: true,
     };
   }
@@ -107,7 +106,7 @@ export class ContainerNodeStructType<Fields extends Record<string, Type<unknown>
   }
 
   value_toTree(value: ValueOfFields<Fields>): Node {
-    return new BranchNodeStruct(this.valueToTree.bind(this), this.computeRootInto.bind(this), value);
+    return new BranchNodeStruct(this.valueToTree.bind(this), value);
   }
 
   private valueToTree(value: ValueOfFields<Fields>): Node {
@@ -115,14 +114,5 @@ export class ContainerNodeStructType<Fields extends Record<string, Type<unknown>
     const dataView = new DataView(uint8Array.buffer, uint8Array.byteOffset, uint8Array.byteLength);
     this.value_serializeToBytes({uint8Array, dataView}, 0, value);
     return super.tree_deserializeFromBytes({uint8Array, dataView}, 0, uint8Array.length);
-  }
-
-  private computeRootInto(value: ValueOfFields<Fields>, node: Node): void {
-    if (node.h0 !== null) {
-      return;
-    }
-
-    this.hashTreeRootInto(value, this.temporaryRoot, 0);
-    byteArrayIntoHashObject(this.temporaryRoot, 0, node);
   }
 }

--- a/packages/ssz/src/view/containerNodeStruct.ts
+++ b/packages/ssz/src/view/containerNodeStruct.ts
@@ -60,7 +60,7 @@ export function getContainerTreeViewClass<Fields extends Record<string, Type<unk
 
           // TODO: Should this check for valid field name? Benchmark the cost
           newNodeValue[fieldName] = value as ValueOf<Fields[keyof Fields]>;
-          this.tree.rootNode = new BranchNodeStruct(node["valueToNode"], node["hashTreeRootInto"], newNodeValue);
+          this.tree.rootNode = new BranchNodeStruct(node["valueToNode"], newNodeValue);
         },
       });
     }
@@ -86,7 +86,7 @@ export function getContainerTreeViewClass<Fields extends Record<string, Type<unk
 
           // TODO: Should this check for valid field name? Benchmark the cost
           newNodeValue[fieldName] = fieldType.toValueFromView(view) as ValueOf<Fields[keyof Fields]>;
-          this.tree.rootNode = new BranchNodeStruct(node["valueToNode"], node["hashTreeRootInto"], newNodeValue);
+          this.tree.rootNode = new BranchNodeStruct(node["valueToNode"], newNodeValue);
         },
       });
     }

--- a/packages/ssz/test/perf/eth2/beaconState.test.ts
+++ b/packages/ssz/test/perf/eth2/beaconState.test.ts
@@ -6,9 +6,9 @@ import {preset} from "../../lodestarTypes/params";
 const {SLOTS_PER_HISTORICAL_ROOT, EPOCHS_PER_ETH1_VOTING_PERIOD, SLOTS_PER_EPOCH} = preset;
 
 const vc = 200_000;
-const numModified = vc / 20;
+const numModified = vc / 2;
 // every we increase vc, need to change this value from "recursive hash" test
-const expectedRoot = "0x759d635af161ac1e4f4af11aa7721fd4996253af50f8a81e5003bbb4cbcaae42";
+const expectedRoot = "0xb0780ec0d44bff1ae8a351e98e37a9d8c3e28edb38c9d5a6312656e0cba915d9";
 
 /**
  * This simulates a BeaconState being modified after an epoch transition in lodestar
@@ -28,7 +28,7 @@ describe(`BeaconState ViewDU partially modified tree vc=${vc} numModified=${numM
     fn: (state: CompositeViewDU<typeof BeaconState>) => {
       state.hashTreeRoot();
       if (toHexString(state.node.root) !== expectedRoot) {
-        throw new Error("hashTreeRoot does not match expectedRoot");
+        throw new Error(`hashTreeRoot ${toHexString(state.node.root)} does not match expectedRoot ${expectedRoot}`);
       }
     },
   });
@@ -63,7 +63,7 @@ describe(`BeaconState ViewDU partially modified tree vc=${vc} numModified=${numM
     fn: (state: CompositeViewDU<typeof BeaconState>) => {
       // commit() step is inside hashTreeRoot(), reuse HashComputationGroup
       if (toHexString(state.batchHashTreeRoot(hc)) !== expectedRoot) {
-        throw new Error("batchHashTreeRoot does not match expectedRoot");
+        throw new Error(`batchHashTreeRoot ${toHexString(state.batchHashTreeRoot(hc))} does not match expectedRoot ${expectedRoot}`);
       }
       state.batchHashTreeRoot(hc);
     },


### PR DESCRIPTION
**Motivation**

Don't want to modify `hashTreeRoot()` in any ways

**Description**

- ListValidatorTreeViewDU: return `super.commit()` if it's from `hashTreeRoot()`
- Revert `BranchNodeStruct` because we compute and apply validator roots in ListValidatorTreeViewDU for `batchHashTreeRoot()` flow
- Update to the original benchmark to make sure there is no performance regression

```
 BeaconState ViewDU partially modified tree vc=200000 numModified=100000
    ✓ BeaconState ViewDU batchHashTreeRoot vc=200000                      7.316355 ops/s    136.6801 ms/op        -         85 runs   20.4 s
    ✓ BeaconState ViewDU batchHashTreeRoot - commit step vc=200000        8.522365 ops/s    117.3383 ms/op        -        101 runs   20.3 s
    ✓ BeaconState ViewDU batchHashTreeRoot - hash step vc=200000          38.30311 ops/s    26.10754 ms/op        -         76 runs   20.3 s
    ✓ BeaconState ViewDU hashTreeRoot() vc=200000                         2.260320 ops/s    442.4152 ms/op        -         39 runs   20.7 s
    ✓ BeaconState ViewDU hashTreeRoot - commit step vc=200000             25.73512 ops/s    38.85740 ms/op        -        165 runs   20.2 s
    ✓ BeaconState ViewDU hashTreeRoot - validator tree creation vc=100    7.122690 ops/s    140.3964 ms/op        -         82 runs   20.9 s

```

this is the same to https://hackmd.io/zj9N5RIqQfCqYz8Y1Xc_hA
