### PR TITLE
fix: add homepage/repo etc to as-sha256 package.json

### DIFF
--- a/packages/as-sha256/package.json
+++ b/packages/as-sha256/package.json
@@ -5,12 +5,12 @@
   "author": "ChainSafe Systems",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/ChainSafe/as-sha256/issues"
+    "url": "https://github.com/ChainSafe/ssz/issues"
   },
-  "homepage": "https://github.com/ChainSafe/as-sha256#readme",
+  "homepage": "https://github.com/ChainSafe/ssz/tree/master/packages/as-sha256/#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chainsafe/as-sha256.git"
+    "url": "git+https://github.com/chainsafe/ssz.git"
   },
   "main": "lib/index.js",
   "typesVersions": {


### PR DESCRIPTION
**Motivation**

The npm page for this module has out of date links.

**Description**

The [npm page](https://www.npmjs.com/package/@chainsafe/as-sha256) for this module has links to a long-archived repo so update the bugs/issues/etc links in the manifest to give a bit of traceability.

**Steps to test or reproduce**

n/a