### PR TITLE
feat: new api to upgrade a tree to new type

### DIFF
--- a/packages/ssz/src/index.ts
+++ b/packages/ssz/src/index.ts
@@ -39,3 +39,4 @@ export {BitArray, getUint8ByteToBitBooleanArray} from "./value/bitArray";
 export {fromHexString, toHexString, byteArrayEquals} from "./util/byteArray";
 export {Snapshot} from "./util/types";
 export {hash64, symbolCachedPermanentRoot} from "./util/merkleize";
+export {upgradeToNewType} from "./util/upgrade";

--- a/packages/ssz/src/util/upgrade.ts
+++ b/packages/ssz/src/util/upgrade.ts
@@ -1,0 +1,25 @@
+import {BranchNode, Node, zeroNode} from "@chainsafe/persistent-merkle-tree";
+import {ContainerType} from "../type/container";
+
+/** Upgrade the current View/ViewDU to a root node of new type */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function upgradeToNewType(rootNode: Node, oldType: ContainerType<any>, newType: ContainerType<any>): Node {
+  const newFieldsCount = newType.fieldsEntries.length;
+  const currentFieldsCount = oldType.fieldsEntries.length;
+  if (newFieldsCount < currentFieldsCount) {
+    throw Error(`Cannot convert to a type with fewer fields: ${newFieldsCount} < ${currentFieldsCount}`);
+  }
+
+  if (newType.depth === oldType.depth) {
+    // no need to grow the tree
+    return rootNode;
+  }
+
+  // grow the tree
+  let node = rootNode;
+  for (let depth = oldType.depth; depth < newType.depth; depth++) {
+    node = new BranchNode(node, zeroNode(depth));
+  }
+
+  return node;
+}


### PR DESCRIPTION
**Motivation**

Cannot reuse an existing tree when upgrading to new type, see https://github.com/ChainSafe/lodestar/issues/6811

**Description**

- new "upgradeToNewType" api as discussed [Lodestar#6811](https://github.com/ChainSafe/lodestar/issues/6811#issuecomment-2129571320)

- usage:

```typescript
  const newType = new ContainerType(newFields);
  const newView = newType.getView(new Tree(view.upgradeToNewType(newType)));
  const newViewDU = newType.getViewDU(viewDU.upgradeToNewType(newType));
```
