### PR TITLE
fix: handle unmodified validators

### DIFF
--- a/packages/ssz/test/lodestarTypes/phase0/viewDU/listValidator.ts
+++ b/packages/ssz/test/lodestarTypes/phase0/viewDU/listValidator.ts
@@ -40,6 +40,11 @@ for (let i = 0; i < PARALLEL_FACTOR; i++) {
 }
 const validatorRoot = new Uint8Array(32);
 
+/**
+ * Similar to ListCompositeTreeViewDU with some differences:
+ * - if called without params, it's from hashTreeRoot() api call, no need to compute root
+ * - otherwise it's from batchHashTreeRoot() call, compute validator roots in batch
+ */
 export class ListValidatorTreeViewDU extends ListCompositeTreeViewDU<ValidatorNodeStructType> {
   constructor(
     readonly type: ListCompositeType<ValidatorNodeStructType>,
@@ -69,8 +74,18 @@ export class ListValidatorTreeViewDU extends ListCompositeTreeViewDU<ValidatorNo
       number,
       ContainerNodeStructTreeViewDU<typeof ValidatorType>
     >;
-    const indicesChanged = Array.from(this.viewsChanged.keys()).sort((a, b) => a - b);
-    const endBatch = indicesChanged.length - (indicesChanged.length % PARALLEL_FACTOR);
+
+    const indicesChanged: number[] = [];
+    for (const [index, viewChanged] of viewsChanged) {
+      // should not have any params here in order not to compute root
+      viewChanged.commit();
+      // `validators.get(i)` was called but it may not modify any property, do not need to compute root
+      if (viewChanged.node.h0 === null) {
+        indicesChanged.push(index);
+      }
+    }
+    const sortedIndicesChanged = indicesChanged.sort((a, b) => a - b);
+    const endBatch = sortedIndicesChanged.length - (sortedIndicesChanged.length % PARALLEL_FACTOR);
     // nodesChanged is sorted by index
     const nodesChanged: {index: number; node: Node}[] = [];
     // commit every 16 validators in batch
@@ -80,7 +95,7 @@ export class ListValidatorTreeViewDU extends ListCompositeTreeViewDU<ValidatorNo
         batchLevel4Bytes.fill(0);
       }
       const indexInBatch = i % PARALLEL_FACTOR;
-      const viewIndex = indicesChanged[i];
+      const viewIndex = sortedIndicesChanged[i];
       const viewChanged = viewsChanged.get(viewIndex);
       if (viewChanged) {
         validatorToChunkBytes(level3ByteViewsArr[indexInBatch], level4BytesArr[indexInBatch], viewChanged.value);
@@ -96,12 +111,10 @@ export class ListValidatorTreeViewDU extends ListCompositeTreeViewDU<ValidatorNo
         digestNLevel(batchLevel3Bytes, 3);
         // commit all validators in this batch
         for (let j = PARALLEL_FACTOR - 1; j >= 0; j--) {
-          const viewIndex = indicesChanged[i - j];
+          const viewIndex = sortedIndicesChanged[i - j];
           const indexInBatch = (i - j) % PARALLEL_FACTOR;
           const viewChanged = viewsChanged.get(viewIndex);
           if (viewChanged) {
-            // should not have any params here in order not to compute root
-            viewChanged.commit();
             const branchNodeStruct = viewChanged.node;
             byteArrayIntoHashObject(validatorRoots[indexInBatch], 0, branchNodeStruct);
             nodesChanged.push({index: viewIndex, node: viewChanged.node});
@@ -114,12 +127,10 @@ export class ListValidatorTreeViewDU extends ListCompositeTreeViewDU<ValidatorNo
 
     // commit the remaining validators, we can do in batch too but don't want to create new Uint8Array views
     // it's not much different to commit one by one
-    for (let i = endBatch; i < indicesChanged.length; i++) {
-      const viewIndex = indicesChanged[i];
+    for (let i = endBatch; i < sortedIndicesChanged.length; i++) {
+      const viewIndex = sortedIndicesChanged[i];
       const viewChanged = viewsChanged.get(viewIndex);
       if (viewChanged) {
-        // commit
-        viewChanged.commit();
         // compute root for each validator
         viewChanged.type.hashTreeRootInto(viewChanged.value, validatorRoot, 0);
         byteArrayIntoHashObject(validatorRoot, 0, viewChanged.node);

--- a/packages/ssz/test/lodestarTypes/phase0/viewDU/listValidator.ts
+++ b/packages/ssz/test/lodestarTypes/phase0/viewDU/listValidator.ts
@@ -84,6 +84,8 @@ export class ListValidatorTreeViewDU extends ListCompositeTreeViewDU<ValidatorNo
         indicesChanged.push(index);
       }
     }
+
+    // these validators don't have roots, we compute roots in batch
     const sortedIndicesChanged = indicesChanged.sort((a, b) => a - b);
     const endBatch = sortedIndicesChanged.length - (sortedIndicesChanged.length % PARALLEL_FACTOR);
     // nodesChanged is sorted by index

--- a/packages/ssz/test/perf/eth2/beaconState.test.ts
+++ b/packages/ssz/test/perf/eth2/beaconState.test.ts
@@ -118,7 +118,12 @@ function createPartiallyModifiedDenebState(): CompositeViewDU<typeof BeaconState
   for (let i = 0; i < numModified; i++) {
     state.validators.get(i).effectiveBalance += 1e9;
   }
+  // all balances are modified as in epoch transition
   state.balances = BeaconState.fields.balances.toViewDU(Array.from({length: vc}, () => 32e9));
+  // remaining validators are accessed with no modification
+  for (let i = numModified; i < vc; i++) {
+    state.validators.get(i);
+  }
 
   state.eth1Data = BeaconState.fields.eth1Data.toViewDU({
     depositRoot: Buffer.alloc(32, 0x02),


### PR DESCRIPTION
**Motivation**

Some `validators.get(i)` may call and it's tracked in `viewsChanged`, right now we compute its root in batch while we should not

**Description**

- commit all validators first
- filter out those have roots already
- update benchmark to test it

**Benchmark**
with half of `validators.get()` called without modifying anything
- current
```
BeaconState ViewDU partially modified tree vc=200000 numModified=100000
    ✓ BeaconState ViewDU batchHashTreeRoot vc=200000                      3.311916 ops/s    301.9400 ms/op        -         40 runs   20.7 s
    ✓ BeaconState ViewDU batchHashTreeRoot - commit step vc=200000        3.735825 ops/s    267.6785 ms/op        -         50 runs   20.5 s
    ✓ BeaconState ViewDU batchHashTreeRoot - hash step vc=200000          21.26964 ops/s    47.01538 ms/op        -         44 runs   25.0 s
    ✓ BeaconState ViewDU hashTreeRoot() vc=200000                         2.024038 ops/s    494.0618 ms/op        -         34 runs   22.1 s
    ✓ BeaconState ViewDU hashTreeRoot - commit step vc=200000             15.08328 ops/s    66.29857 ms/op        -        101 runs   21.8 s
    ✓ BeaconState ViewDU hashTreeRoot - validator tree creation vc=100    6.294561 ops/s    158.8673 ms/op        -         57 runs   20.4 s
```

- this PR
```
 BeaconState ViewDU partially modified tree vc=200000 numModified=100000
    ✓ BeaconState ViewDU batchHashTreeRoot vc=200000                      5.816562 ops/s    171.9229 ms/op        -         57 runs   20.5 s
    ✓ BeaconState ViewDU batchHashTreeRoot - commit step vc=200000        6.362287 ops/s    157.1762 ms/op        -         67 runs   20.3 s
    ✓ BeaconState ViewDU batchHashTreeRoot - hash step vc=200000          36.34095 ops/s    27.51717 ms/op        -         52 runs   20.7 s
    ✓ BeaconState ViewDU hashTreeRoot() vc=200000                         2.066677 ops/s    483.8685 ms/op        -         33 runs   20.7 s
    ✓ BeaconState ViewDU hashTreeRoot - commit step vc=200000             16.28455 ops/s    61.40789 ms/op        -        100 runs   20.2 s
    ✓ BeaconState ViewDU hashTreeRoot - validator tree creation vc=100    6.153062 ops/s    162.5207 ms/op        -         57 runs   20.3 s


```