### PR TITLE
fix: update the publish script to use only npm options

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           echo npmAuthToken: "$NODE_AUTH_TOKEN" >> ./.yarnrc.yml
           
-      - run: yarn lerna exec --ignore root --ignore simpleserialize.com --no-private "npm publish --tolerate-republish --access public"
+      - run: yarn lerna exec --ignore root --ignore simpleserialize.com --no-private "npm publish --access public"
         if: ${{ steps.release.outputs.releases_created }}
 
 


### PR DESCRIPTION
**Motivation**

Fix the publish script for the workflow. 

**Description**

In previous https://github.com/ChainSafe/ssz/pull/408 I left out `--tolerate-republish` as it was used for a very long time. 

https://github.com/ChainSafe/ssz/blob/18baeaa7b47fcda67bdba8380cbf430827e1eb3d/.github/workflows/cd.yml#L58

But actual issue was mixing up `npm publish` with the `yarn npm publish`. So eventually `yarn` had it's own set of npm commands. 🥹 

https://yarnpkg.com/cli/npm/publish

**Steps to test or reproduce**

- Run all tests and publish a newer version later on.  