### PR TITLE
fix: lerna command for publishing packages

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           echo npmAuthToken: "$NODE_AUTH_TOKEN" >> ./.yarnrc.yml
           
-      - run: yarn lerna run -v --ignore root --ignore simpleserialize.com --no-private npm publish --tolerate-republish --access public
+      - run: yarn lerna exec --ignore root --ignore simpleserialize.com --no-private "npm publish --tolerate-republish --access public"
         if: ${{ steps.release.outputs.releases_created }}
 
 


### PR DESCRIPTION
**Motivation**

Fix the lerna command for publishing the packages. 

**Description**

During the downgrading of the `yarn` https://github.com/ChainSafe/ssz/pull/374 the command was broken. 

Closes https://github.com/ChainSafe/ssz/issues/396

**Steps to test or reproduce**

- Merge the PR and run the CD pipeline