### PR TITLE
feat: getAll() apis to support output parameters

### DIFF
--- a/packages/ssz/src/view/arrayBasic.ts
+++ b/packages/ssz/src/view/arrayBasic.ts
@@ -87,14 +87,18 @@ export class ArrayBasicTreeView<ElementType extends BasicType<unknown>> extends 
 
   /**
    * Get all values of this array as Basic element type values, from index zero to `this.length - 1`
+   * @param values optional output parameter, if is provided it must be an array of the same length as this array
    */
-  getAll(): ValueOf<ElementType>[] {
+  getAll(values?: ValueOf<ElementType>[]): ValueOf<ElementType>[] {
+    if (values && values.length !== this.length) {
+      throw Error(`Expected ${this.length} values, got ${values.length}`);
+    }
     const length = this.length;
     const chunksNode = this.type.tree_getChunksNode(this.node);
     const chunkCount = Math.ceil(length / this.type.itemsPerChunk);
     const leafNodes = getNodesAtDepth(chunksNode, this.type.chunkDepth, 0, chunkCount) as LeafNode[];
 
-    const values = new Array<ValueOf<ElementType>>(length);
+    values = values ?? new Array<ValueOf<ElementType>>(length);
     const itemsPerChunk = this.type.itemsPerChunk; // Prevent many access in for loop below
     const lenFullNodes = Math.floor(length / itemsPerChunk);
     const remainder = length % itemsPerChunk;

--- a/packages/ssz/src/view/arrayComposite.ts
+++ b/packages/ssz/src/view/arrayComposite.ts
@@ -73,12 +73,16 @@ export class ArrayCompositeTreeView<
    * Returns an array of views of all elements in the array, from index zero to `this.length - 1`.
    * The returned views don't have a parent hook to this View's Tree, so changes in the returned views won't be
    * propagated upwards. To get linked element Views use `this.get()`
+   * @param views optional output parameter, if is provided it must be an array of the same length as this array
    */
-  getAllReadonly(): CompositeView<ElementType>[] {
+  getAllReadonly(views?: CompositeView<ElementType>[]): CompositeView<ElementType>[] {
+    if (views && views.length !== this.length) {
+      throw Error(`Expected ${this.length} views, got ${views.length}`);
+    }
     const length = this.length;
     const chunksNode = this.type.tree_getChunksNode(this.node);
     const nodes = getNodesAtDepth(chunksNode, this.type.chunkDepth, 0, length);
-    const views = new Array<CompositeView<ElementType>>(length);
+    views = views ?? new Array<CompositeView<ElementType>>(length);
     for (let i = 0; i < length; i++) {
       // TODO: Optimize
       views[i] = this.type.elementType.getView(new Tree(nodes[i]));
@@ -90,12 +94,16 @@ export class ArrayCompositeTreeView<
    * Returns an array of values of all elements in the array, from index zero to `this.length - 1`.
    * The returned values are not Views so any changes won't be propagated upwards.
    * To get linked element Views use `this.get()`
+   * @param values optional output parameter, if is provided it must be an array of the same length as this array
    */
-  getAllReadonlyValues(): ValueOf<ElementType>[] {
+  getAllReadonlyValues(values?: ValueOf<ElementType>[]): ValueOf<ElementType>[] {
+    if (values && values.length !== this.length) {
+      throw Error(`Expected ${this.length} values, got ${values.length}`);
+    }
     const length = this.length;
     const chunksNode = this.type.tree_getChunksNode(this.node);
     const nodes = getNodesAtDepth(chunksNode, this.type.chunkDepth, 0, length);
-    const values = new Array<ValueOf<ElementType>>(length);
+    values = values ?? new Array<ValueOf<ElementType>>(length);
     for (let i = 0; i < length; i++) {
       values[i] = this.type.elementType.tree_toValue(nodes[i]);
     }

--- a/packages/ssz/src/viewDU/arrayBasic.ts
+++ b/packages/ssz/src/viewDU/arrayBasic.ts
@@ -109,8 +109,12 @@ export class ArrayBasicTreeViewDU<ElementType extends BasicType<unknown>> extend
 
   /**
    * Get all values of this array as Basic element type values, from index zero to `this.length - 1`
+   * @param values optional output parameter, if is provided it must be an array of the same length as this array
    */
-  getAll(): ValueOf<ElementType>[] {
+  getAll(values?: ValueOf<ElementType>[]): ValueOf<ElementType>[] {
+    if (values && values.length !== this._length) {
+      throw Error(`Expected ${this._length} values, got ${values.length}`);
+    }
     if (!this.nodesPopulated) {
       const nodesPrev = this.nodes;
       const chunksNode = this.type.tree_getChunksNode(this.node);
@@ -125,7 +129,7 @@ export class ArrayBasicTreeViewDU<ElementType extends BasicType<unknown>> extend
       this.nodesPopulated = true;
     }
 
-    const values = new Array<ValueOf<ElementType>>(this._length);
+    values = values ?? new Array<ValueOf<ElementType>>(this._length);
     const itemsPerChunk = this.type.itemsPerChunk; // Prevent many access in for loop below
     const lenFullNodes = Math.floor(this._length / itemsPerChunk);
     const remainder = this._length % itemsPerChunk;

--- a/packages/ssz/src/viewDU/container.ts
+++ b/packages/ssz/src/viewDU/container.ts
@@ -101,9 +101,12 @@ export class BasicContainerTreeViewDU<Fields extends Record<string, Type<unknown
     for (const [index, view] of this.viewsChanged) {
       const fieldType = this.type.fieldsEntries[index].fieldType as unknown as CompositeTypeAny;
       const node = fieldType.commitViewDU(view, offsetView, byLevelView);
-      // Set new node in nodes array to ensure data represented in the tree and fast nodes access is equal
-      this.nodes[index] = node;
-      nodesChanged.push({index, node});
+      // there's a chance the view is not changed, no need to rebind nodes in that case
+      if (this.nodes[index] !== node) {
+        // Set new node in nodes array to ensure data represented in the tree and fast nodes access is equal
+        this.nodes[index] = node;
+        nodesChanged.push({index, node});
+      }
 
       // Cache the view's caches to preserve it's data after 'this.viewsChanged.clear()'
       const cache = fieldType.cacheOfViewDU(view);

--- a/packages/ssz/test/unit/byType/listComposite/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listComposite/tree.test.ts
@@ -337,3 +337,115 @@ describe("ListCompositeType batchHashTreeRoot", () => {
     });
   }
 });
+
+describe("ListCompositeType batchHashTreeRoot", () => {
+  const value = [
+    {a: 1, b: 2},
+    {a: 3, b: 4},
+  ];
+  const containerStructUintsType = new ContainerNodeStructType(
+    {a: uint64NumInfType, b: uint64NumInfType},
+    {typeName: "ContainerNodeStruct(uint64)"}
+  );
+  const listOfContainersType2 = new ListCompositeType(containerStructUintsType, 4, {
+    typeName: "ListCompositeType(ContainerNodeStructType)",
+  });
+
+  for (const list of [listOfContainersType, listOfContainersType2]) {
+    const typeName = list.typeName;
+    const expectedRoot = list.toView(value).hashTreeRoot();
+
+    it(`${typeName} - fresh ViewDU`, () => {
+      expect(listOfContainersType.toViewDU(value).batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+    });
+
+    it(`${typeName} - push then batchHashTreeRoot()`, () => {
+      const viewDU = listOfContainersType.defaultViewDU();
+      viewDU.push(containerUintsType.toViewDU({a: 1, b: 2}));
+      viewDU.push(containerUintsType.toViewDU({a: 3, b: 4}));
+      expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+      // assign again, commit() then batchHashTreeRoot()
+      viewDU.set(0, containerUintsType.toViewDU({a: 1, b: 2}));
+      viewDU.set(1, containerUintsType.toViewDU({a: 3, b: 4}));
+      viewDU.commit();
+      expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+    });
+
+    it(`${typeName} - full hash then modify full non-hashed child element`, () => {
+      const viewDU = listOfContainersType.defaultViewDU();
+      viewDU.push(containerUintsType.toViewDU({a: 1, b: 2}));
+      viewDU.push(containerUintsType.toViewDU({a: 33, b: 44}));
+      viewDU.batchHashTreeRoot();
+      viewDU.set(1, containerUintsType.toViewDU({a: 3, b: 4}));
+      expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+      // assign the same value again, commit() then batchHashTreeRoot()
+      viewDU.set(1, containerUintsType.toViewDU({a: 3, b: 4}));
+      viewDU.commit();
+      expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+    });
+
+    it(`${typeName} - full hash then modify partially hashed child element`, () => {
+      const viewDU = listOfContainersType.defaultViewDU();
+      viewDU.push(containerUintsType.toViewDU({a: 1, b: 2}));
+      viewDU.push(containerUintsType.toViewDU({a: 33, b: 44}));
+      viewDU.batchHashTreeRoot();
+      const item1 = containerUintsType.toViewDU({a: 3, b: 44});
+      item1.batchHashTreeRoot();
+      item1.b = 4;
+      viewDU.set(1, item1);
+      expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+      // assign the same value again, commit() then batchHashTreeRoot()
+      const item2 = viewDU.get(1);
+      item2.a = 3;
+      item2.b = 4;
+      viewDU.commit();
+      expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+    });
+
+    it(`${typeName} - full hash then modify full hashed child element`, () => {
+      const viewDU = listOfContainersType.defaultViewDU();
+      viewDU.push(containerUintsType.toViewDU({a: 1, b: 2}));
+      viewDU.push(containerUintsType.toViewDU({a: 33, b: 44}));
+      viewDU.batchHashTreeRoot();
+      const item1 = containerUintsType.toViewDU({a: 3, b: 4});
+      item1.batchHashTreeRoot();
+      viewDU.set(1, item1);
+      expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+      // assign the same value again, commit() then batchHashTreeRoot()
+      const newItem = containerUintsType.toViewDU({a: 3, b: 4});
+      viewDU.set(1, newItem);
+      viewDU.commit();
+      expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+    });
+
+    it(`${typeName} - full hash then modify partial child element`, () => {
+      const viewDU = listOfContainersType.defaultViewDU();
+      viewDU.push(containerUintsType.toViewDU({a: 1, b: 2}));
+      viewDU.push(containerUintsType.toViewDU({a: 33, b: 44}));
+      viewDU.batchHashTreeRoot();
+      viewDU.get(1).a = 3;
+      viewDU.get(1).b = 4;
+      expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+
+      // assign the same value again, commit() then batchHashTreeRoot()
+      viewDU.get(1).a = 3;
+      viewDU.get(1).b = 4;
+      viewDU.commit();
+      expect(viewDU.batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+    });
+
+    // similar to a fresh ViewDU but it's good to test
+    it(`${typeName} - sliceTo()`, () => {
+      const viewDU = listOfContainersType.defaultViewDU();
+      viewDU.push(containerUintsType.toViewDU({a: 1, b: 2}));
+      viewDU.push(containerUintsType.toViewDU({a: 3, b: 4}));
+      viewDU.push(containerUintsType.toViewDU({a: 5, b: 6}));
+      viewDU.batchHashTreeRoot();
+      expect(viewDU.sliceTo(1).batchHashTreeRoot()).to.be.deep.equal(expectedRoot);
+    });
+  }
+});

--- a/packages/ssz/test/unit/unchangedViewDUs.test.ts
+++ b/packages/ssz/test/unit/unchangedViewDUs.test.ts
@@ -5,7 +5,7 @@ import {getRandomState} from "../utils/generateEth2Objs";
 describe("Unchanged ViewDUs", () => {
   const state = sszAltair.BeaconState.toViewDU(getRandomState(100));
 
-  it.skip("should not recompute batchHashTreeRoot() when no fields is changed", () => {
+  it("should not recompute batchHashTreeRoot() when no fields is changed", () => {
     const root = state.batchHashTreeRoot();
     // this causes viewsChanged inside BeaconState container
     state.validators.length;


### PR DESCRIPTION
**Motivation**

- right now at lodestar, it has to allocate new array to loop through all elements and it cost memory allocation
- for readonly operation, ssz still have to recompute root, see #379

**Description**

- improve getAll() apis by supporting output parameters
- add `forEach()` apis
- if a ViewDU does not change root node after a commit(), its parent should discard the change and so that it does not have to recompute root

Closes #379
