### PR TITLE
feat: merkleize block array

### DIFF
--- a/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
+++ b/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
@@ -20,8 +20,8 @@ export const hasher: Hasher = {
   merkleizeBlocksBytes(blocksBytes: Uint8Array, padFor: number, output: Uint8Array, offset: number): void {
     return doMerkleizeBlocksBytes(blocksBytes, padFor, output, offset, hashInto);
   },
-  merkleizeBlockArray(blocks, padFor, output, offset) {
-    return doMerkleizeBlockArray(blocks, padFor, output, offset, hashInto, buffer);
+  merkleizeBlockArray(blocks, blockLimit, padFor, output, offset) {
+    return doMerkleizeBlockArray(blocks, blockLimit, padFor, output, offset, hashInto, buffer);
   },
   digestNLevel(data: Uint8Array, nLevel: number): Uint8Array {
     return doDigestNLevel(data, nLevel, hashInto);

--- a/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
+++ b/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
@@ -8,7 +8,10 @@ import {
 import type {Hasher} from "./types";
 import {Node} from "../node";
 import type {HashComputationLevel} from "../hashComputation";
-import {doDigestNLevel, doMerkleizeBlocksBytes} from "./util";
+import {BLOCK_SIZE, doDigestNLevel, doMerkleizeBlockArray, doMerkleizeBlocksBytes} from "./util";
+
+/** hashInto() function of as-sha256 loop through every 256 bytes */
+const buffer = new Uint8Array(4 * BLOCK_SIZE);
 
 export const hasher: Hasher = {
   name: "as-sha256",
@@ -16,6 +19,9 @@ export const hasher: Hasher = {
   digest64HashObjects: digest64HashObjectsInto,
   merkleizeBlocksBytes(blocksBytes: Uint8Array, padFor: number, output: Uint8Array, offset: number): void {
     return doMerkleizeBlocksBytes(blocksBytes, padFor, output, offset, hashInto);
+  },
+  merkleizeBlockArray(blocks, padFor, output, offset) {
+    return doMerkleizeBlockArray(blocks, padFor, output, offset, hashInto, buffer);
   },
   digestNLevel(data: Uint8Array, nLevel: number): Uint8Array {
     return doDigestNLevel(data, nLevel, hashInto);

--- a/packages/persistent-merkle-tree/src/hasher/hashtree.ts
+++ b/packages/persistent-merkle-tree/src/hasher/hashtree.ts
@@ -3,7 +3,7 @@ import {Hasher, HashObject} from "./types";
 import {Node} from "../node";
 import type {HashComputationLevel} from "../hashComputation";
 import {byteArrayIntoHashObject} from "@chainsafe/as-sha256/lib/hashObject";
-import {doDigestNLevel, doMerkleizeBlocksBytes} from "./util";
+import {doDigestNLevel, doMerkleizeBlockArray, doMerkleizeBlocksBytes} from "./util";
 
 /**
  * Best SIMD implementation is in 512 bits = 64 bytes
@@ -42,6 +42,9 @@ export const hasher: Hasher = {
   },
   merkleizeBlocksBytes(blocksBytes: Uint8Array, padFor: number, output: Uint8Array, offset: number): void {
     return doMerkleizeBlocksBytes(blocksBytes, padFor, output, offset, hashInto);
+  },
+  merkleizeBlockArray(blocks, padFor, output, offset) {
+    return doMerkleizeBlockArray(blocks, padFor, output, offset, hashInto, uint8Input);
   },
   digestNLevel(data: Uint8Array, nLevel: number): Uint8Array {
     return doDigestNLevel(data, nLevel, hashInto);

--- a/packages/persistent-merkle-tree/src/hasher/hashtree.ts
+++ b/packages/persistent-merkle-tree/src/hasher/hashtree.ts
@@ -43,8 +43,8 @@ export const hasher: Hasher = {
   merkleizeBlocksBytes(blocksBytes: Uint8Array, padFor: number, output: Uint8Array, offset: number): void {
     return doMerkleizeBlocksBytes(blocksBytes, padFor, output, offset, hashInto);
   },
-  merkleizeBlockArray(blocks, padFor, output, offset) {
-    return doMerkleizeBlockArray(blocks, padFor, output, offset, hashInto, uint8Input);
+  merkleizeBlockArray(blocks, blockLimit, padFor, output, offset) {
+    return doMerkleizeBlockArray(blocks, blockLimit, padFor, output, offset, hashInto, uint8Input);
   },
   digestNLevel(data: Uint8Array, nLevel: number): Uint8Array {
     return doDigestNLevel(data, nLevel, hashInto);

--- a/packages/persistent-merkle-tree/src/hasher/index.ts
+++ b/packages/persistent-merkle-tree/src/hasher/index.ts
@@ -36,6 +36,10 @@ export function merkleizeBlocksBytes(
   hasher.merkleizeBlocksBytes(blocksBytes, padFor, output, offset);
 }
 
+export function merkleizeBlockArray(blocks: Uint8Array[], padFor: number, output: Uint8Array, offset: number): void {
+  hasher.merkleizeBlockArray(blocks, padFor, output, offset);
+}
+
 export function executeHashComputations(hashComputations: HashComputationLevel[]): void {
   hasher.executeHashComputations(hashComputations);
 }

--- a/packages/persistent-merkle-tree/src/hasher/index.ts
+++ b/packages/persistent-merkle-tree/src/hasher/index.ts
@@ -36,8 +36,14 @@ export function merkleizeBlocksBytes(
   hasher.merkleizeBlocksBytes(blocksBytes, padFor, output, offset);
 }
 
-export function merkleizeBlockArray(blocks: Uint8Array[], padFor: number, output: Uint8Array, offset: number): void {
-  hasher.merkleizeBlockArray(blocks, padFor, output, offset);
+export function merkleizeBlockArray(
+  blocks: Uint8Array[],
+  blockLimit: number,
+  padFor: number,
+  output: Uint8Array,
+  offset: number
+): void {
+  hasher.merkleizeBlockArray(blocks, blockLimit, padFor, output, offset);
 }
 
 export function executeHashComputations(hashComputations: HashComputationLevel[]): void {

--- a/packages/persistent-merkle-tree/src/hasher/noble.ts
+++ b/packages/persistent-merkle-tree/src/hasher/noble.ts
@@ -40,8 +40,8 @@ export const hasher: Hasher = {
   merkleizeBlocksBytes(blocksBytes: Uint8Array, padFor: number, output: Uint8Array, offset: number): void {
     return doMerkleizeBlocksBytes(blocksBytes, padFor, output, offset, hashInto);
   },
-  merkleizeBlockArray(blocks, padFor, output, offset) {
-    return doMerkleizeBlockArray(blocks, padFor, output, offset, hashInto, buffer);
+  merkleizeBlockArray(blocks, blockLimit, padFor, output, offset) {
+    return doMerkleizeBlockArray(blocks, blockLimit, padFor, output, offset, hashInto, buffer);
   },
   digestNLevel(data: Uint8Array, nLevel: number): Uint8Array {
     return doDigestNLevel(data, nLevel, hashInto);

--- a/packages/persistent-merkle-tree/src/hasher/noble.ts
+++ b/packages/persistent-merkle-tree/src/hasher/noble.ts
@@ -1,7 +1,13 @@
 import {sha256} from "@noble/hashes/sha256";
 import {digest64HashObjects, byteArrayIntoHashObject} from "@chainsafe/as-sha256";
 import type {Hasher} from "./types";
-import {doDigestNLevel, doMerkleizeBlocksBytes, hashObjectToUint8Array} from "./util";
+import {
+  BLOCK_SIZE,
+  doDigestNLevel,
+  doMerkleizeBlockArray,
+  doMerkleizeBlocksBytes,
+  hashObjectToUint8Array,
+} from "./util";
 
 const digest64 = (a: Uint8Array, b: Uint8Array): Uint8Array => sha256.create().update(a).update(b).digest();
 const hashInto = (input: Uint8Array, output: Uint8Array): void => {
@@ -22,6 +28,9 @@ const hashInto = (input: Uint8Array, output: Uint8Array): void => {
   }
 };
 
+/** should be multiple of 64, make it the same to as-sha256 */
+const buffer = new Uint8Array(4 * BLOCK_SIZE);
+
 export const hasher: Hasher = {
   name: "noble",
   digest64,
@@ -30,6 +39,9 @@ export const hasher: Hasher = {
   },
   merkleizeBlocksBytes(blocksBytes: Uint8Array, padFor: number, output: Uint8Array, offset: number): void {
     return doMerkleizeBlocksBytes(blocksBytes, padFor, output, offset, hashInto);
+  },
+  merkleizeBlockArray(blocks, padFor, output, offset) {
+    return doMerkleizeBlockArray(blocks, padFor, output, offset, hashInto, buffer);
   },
   digestNLevel(data: Uint8Array, nLevel: number): Uint8Array {
     return doDigestNLevel(data, nLevel, hashInto);

--- a/packages/persistent-merkle-tree/src/hasher/types.ts
+++ b/packages/persistent-merkle-tree/src/hasher/types.ts
@@ -21,6 +21,12 @@ export type Hasher = {
    */
   merkleizeBlocksBytes(blocksBytes: Uint8Array, padFor: number, output: Uint8Array, offset: number): void;
   /**
+   * Merkleize n SHA256 blocks, each is 64 bytes Uint8Array
+   * padFor is maxChunkCount, use it to compute layers to hash
+   * blocks are mutated after the function
+   */
+  merkleizeBlockArray(blocks: Uint8Array[], padFor: number, output: Uint8Array, offset: number): void;
+  /**
    * Hash multiple chunks (1 chunk = 32 bytes) at multiple levels
    * With nLevel = 3, hash multiple of 256 bytes, return multiple of 32 bytes.
    * The result is unsafe as it will be overwritten by the next call.

--- a/packages/persistent-merkle-tree/src/hasher/types.ts
+++ b/packages/persistent-merkle-tree/src/hasher/types.ts
@@ -25,7 +25,13 @@ export type Hasher = {
    * padFor is maxChunkCount, use it to compute layers to hash
    * blocks are mutated after the function
    */
-  merkleizeBlockArray(blocks: Uint8Array[], padFor: number, output: Uint8Array, offset: number): void;
+  merkleizeBlockArray(
+    blocks: Uint8Array[],
+    blockLimit: number,
+    padFor: number,
+    output: Uint8Array,
+    offset: number
+  ): void;
   /**
    * Hash multiple chunks (1 chunk = 32 bytes) at multiple levels
    * With nLevel = 3, hash multiple of 256 bytes, return multiple of 32 bytes.

--- a/packages/persistent-merkle-tree/src/hasher/util.ts
+++ b/packages/persistent-merkle-tree/src/hasher/util.ts
@@ -87,8 +87,8 @@ export function doMerkleizeBlockArray(
   hashInto: HashIntoFn,
   buffer: Uint8Array
 ): void {
-  if (padFor < 2) {
-    throw new Error(`Invalid padFor, expect to be at least 2, got ${padFor}`);
+  if (padFor < 1) {
+    throw new Error(`Invalid padFor, expect to be at least 1, got ${padFor}`);
   }
 
   const layerCount = Math.ceil(Math.log2(padFor));

--- a/packages/persistent-merkle-tree/src/hasher/util.ts
+++ b/packages/persistent-merkle-tree/src/hasher/util.ts
@@ -78,9 +78,11 @@ export function doMerkleizeBlocksBytes(
  * Merkleize multiple SHA256 blocks into ${output} at ${offset}
  * @param padFor is maxChunkCount, should be >= 2
  * @param blocks is unsafe because it's modified
+ * @param blockLimit number of blocks, should be <= blocks.length so that consumer can reuse memory
  */
 export function doMerkleizeBlockArray(
   blocks: Uint8Array[],
+  blockLimit: number,
   padFor: number,
   output: Uint8Array,
   offset: number,
@@ -89,6 +91,12 @@ export function doMerkleizeBlockArray(
 ): void {
   if (padFor < 1) {
     throw new Error(`Invalid padFor, expect to be at least 1, got ${padFor}`);
+  }
+
+  if (blockLimit > blocks.length) {
+    throw new Error(
+      `Invalid blockLimit, expect to be less than or equal blocks.length ${blocks.length}, got ${blockLimit}`
+    );
   }
 
   const layerCount = Math.ceil(Math.log2(padFor));
@@ -115,7 +123,8 @@ export function doMerkleizeBlockArray(
   let bufferIn = buffer;
   // hash into the same buffer
   let bufferOut = buffer.subarray(0, halfBatchSize * BLOCK_SIZE);
-  let blockCount = blocks.length;
+  // ignore remaining blocks
+  let blockCount = blockLimit;
   // hash into the same blocks to save memory allocation
   for (let layer = 0; layer < layerCount; layer++) {
     let outBlockIndex = 0;

--- a/packages/persistent-merkle-tree/src/hasher/util.ts
+++ b/packages/persistent-merkle-tree/src/hasher/util.ts
@@ -13,13 +13,15 @@ export function uint8ArrayToHashObject(byteArr: Uint8Array): HashObject {
 
 type HashIntoFn = (input: Uint8Array, output: Uint8Array) => void;
 
+/** a SHA256 block is 64 bytes */
+export const BLOCK_SIZE = 64;
+
 /**
- * A SHA256 block is 64 bytes
+ * Merkleize multiple SHA256 blocks in a single Uint8Array into ${output} at ${offset}
  *   - if padFor > 1 blocksBytes need to be multiple of 64 bytes.
  *   - if padFor = 1, blocksBytes need to be at least 32 bytes
  *   - if padFor = 0, throw error
  * blocksBytes is unsafe because it's modified
- * The Uint8Array(32) will be written to output at offset
  */
 export function doMerkleizeBlocksBytes(
   blocksBytes: Uint8Array,
@@ -43,7 +45,7 @@ export function doMerkleizeBlocksBytes(
   }
 
   // if padFor = 1, only need 32 bytes
-  if (padFor > 1 && blocksBytes.length % 64 !== 0) {
+  if (padFor > 1 && blocksBytes.length % BLOCK_SIZE !== 0) {
     throw new Error(
       `Invalid input length, expect to be multiple of 64 bytes, got ${blocksBytes.length}, padFor=${padFor}`
     );
@@ -52,16 +54,16 @@ export function doMerkleizeBlocksBytes(
   let inputLength = blocksBytes.length;
   let outputLength = Math.floor(inputLength / 2);
   let bufferIn = blocksBytes;
-  // hash into the same buffer
-  for (let i = 0; i < layerCount; i++) {
+  // hash into the same buffer to save memory allocation
+  for (let layer = 0; layer < layerCount; layer++) {
     const bufferOut = blocksBytes.subarray(0, outputLength);
     hashInto(bufferIn, bufferOut);
     const chunkCount = Math.floor(outputLength / 32);
-    if (chunkCount % 2 === 1 && i < layerCount - 1) {
+    if (chunkCount % 2 === 1 && layer < layerCount - 1) {
       // extend to 1 more chunk
       inputLength = outputLength + 32;
       bufferIn = blocksBytes.subarray(0, inputLength);
-      bufferIn.set(zeroHash(i + 1), outputLength);
+      bufferIn.set(zeroHash(layer + 1), outputLength);
     } else {
       bufferIn = bufferOut;
       inputLength = outputLength;
@@ -70,6 +72,106 @@ export function doMerkleizeBlocksBytes(
   }
 
   output.set(bufferIn.subarray(0, 32), offset);
+}
+
+/**
+ * Merkleize multiple SHA256 blocks into ${output} at ${offset}
+ * @param padFor is maxChunkCount, should be >= 2
+ * @param blocks is unsafe because it's modified
+ */
+export function doMerkleizeBlockArray(
+  blocks: Uint8Array[],
+  padFor: number,
+  output: Uint8Array,
+  offset: number,
+  hashInto: HashIntoFn,
+  buffer: Uint8Array
+): void {
+  if (padFor < 2) {
+    throw new Error(`Invalid padFor, expect to be at least 2, got ${padFor}`);
+  }
+
+  const layerCount = Math.ceil(Math.log2(padFor));
+  if (blocks.length === 0) {
+    output.set(zeroHash(layerCount), offset);
+    return;
+  }
+
+  for (const block of blocks) {
+    if (block.length !== BLOCK_SIZE) {
+      throw new Error(`Invalid block length, expect to be 64 bytes, got ${block.length}`);
+    }
+  }
+
+  // as-sha256 has a buffer of 4 * 64 bytes
+  // hashtree has a buffer of 16 * 64 bytes
+  if (buffer.length === 0 || buffer.length % (4 * BLOCK_SIZE) !== 0) {
+    throw new Error(`Invalid buffer length, expect to be multiple of 64 bytes, got ${buffer.length}`);
+  }
+
+  // batchSize is 4 for as-sha256, 16 for hashtree
+  const batchSize = Math.floor(buffer.length / BLOCK_SIZE);
+  const halfBatchSize = Math.floor(batchSize / 2);
+  let bufferIn = buffer;
+  // hash into the same buffer
+  let bufferOut = buffer.subarray(0, halfBatchSize * BLOCK_SIZE);
+  let blockCount = blocks.length;
+  // hash into the same blocks to save memory allocation
+  for (let layer = 0; layer < layerCount; layer++) {
+    let outBlockIndex = 0;
+    const sameLayerLoop = Math.floor(blockCount / batchSize);
+    for (let i = 0; i < sameLayerLoop; i++) {
+      // populate bufferIn
+      for (let j = 0; j < batchSize; j++) {
+        const blockIndex = i * batchSize + j;
+        bufferIn.set(blocks[blockIndex], j * BLOCK_SIZE);
+      }
+
+      // hash into bufferOut
+      hashInto(bufferIn, bufferOut);
+
+      // copy bufferOut to blocks, bufferOut.len = halfBatchSize * BLOCK_SIZE
+      for (let j = 0; j < halfBatchSize; j++) {
+        blocks[outBlockIndex].set(bufferOut.subarray(j * BLOCK_SIZE, (j + 1) * BLOCK_SIZE));
+        outBlockIndex++;
+      }
+    }
+
+    // remaining blocks
+    const remainingBlocks = blockCount % batchSize;
+    bufferIn = buffer.subarray(0, remainingBlocks * BLOCK_SIZE);
+    bufferOut = buffer.subarray(0, Math.floor(bufferIn.length / 2));
+
+    // populate bufferIn
+    for (let blockIndex = Math.floor(blockCount / batchSize) * batchSize; blockIndex < blockCount; blockIndex++) {
+      bufferIn.set(blocks[blockIndex], (blockIndex % batchSize) * BLOCK_SIZE);
+    }
+
+    // hash into bufferOut
+    hashInto(bufferIn, bufferOut);
+
+    // copy bufferOut to blocks, note that bufferOut.len may not be divisible by BLOCK_SIZE
+    for (let j = 0; j < Math.floor(bufferOut.length / BLOCK_SIZE); j++) {
+      blocks[outBlockIndex].set(bufferOut.subarray(j * BLOCK_SIZE, (j + 1) * BLOCK_SIZE));
+      outBlockIndex++;
+    }
+
+    if (bufferOut.length % BLOCK_SIZE !== 0) {
+      // set the last 32 bytes of bufferOut
+      blocks[outBlockIndex].set(bufferOut.subarray(bufferOut.length - 32, bufferOut.length), 0);
+      // add zeroHash
+      blocks[outBlockIndex].set(zeroHash(layer + 1), 32);
+      outBlockIndex++;
+    }
+
+    // end of layer, update blockCount, bufferIn, bufferOut
+    blockCount = outBlockIndex;
+    bufferIn = buffer.subarray(0, blockCount * BLOCK_SIZE);
+    bufferOut = buffer.subarray(0, Math.floor(bufferIn.length / 2));
+  }
+
+  // the end result stays in blocks[0]
+  output.set(blocks[0].subarray(0, 32), offset);
 }
 
 /**

--- a/packages/persistent-merkle-tree/src/hasher/util.ts
+++ b/packages/persistent-merkle-tree/src/hasher/util.ts
@@ -100,7 +100,7 @@ export function doMerkleizeBlockArray(
   }
 
   const layerCount = Math.ceil(Math.log2(padFor));
-  if (blocks.length === 0) {
+  if (blockLimit === 0) {
     output.set(zeroHash(layerCount), offset);
     return;
   }

--- a/packages/persistent-merkle-tree/test/unit/hasher.test.ts
+++ b/packages/persistent-merkle-tree/test/unit/hasher.test.ts
@@ -126,11 +126,11 @@ describe("hasher.merkleizeBlockArray", function () {
       expect(() => hasher.merkleizeBlockArray([data], 2, output, 0)).to.throw("Invalid block length, expect to be 64 bytes, got 63");
     });
 
-    it (`${hasher.name} should throw error if chunkCount <= 1`, () => {
+    it (`${hasher.name} should throw error if chunkCount < 1`, () => {
       const data = Buffer.alloc(64, 0);
       const output = Buffer.alloc(32);
-      const chunkCount = 1;
-      expect(() => hasher.merkleizeBlockArray([data], 1, output, 0)).to.throw("Invalid padFor, expect to be at least 2, got 1");
+      const chunkCount = 0;
+      expect(() => hasher.merkleizeBlockArray([data], chunkCount, output, 0)).to.throw("Invalid padFor, expect to be at least 1, got 0");
     });
 
     // hashtree has a buffer of 16 * 64 bytes = 32 nodes

--- a/packages/persistent-merkle-tree/test/unit/hasher.test.ts
+++ b/packages/persistent-merkle-tree/test/unit/hasher.test.ts
@@ -120,17 +120,23 @@ describe("hasher.merkleizeBlocksBytes", function () {
  */
 describe("hasher.merkleizeBlockArray", function () {
   for (const hasher of [nobleHasher, hashtreeHasher, asSha256Hasher]) {
+    it (`${hasher.name} should throw error if invalid blockLimit`, () => {
+      const data = Buffer.alloc(64, 0);
+      const output = Buffer.alloc(32);
+      expect(() => hasher.merkleizeBlockArray([data], 2, 2, output, 0)).to.throw("Invalid blockLimit, expect to be less than or equal blocks.length 1, got 2");
+    });
+
     it (`${hasher.name} should throw error if not multiple of 64 bytes`, () => {
       const data = Buffer.alloc(63, 0);
       const output = Buffer.alloc(32);
-      expect(() => hasher.merkleizeBlockArray([data], 2, output, 0)).to.throw("Invalid block length, expect to be 64 bytes, got 63");
+      expect(() => hasher.merkleizeBlockArray([data], 1, 2, output, 0)).to.throw("Invalid block length, expect to be 64 bytes, got 63");
     });
 
     it (`${hasher.name} should throw error if chunkCount < 1`, () => {
       const data = Buffer.alloc(64, 0);
       const output = Buffer.alloc(32);
       const chunkCount = 0;
-      expect(() => hasher.merkleizeBlockArray([data], chunkCount, output, 0)).to.throw("Invalid padFor, expect to be at least 1, got 0");
+      expect(() => hasher.merkleizeBlockArray([data], 1, chunkCount, output, 0)).to.throw("Invalid padFor, expect to be at least 1, got 0");
     });
 
     // hashtree has a buffer of 16 * 64 bytes = 32 nodes
@@ -149,7 +155,11 @@ describe("hasher.merkleizeBlockArray", function () {
         for (let i = 0; i < padData.length; i += 64) {
           blocks.push(padData.slice(i, i + 64));
         }
-        hasher.merkleizeBlockArray(blocks, chunkCount, output, 0);
+        const blockLimit = blocks.length;
+        // should be able to run with above blocks, however add some redundant blocks similar to the consumer
+        blocks.push(Buffer.alloc(64, 1));
+        blocks.push(Buffer.alloc(64, 2));
+        hasher.merkleizeBlockArray(blocks, blockLimit, chunkCount, output, 0);
         const depth = Math.ceil(Math.log2(chunkCount));
         const root = subtreeFillToContents(nodes, depth).root;
         expectEqualHex(output, root);

--- a/packages/persistent-merkle-tree/test/unit/hasher.test.ts
+++ b/packages/persistent-merkle-tree/test/unit/hasher.test.ts
@@ -115,3 +115,46 @@ describe("hasher.merkleizeBlocksBytes", function () {
   }
 });
 
+/**
+ * The same to the previous test, but using the merkleizeBlockArray method
+ */
+describe("hasher.merkleizeBlockArray", function () {
+  for (const hasher of [nobleHasher, hashtreeHasher, asSha256Hasher]) {
+    it (`${hasher.name} should throw error if not multiple of 64 bytes`, () => {
+      const data = Buffer.alloc(63, 0);
+      const output = Buffer.alloc(32);
+      expect(() => hasher.merkleizeBlockArray([data], 2, output, 0)).to.throw("Invalid block length, expect to be 64 bytes, got 63");
+    });
+
+    it (`${hasher.name} should throw error if chunkCount <= 1`, () => {
+      const data = Buffer.alloc(64, 0);
+      const output = Buffer.alloc(32);
+      const chunkCount = 1;
+      expect(() => hasher.merkleizeBlockArray([data], 1, output, 0)).to.throw("Invalid padFor, expect to be at least 2, got 1");
+    });
+
+    // hashtree has a buffer of 16 * 64 bytes = 32 nodes
+    const numNodes = [64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79];
+    for (const numNode of numNodes) {
+      it(`${hasher.name}.merkleizeBlockArray for ${numNode} nodes`, () => {
+
+        const nodes = Array.from({length: numNode}, (_, i) => LeafNode.fromRoot(Buffer.alloc(32, i)));
+        const data = Buffer.concat(nodes.map((node) => node.root));
+        const output = Buffer.alloc(32);
+        // depth of 79 nodes are 7, make it 10 to test the padding
+        const chunkCount = Math.max(numNode, 10);
+        const padData = numNode % 2 === 1 ? Buffer.concat([data, zeroHash(0)]) : data;
+        expect(padData.length % 64).to.equal(0);
+        const blocks: Uint8Array[] = [];
+        for (let i = 0; i < padData.length; i += 64) {
+          blocks.push(padData.slice(i, i + 64));
+        }
+        hasher.merkleizeBlockArray(blocks, chunkCount, output, 0);
+        const depth = Math.ceil(Math.log2(chunkCount));
+        const root = subtreeFillToContents(nodes, depth).root;
+        expectEqualHex(output, root);
+      });
+    }
+  }
+});
+

--- a/packages/ssz/src/type/arrayComposite.ts
+++ b/packages/ssz/src/type/arrayComposite.ts
@@ -215,14 +215,14 @@ export function value_getChunkBytesArrayComposite<ElementType extends CompositeT
   elementType: ElementType,
   length: number,
   value: ValueOf<ElementType>[],
-  chunkBytesBuffer: Uint8Array
+  blocksBuffer: Uint8Array
 ): Uint8Array {
   const isOddChunk = length % 2 === 1;
   const chunkBytesLen = isOddChunk ? length * 32 + 32 : length * 32;
-  if (chunkBytesLen > chunkBytesBuffer.length) {
-    throw new Error(`chunkBytesBuffer is too small: ${chunkBytesBuffer.length} < ${chunkBytesLen}`);
+  if (chunkBytesLen > blocksBuffer.length) {
+    throw new Error(`blocksBuffer is too small: ${blocksBuffer.length} < ${chunkBytesLen}`);
   }
-  const chunkBytes = chunkBytesBuffer.subarray(0, chunkBytesLen);
+  const chunkBytes = blocksBuffer.subarray(0, chunkBytesLen);
 
   for (let i = 0; i < length; i++) {
     elementType.hashTreeRootInto(value[i], chunkBytes, i * 32);

--- a/packages/ssz/src/type/arrayComposite.ts
+++ b/packages/ssz/src/type/arrayComposite.ts
@@ -211,29 +211,29 @@ export function tree_deserializeFromBytesArrayComposite<ElementType extends Comp
   }
 }
 
-export function value_getChunkBytesArrayComposite<ElementType extends CompositeType<unknown, unknown, unknown>>(
+export function value_getBlocksBytesArrayComposite<ElementType extends CompositeType<unknown, unknown, unknown>>(
   elementType: ElementType,
   length: number,
   value: ValueOf<ElementType>[],
   blocksBuffer: Uint8Array
 ): Uint8Array {
-  const isOddChunk = length % 2 === 1;
-  const chunkBytesLen = isOddChunk ? length * 32 + 32 : length * 32;
-  if (chunkBytesLen > blocksBuffer.length) {
-    throw new Error(`blocksBuffer is too small: ${blocksBuffer.length} < ${chunkBytesLen}`);
+  const blockBytesLen = Math.ceil(length / 2) * 64;
+  if (blockBytesLen > blocksBuffer.length) {
+    throw new Error(`blocksBuffer is too small: ${blocksBuffer.length} < ${blockBytesLen}`);
   }
-  const chunkBytes = blocksBuffer.subarray(0, chunkBytesLen);
+  const blocksBytes = blocksBuffer.subarray(0, blockBytesLen);
 
   for (let i = 0; i < length; i++) {
-    elementType.hashTreeRootInto(value[i], chunkBytes, i * 32);
+    elementType.hashTreeRootInto(value[i], blocksBytes, i * 32);
   }
 
+  const isOddChunk = length % 2 === 1;
   if (isOddChunk) {
     // similar to append zeroHash(0)
-    chunkBytes.subarray(length * 32, chunkBytesLen).fill(0);
+    blocksBytes.subarray(length * 32, blockBytesLen).fill(0);
   }
 
-  return chunkBytes;
+  return blocksBytes;
 }
 
 function readOffsetsArrayComposite(

--- a/packages/ssz/src/type/bitArray.ts
+++ b/packages/ssz/src/type/bitArray.ts
@@ -44,9 +44,7 @@ export abstract class BitArrayType extends CompositeType<BitArray, BitArrayTreeV
     // reallocate this.blocksBuffer if needed
     if (value.uint8Array.length > this.blocksBuffer.length) {
       const chunkCount = Math.ceil(value.bitLen / 8 / 32);
-      const chunkBytes = chunkCount * 32;
-      // pad 1 chunk if maxChunkCount is not even
-      this.blocksBuffer = chunkCount % 2 === 1 ? new Uint8Array(chunkBytes + 32) : new Uint8Array(chunkBytes);
+      this.blocksBuffer = new Uint8Array(Math.ceil(chunkCount / 2) * 64);
     }
     return getBlockBytes(value.uint8Array, this.blocksBuffer);
   }

--- a/packages/ssz/src/type/bitArray.ts
+++ b/packages/ssz/src/type/bitArray.ts
@@ -4,7 +4,7 @@ import {CompositeType, LENGTH_GINDEX} from "./composite";
 import {BitArray} from "../value/bitArray";
 import {BitArrayTreeView} from "../view/bitArray";
 import {BitArrayTreeViewDU} from "../viewDU/bitArray";
-import {getBlockBytes} from "./byteArray";
+import {getBlocksBytes} from "./byteArray";
 
 /* eslint-disable @typescript-eslint/member-ordering */
 
@@ -46,7 +46,7 @@ export abstract class BitArrayType extends CompositeType<BitArray, BitArrayTreeV
       const chunkCount = Math.ceil(value.bitLen / 8 / 32);
       this.blocksBuffer = new Uint8Array(Math.ceil(chunkCount / 2) * 64);
     }
-    return getBlockBytes(value.uint8Array, this.blocksBuffer);
+    return getBlocksBytes(value.uint8Array, this.blocksBuffer);
   }
 
   // Proofs

--- a/packages/ssz/src/type/bitList.ts
+++ b/packages/ssz/src/type/bitList.ts
@@ -36,11 +36,11 @@ export class BitListType extends BitArrayType {
   readonly maxSize: number;
   readonly maxChunkCount: number;
   readonly isList = true;
-  readonly mixInLengthChunkBytes = new Uint8Array(64);
+  readonly mixInLengthBlockBytes = new Uint8Array(64);
   readonly mixInLengthBuffer = Buffer.from(
-    this.mixInLengthChunkBytes.buffer,
-    this.mixInLengthChunkBytes.byteOffset,
-    this.mixInLengthChunkBytes.byteLength
+    this.mixInLengthBlockBytes.buffer,
+    this.mixInLengthBlockBytes.byteOffset,
+    this.mixInLengthBlockBytes.byteLength
   );
 
   constructor(readonly limitBits: number, opts?: BitListOptions) {
@@ -120,12 +120,12 @@ export class BitListType extends BitArrayType {
   }
 
   hashTreeRootInto(value: BitArray, output: Uint8Array, offset: number): void {
-    super.hashTreeRootInto(value, this.mixInLengthChunkBytes, 0);
+    super.hashTreeRootInto(value, this.mixInLengthBlockBytes, 0);
     // mixInLength
     this.mixInLengthBuffer.writeUIntLE(value.bitLen, 32, 6);
     // one for hashTreeRoot(value), one for length
     const chunkCount = 2;
-    merkleizeBlocksBytes(this.mixInLengthChunkBytes, chunkCount, output, offset);
+    merkleizeBlocksBytes(this.mixInLengthBlockBytes, chunkCount, output, offset);
   }
 
   // Proofs: inherited from BitArrayType

--- a/packages/ssz/src/type/byteArray.ts
+++ b/packages/ssz/src/type/byteArray.ts
@@ -95,7 +95,7 @@ export abstract class ByteArrayType extends CompositeType<ByteArray, ByteArray, 
       const chunkCount = Math.ceil(value.length / 32);
       this.blocksBuffer = new Uint8Array(Math.ceil(chunkCount / 2) * 64);
     }
-    return getBlockBytes(value, this.blocksBuffer);
+    return getBlocksBytes(value, this.blocksBuffer);
   }
 
   // Proofs
@@ -160,15 +160,15 @@ export abstract class ByteArrayType extends CompositeType<ByteArray, ByteArray, 
   protected abstract assertValidSize(size: number): void;
 }
 
-export function getBlockBytes(value: Uint8Array, blocksBuffer: Uint8Array): Uint8Array {
+export function getBlocksBytes(value: Uint8Array, blocksBuffer: Uint8Array): Uint8Array {
   if (value.length > blocksBuffer.length) {
     throw new Error(`data length ${value.length} exceeds blocksBuffer length ${blocksBuffer.length}`);
   }
 
   blocksBuffer.set(value);
   const valueLen = value.length;
-  const chunkByteLen = Math.ceil(valueLen / 64) * 64;
+  const blockByteLen = Math.ceil(valueLen / 64) * 64;
   // all padding bytes must be zero, this is similar to set zeroHash(0)
-  blocksBuffer.subarray(valueLen, chunkByteLen).fill(0);
-  return blocksBuffer.subarray(0, chunkByteLen);
+  blocksBuffer.subarray(valueLen, blockByteLen).fill(0);
+  return blocksBuffer.subarray(0, blockByteLen);
 }

--- a/packages/ssz/src/type/byteArray.ts
+++ b/packages/ssz/src/type/byteArray.ts
@@ -93,9 +93,7 @@ export abstract class ByteArrayType extends CompositeType<ByteArray, ByteArray, 
     // reallocate this.blocksBuffer if needed
     if (value.length > this.blocksBuffer.length) {
       const chunkCount = Math.ceil(value.length / 32);
-      const chunkBytes = chunkCount * 32;
-      // pad 1 chunk if maxChunkCount is not even
-      this.blocksBuffer = chunkCount % 2 === 1 ? new Uint8Array(chunkBytes + 32) : new Uint8Array(chunkBytes);
+      this.blocksBuffer = new Uint8Array(Math.ceil(chunkCount / 2) * 64);
     }
     return getBlockBytes(value, this.blocksBuffer);
   }

--- a/packages/ssz/src/type/byteList.ts
+++ b/packages/ssz/src/type/byteList.ts
@@ -5,6 +5,7 @@ import {
   packedNodeRootsToBytes,
   packedRootsBytesToNode,
   merkleizeBlocksBytes,
+  merkleizeBlockArray,
 } from "@chainsafe/persistent-merkle-tree";
 import {maxChunksToDepth} from "../util/merkleize";
 import {Require} from "../util/types";
@@ -40,6 +41,8 @@ export class ByteListType extends ByteArrayType {
   readonly maxSize: number;
   readonly maxChunkCount: number;
   readonly isList = true;
+  readonly blockArray: Uint8Array[] = [];
+  private blockBytesLen = 0;
   readonly mixInLengthChunkBytes = new Uint8Array(64);
   readonly mixInLengthBuffer = Buffer.from(
     this.mixInLengthChunkBytes.buffer,
@@ -106,8 +109,39 @@ export class ByteListType extends ByteArrayType {
     return root;
   }
 
+  /**
+   * Use  merkleizeBlockArray() instead of merkleizeBlocksBytes() to avoid big memory allocation
+   */
   hashTreeRootInto(value: Uint8Array, output: Uint8Array, offset: number): void {
-    super.hashTreeRootInto(value, this.mixInLengthChunkBytes, 0);
+    // should not call super.hashTreeRoot() here
+    // use  merkleizeBlockArray() instead of merkleizeBlocksBytes() to avoid big memory allocation
+    // reallocate this.blockArray if needed
+    if (value.length > this.blockBytesLen) {
+      const newBlockCount = Math.ceil(value.length / 64);
+      // this.blockBytesLen should be a multiple of 64
+      const oldBlockCount = Math.ceil(this.blockBytesLen / 64);
+      const blockDiff = newBlockCount - oldBlockCount;
+      const newBlocksBytes = new Uint8Array(blockDiff * 64);
+      for (let i = 0; i < blockDiff; i++) {
+        this.blockArray.push(newBlocksBytes.subarray(i * 64, (i + 1) * 64));
+        this.blockBytesLen += 64;
+      }
+    }
+
+    // populate this.blockArray
+    for (let i = 0; i < value.length; i += 64) {
+      const block = this.blockArray[i / 64];
+      // zero out the last block if it's over value.length
+      if (i + 64 > value.length) {
+        block.fill(0);
+      }
+      block.set(value.subarray(i, Math.min(i + 64, value.length)));
+    }
+
+    // compute hashTreeRoot
+    const blockLimit = Math.ceil(value.length / 64);
+    merkleizeBlockArray(this.blockArray, blockLimit, this.maxChunkCount, this.mixInLengthChunkBytes, 0);
+
     // mixInLength
     this.mixInLengthBuffer.writeUIntLE(value.length, 32, 6);
     // one for hashTreeRoot(value), one for length

--- a/packages/ssz/src/type/byteList.ts
+++ b/packages/ssz/src/type/byteList.ts
@@ -43,11 +43,11 @@ export class ByteListType extends ByteArrayType {
   readonly isList = true;
   readonly blockArray: Uint8Array[] = [];
   private blockBytesLen = 0;
-  readonly mixInLengthChunkBytes = new Uint8Array(64);
+  readonly mixInLengthBlockBytes = new Uint8Array(64);
   readonly mixInLengthBuffer = Buffer.from(
-    this.mixInLengthChunkBytes.buffer,
-    this.mixInLengthChunkBytes.byteOffset,
-    this.mixInLengthChunkBytes.byteLength
+    this.mixInLengthBlockBytes.buffer,
+    this.mixInLengthBlockBytes.byteOffset,
+    this.mixInLengthBlockBytes.byteLength
   );
 
   constructor(readonly limitBytes: number, opts?: ByteListOptions) {
@@ -140,13 +140,13 @@ export class ByteListType extends ByteArrayType {
 
     // compute hashTreeRoot
     const blockLimit = Math.ceil(value.length / 64);
-    merkleizeBlockArray(this.blockArray, blockLimit, this.maxChunkCount, this.mixInLengthChunkBytes, 0);
+    merkleizeBlockArray(this.blockArray, blockLimit, this.maxChunkCount, this.mixInLengthBlockBytes, 0);
 
     // mixInLength
     this.mixInLengthBuffer.writeUIntLE(value.length, 32, 6);
     // one for hashTreeRoot(value), one for length
     const chunkCount = 2;
-    merkleizeBlocksBytes(this.mixInLengthChunkBytes, chunkCount, output, offset);
+    merkleizeBlocksBytes(this.mixInLengthBlockBytes, chunkCount, output, offset);
   }
 
   // Proofs: inherited from BitArrayType

--- a/packages/ssz/src/type/container.ts
+++ b/packages/ssz/src/type/container.ts
@@ -131,8 +131,7 @@ export class ContainerType<Fields extends Record<string, Type<unknown>>> extends
     this.TreeView = opts?.getContainerTreeViewClass?.(this) ?? getContainerTreeViewClass(this);
     this.TreeViewDU = opts?.getContainerTreeViewDUClass?.(this) ?? getContainerTreeViewDUClass(this);
     const fieldBytes = this.fieldsEntries.length * 32;
-    const chunkBytes = Math.ceil(fieldBytes / 64) * 64;
-    this.blocksBuffer = new Uint8Array(chunkBytes);
+    this.blocksBuffer = new Uint8Array(Math.ceil(fieldBytes / 64) * 64);
   }
 
   static named<Fields extends Record<string, Type<unknown>>>(

--- a/packages/ssz/src/type/listBasic.ts
+++ b/packages/ssz/src/type/listBasic.ts
@@ -47,11 +47,11 @@ export class ListBasicType<ElementType extends BasicType<unknown>>
   readonly maxSize: number;
   readonly isList = true;
   readonly isViewMutable = true;
-  readonly mixInLengthChunkBytes = new Uint8Array(64);
+  readonly mixInLengthBlockBytes = new Uint8Array(64);
   readonly mixInLengthBuffer = Buffer.from(
-    this.mixInLengthChunkBytes.buffer,
-    this.mixInLengthChunkBytes.byteOffset,
-    this.mixInLengthChunkBytes.byteLength
+    this.mixInLengthBlockBytes.buffer,
+    this.mixInLengthBlockBytes.byteOffset,
+    this.mixInLengthBlockBytes.byteLength
   );
   protected readonly defaultLen = 0;
 
@@ -193,12 +193,12 @@ export class ListBasicType<ElementType extends BasicType<unknown>>
       }
     }
 
-    super.hashTreeRootInto(value, this.mixInLengthChunkBytes, 0);
+    super.hashTreeRootInto(value, this.mixInLengthBlockBytes, 0);
     // mixInLength
     this.mixInLengthBuffer.writeUIntLE(value.length, 32, 6);
     // one for hashTreeRoot(value), one for length
     const chunkCount = 2;
-    merkleizeBlocksBytes(this.mixInLengthChunkBytes, chunkCount, output, offset);
+    merkleizeBlocksBytes(this.mixInLengthBlockBytes, chunkCount, output, offset);
 
     if (this.cachePermanentRootStruct) {
       cacheRoot(value as ValueWithCachedPermanentRoot, output, offset, safeCache);
@@ -207,20 +207,20 @@ export class ListBasicType<ElementType extends BasicType<unknown>>
 
   protected getBlocksBytes(value: ValueOf<ElementType>[]): Uint8Array {
     const byteLen = this.value_serializedSize(value);
-    const chunkByteLen = Math.ceil(byteLen / 64) * 64;
+    const blockByteLen = Math.ceil(byteLen / 64) * 64;
     // reallocate this.blocksBuffer if needed
     if (byteLen > this.blocksBuffer.length) {
       // pad 1 chunk if maxChunkCount is not even
-      this.blocksBuffer = new Uint8Array(chunkByteLen);
+      this.blocksBuffer = new Uint8Array(blockByteLen);
     }
-    const chunkBytes = this.blocksBuffer.subarray(0, chunkByteLen);
-    const uint8Array = chunkBytes.subarray(0, byteLen);
+    const blockBytes = this.blocksBuffer.subarray(0, blockByteLen);
+    const uint8Array = blockBytes.subarray(0, byteLen);
     const dataView = new DataView(uint8Array.buffer, uint8Array.byteOffset, uint8Array.byteLength);
     value_serializeToBytesArrayBasic(this.elementType, value.length, {uint8Array, dataView}, 0, value);
 
     // all padding bytes must be zero, this is similar to set zeroHash(0)
-    this.blocksBuffer.subarray(byteLen, chunkByteLen).fill(0);
-    return chunkBytes;
+    this.blocksBuffer.subarray(byteLen, blockByteLen).fill(0);
+    return blockBytes;
   }
 
   // JSON: inherited from ArrayType

--- a/packages/ssz/src/type/listBasic.ts
+++ b/packages/ssz/src/type/listBasic.ts
@@ -208,7 +208,7 @@ export class ListBasicType<ElementType extends BasicType<unknown>>
   protected getBlocksBytes(value: ValueOf<ElementType>[]): Uint8Array {
     const byteLen = this.value_serializedSize(value);
     const chunkByteLen = Math.ceil(byteLen / 64) * 64;
-    // reallocate this.verkleBytes if needed
+    // reallocate this.blocksBuffer if needed
     if (byteLen > this.blocksBuffer.length) {
       // pad 1 chunk if maxChunkCount is not even
       this.blocksBuffer = new Uint8Array(chunkByteLen);

--- a/packages/ssz/src/type/listComposite.ts
+++ b/packages/ssz/src/type/listComposite.ts
@@ -13,7 +13,7 @@ import {
   tree_deserializeFromBytesArrayComposite,
   tree_serializeToBytesArrayComposite,
   maxSizeArrayComposite,
-  value_getChunkBytesArrayComposite,
+  value_getBlocksBytesArrayComposite,
 } from "./arrayComposite";
 import {ArrayCompositeType} from "../view/arrayComposite";
 import {ListCompositeTreeView} from "../view/listComposite";
@@ -52,11 +52,11 @@ export class ListCompositeType<
   readonly maxSize: number;
   readonly isList = true;
   readonly isViewMutable = true;
-  readonly mixInLengthChunkBytes = new Uint8Array(64);
+  readonly mixInLengthBlockBytes = new Uint8Array(64);
   readonly mixInLengthBuffer = Buffer.from(
-    this.mixInLengthChunkBytes.buffer,
-    this.mixInLengthChunkBytes.byteOffset,
-    this.mixInLengthChunkBytes.byteLength
+    this.mixInLengthBlockBytes.buffer,
+    this.mixInLengthBlockBytes.byteOffset,
+    this.mixInLengthBlockBytes.byteLength
   );
   protected readonly defaultLen = 0;
 
@@ -200,12 +200,12 @@ export class ListCompositeType<
       }
     }
 
-    super.hashTreeRootInto(value, this.mixInLengthChunkBytes, 0);
+    super.hashTreeRootInto(value, this.mixInLengthBlockBytes, 0);
     // mixInLength
     this.mixInLengthBuffer.writeUIntLE(value.length, 32, 6);
     // one for hashTreeRoot(value), one for length
     const chunkCount = 2;
-    merkleizeBlocksBytes(this.mixInLengthChunkBytes, chunkCount, output, offset);
+    merkleizeBlocksBytes(this.mixInLengthBlockBytes, chunkCount, output, offset);
 
     if (this.cachePermanentRootStruct) {
       cacheRoot(value as ValueWithCachedPermanentRoot, output, offset, safeCache);
@@ -218,7 +218,7 @@ export class ListCompositeType<
     if (byteLen > blockByteLen) {
       this.blocksBuffer = new Uint8Array(Math.ceil(byteLen / 64) * 64);
     }
-    return value_getChunkBytesArrayComposite(this.elementType, value.length, value, this.blocksBuffer);
+    return value_getBlocksBytesArrayComposite(this.elementType, value.length, value, this.blocksBuffer);
   }
 
   // JSON: inherited from ArrayType

--- a/packages/ssz/src/type/optional.ts
+++ b/packages/ssz/src/type/optional.ts
@@ -66,6 +66,7 @@ export class OptionalType<ElementType extends Type<unknown>> extends CompositeTy
     this.minSize = 0;
     // Max size includes prepended 0x01 byte
     this.maxSize = elementType.maxSize + 1;
+    // maxChunkCount = 1 so this.blocksBuffer.length = 32 in this case
     this.blocksBuffer = new Uint8Array(32);
   }
 

--- a/packages/ssz/src/type/optional.ts
+++ b/packages/ssz/src/type/optional.ts
@@ -48,11 +48,11 @@ export class OptionalType<ElementType extends Type<unknown>> extends CompositeTy
   readonly maxSize: number;
   readonly isList = true;
   readonly isViewMutable = true;
-  readonly mixInLengthChunkBytes = new Uint8Array(64);
+  readonly mixInLengthBlockBytes = new Uint8Array(64);
   readonly mixInLengthBuffer = Buffer.from(
-    this.mixInLengthChunkBytes.buffer,
-    this.mixInLengthChunkBytes.byteOffset,
-    this.mixInLengthChunkBytes.byteLength
+    this.mixInLengthBlockBytes.buffer,
+    this.mixInLengthBlockBytes.byteOffset,
+    this.mixInLengthBlockBytes.byteLength
   );
 
   constructor(readonly elementType: ElementType, opts?: OptionalOpts) {
@@ -186,12 +186,12 @@ export class OptionalType<ElementType extends Type<unknown>> extends CompositeTy
   }
 
   hashTreeRootInto(value: ValueOfType<ElementType>, output: Uint8Array, offset: number): void {
-    super.hashTreeRootInto(value, this.mixInLengthChunkBytes, 0);
+    super.hashTreeRootInto(value, this.mixInLengthBlockBytes, 0);
     const selector = value === null ? 0 : 1;
     this.mixInLengthBuffer.writeUIntLE(selector, 32, 6);
     // one for hashTreeRoot(value), one for selector
     const chunkCount = 2;
-    merkleizeBlocksBytes(this.mixInLengthChunkBytes, chunkCount, output, offset);
+    merkleizeBlocksBytes(this.mixInLengthBlockBytes, chunkCount, output, offset);
   }
 
   protected getBlocksBytes(value: ValueOfType<ElementType>): Uint8Array {

--- a/packages/ssz/src/type/profile.ts
+++ b/packages/ssz/src/type/profile.ts
@@ -158,8 +158,7 @@ export class ProfileType<Fields extends Record<string, Type<unknown>>> extends C
     this.TreeView = opts?.getProfileTreeViewClass?.(this) ?? getProfileTreeViewClass(this);
     this.TreeViewDU = opts?.getProfileTreeViewDUClass?.(this) ?? getProfileTreeViewDUClass(this);
     const fieldBytes = this.activeFields.bitLen * 32;
-    const chunkBytes = Math.ceil(fieldBytes / 64) * 64;
-    this.blocksBuffer = new Uint8Array(chunkBytes);
+    this.blocksBuffer = new Uint8Array(Math.ceil(fieldBytes / 64) * 64);
   }
 
   static named<Fields extends Record<string, Type<unknown>>>(

--- a/packages/ssz/src/type/union.ts
+++ b/packages/ssz/src/type/union.ts
@@ -49,11 +49,11 @@ export class UnionType<Types extends Type<unknown>[]> extends CompositeType<
   readonly maxSize: number;
   readonly isList = true;
   readonly isViewMutable = true;
-  readonly mixInLengthChunkBytes = new Uint8Array(64);
+  readonly mixInLengthBlockBytes = new Uint8Array(64);
   readonly mixInLengthBuffer = Buffer.from(
-    this.mixInLengthChunkBytes.buffer,
-    this.mixInLengthChunkBytes.byteOffset,
-    this.mixInLengthChunkBytes.byteLength
+    this.mixInLengthBlockBytes.buffer,
+    this.mixInLengthBlockBytes.byteOffset,
+    this.mixInLengthBlockBytes.byteLength
   );
 
   protected readonly maxSelector: number;
@@ -185,10 +185,10 @@ export class UnionType<Types extends Type<unknown>[]> extends CompositeType<
   }
 
   hashTreeRootInto(value: ValueOfTypes<Types>, output: Uint8Array, offset: number): void {
-    super.hashTreeRootInto(value, this.mixInLengthChunkBytes, 0);
+    super.hashTreeRootInto(value, this.mixInLengthBlockBytes, 0);
     this.mixInLengthBuffer.writeUIntLE(value.selector, 32, 6);
     const chunkCount = 2;
-    merkleizeBlocksBytes(this.mixInLengthChunkBytes, chunkCount, output, offset);
+    merkleizeBlocksBytes(this.mixInLengthBlockBytes, chunkCount, output, offset);
   }
 
   protected getBlocksBytes(value: ValueOfTypes<Types>): Uint8Array {

--- a/packages/ssz/src/type/union.ts
+++ b/packages/ssz/src/type/union.ts
@@ -92,6 +92,7 @@ export class UnionType<Types extends Type<unknown>[]> extends CompositeType<
     this.minSize = 1 + Math.min(...minLens);
     this.maxSize = 1 + Math.max(...maxLens);
     this.maxSelector = this.types.length - 1;
+    // maxChunkCount = 1 so this.blocksBuffer.length = 32 in this case
     this.blocksBuffer = new Uint8Array(32);
   }
 

--- a/packages/ssz/src/type/vectorBasic.ts
+++ b/packages/ssz/src/type/vectorBasic.ts
@@ -152,7 +152,7 @@ export class VectorBasicType<ElementType extends BasicType<unknown>>
     const dataView = new DataView(uint8Array.buffer, uint8Array.byteOffset, uint8Array.byteLength);
     value_serializeToBytesArrayBasic(this.elementType, this.length, {uint8Array, dataView}, 0, value);
 
-    // remaining bytes from this.fixedSize to this.chunkBytesBuffer.length must be zeroed
+    // remaining bytes from this.fixedSize to this.blocksBuffer.length must be zeroed
     return this.blocksBuffer;
   }
 

--- a/packages/ssz/src/type/vectorBasic.ts
+++ b/packages/ssz/src/type/vectorBasic.ts
@@ -59,10 +59,7 @@ export class VectorBasicType<ElementType extends BasicType<unknown>>
     this.minSize = this.fixedSize;
     this.maxSize = this.fixedSize;
     this.defaultLen = length;
-    // pad 1 chunk if maxChunkCount is not even
-    this.blocksBuffer = new Uint8Array(
-      this.maxChunkCount % 2 === 1 ? this.maxChunkCount * 32 + 32 : this.maxChunkCount * 32
-    );
+    this.blocksBuffer = new Uint8Array(Math.ceil(this.maxChunkCount / 2) * 64);
   }
 
   static named<ElementType extends BasicType<unknown>>(

--- a/packages/ssz/src/type/vectorComposite.ts
+++ b/packages/ssz/src/type/vectorComposite.ts
@@ -65,10 +65,7 @@ export class VectorCompositeType<
     this.minSize = minSizeArrayComposite(elementType, length);
     this.maxSize = maxSizeArrayComposite(elementType, length);
     this.defaultLen = length;
-    this.blocksBuffer =
-      this.maxChunkCount % 2 === 1
-        ? new Uint8Array(this.maxChunkCount * 32 + 32)
-        : new Uint8Array(this.maxChunkCount * 32);
+    this.blocksBuffer = new Uint8Array(Math.ceil(this.maxChunkCount / 2) * 64);
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/ssz/src/type/vectorComposite.ts
+++ b/packages/ssz/src/type/vectorComposite.ts
@@ -13,7 +13,7 @@ import {
   tree_serializeToBytesArrayComposite,
   maxSizeArrayComposite,
   minSizeArrayComposite,
-  value_getChunkBytesArrayComposite,
+  value_getBlocksBytesArrayComposite,
 } from "./arrayComposite";
 import {ArrayCompositeType, ArrayCompositeTreeView} from "../view/arrayComposite";
 import {ArrayCompositeTreeViewDU} from "../viewDU/arrayComposite";
@@ -155,7 +155,7 @@ export class VectorCompositeType<
   // Merkleization
 
   protected getBlocksBytes(value: ValueOf<ElementType>[]): Uint8Array {
-    return value_getChunkBytesArrayComposite(this.elementType, this.length, value, this.blocksBuffer);
+    return value_getBlocksBytesArrayComposite(this.elementType, this.length, value, this.blocksBuffer);
   }
 
   // JSON: inherited from ArrayType

--- a/packages/ssz/test/perf/merkleize.test.ts
+++ b/packages/ssz/test/perf/merkleize.test.ts
@@ -39,7 +39,7 @@ describe("merkleize vs persistent-merkle-tree merkleizeBlocksBytes", () => {
     });
 
     itBench(`merkleizeBlockArray ${chunkCount} chunks`, () => {
-      merkleizeBlockArray(blockArray, chunkCount, result, 0);
+      merkleizeBlockArray(blockArray, blockArray.length, chunkCount, result, 0);
     });
   }
 });

--- a/packages/ssz/test/perf/merkleize.test.ts
+++ b/packages/ssz/test/perf/merkleize.test.ts
@@ -1,6 +1,6 @@
 import {itBench} from "@dapplion/benchmark";
 import {bitLength, merkleize} from "../../src/util/merkleize";
-import {merkleizeBlocksBytes} from "@chainsafe/persistent-merkle-tree";
+import {merkleizeBlockArray, merkleizeBlocksBytes} from "@chainsafe/persistent-merkle-tree";
 
 describe("merkleize / bitLength", () => {
   for (const n of [50, 8000, 250000]) {
@@ -15,18 +15,31 @@ describe("merkleize / bitLength", () => {
 });
 
 describe("merkleize vs persistent-merkle-tree merkleizeBlocksBytes", () => {
-  const chunkCounts = [4, 8, 16, 32];
+  const chunkCounts = [32, 128, 512, 1024];
 
   for (const chunkCount of chunkCounts) {
     const rootArr = Array.from({length: chunkCount}, (_, i) => Buffer.alloc(32, i));
-    const roots = Buffer.concat(rootArr);
+    const blocksBytes = Buffer.concat(rootArr);
+    if (blocksBytes.length % 64 !== 0) {
+      throw new Error("blockBytes length must be a multiple of 64");
+    }
+    const blockArray: Uint8Array[] = [];
+    for (let i = 0; i < blocksBytes.length; i += 64) {
+      blockArray.push(blocksBytes.slice(i, i + 64));
+    }
+
     const result = Buffer.alloc(32);
-    itBench(`merkleizeBlocksBytes ${chunkCount} chunks`, () => {
-      merkleizeBlocksBytes(roots, chunkCount, result, 0);
-    });
 
     itBench(`merkleize ${chunkCount} chunks`, () => {
       merkleize(rootArr, chunkCount);
+    });
+
+    itBench(`merkleizeBlocksBytes ${chunkCount} chunks`, () => {
+      merkleizeBlocksBytes(blocksBytes, chunkCount, result, 0);
+    });
+
+    itBench(`merkleizeBlockArray ${chunkCount} chunks`, () => {
+      merkleizeBlockArray(blockArray, chunkCount, result, 0);
     });
   }
 });

--- a/packages/ssz/test/unit/byType/byteList/value.test.ts
+++ b/packages/ssz/test/unit/byType/byteList/value.test.ts
@@ -1,0 +1,28 @@
+import {expect} from "chai";
+import {ByteListType} from "../../../../src";
+
+describe("ByteListValue", () => {
+  const type = new ByteListType(1024);
+
+  it("should zero out the last sha256 block if it's over value.length", () => {
+    const value = Buffer.alloc(65, 1);
+    const expectedRoot = type.hashTreeRoot(value);
+    // now hash another value which make the cached blocks non zero
+    type.hashTreeRoot(Buffer.alloc(1024, 2));
+    const actualRoot = type.hashTreeRoot(value);
+    expect(actualRoot).to.deep.equal(expectedRoot);
+  });
+
+  it("should increase blockArray size if needed", () => {
+    const value0 = Buffer.alloc(65, 1);
+    const expectedRoot0 = type.hashTreeRoot(value0);
+    const value1 = Buffer.alloc(1024, 3);
+    const expectedRoot1 = type.hashTreeRoot(value1);
+    // now increase block array size
+    type.hashTreeRoot(Buffer.alloc(1024, 2));
+
+    // hash again
+    expect(type.hashTreeRoot(value0)).to.deep.equal(expectedRoot0);
+    expect(type.hashTreeRoot(value1)).to.deep.equal(expectedRoot1);
+  });
+});

--- a/packages/ssz/test/unit/merkleize.test.ts
+++ b/packages/ssz/test/unit/merkleize.test.ts
@@ -1,6 +1,6 @@
 import {expect} from "chai";
 import {bitLength, maxChunksToDepth, merkleize, mixInLength, nextPowerOf2} from "../../src/util/merkleize";
-import {merkleizeBlocksBytes, LeafNode, zeroHash} from "@chainsafe/persistent-merkle-tree";
+import {merkleizeBlocksBytes, LeafNode, zeroHash, merkleizeBlockArray} from "@chainsafe/persistent-merkle-tree";
 
 describe("util / merkleize / bitLength", () => {
   const bitLengthByIndex = [0, 1, 2, 2, 3, 3, 3, 3, 4, 4];
@@ -59,6 +59,30 @@ describe("merkleize should be equal to merkleizeBlocksBytes of hasher", () => {
       const expectedRoot = Buffer.alloc(32);
       const chunkCount = Math.max(numNode, 1);
       merkleizeBlocksBytes(padData, chunkCount, expectedRoot, 0);
+      expect(merkleize(roots, chunkCount)).to.be.deep.equal(expectedRoot);
+    });
+  }
+});
+
+// same to the above but with merkleizeBlockArray() method
+describe("merkleize should be equal to merkleizeBlockArray of hasher", () => {
+  // hashtree has a buffer of 16 * 64 bytes = 32 nodes
+  const numNodes = [64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79];
+  for (const numNode of numNodes) {
+    it(`merkleize for ${numNode} nodes`, () => {
+      const nodes = Array.from({length: numNode}, (_, i) => LeafNode.fromRoot(Buffer.alloc(32, i)));
+      const data = Buffer.concat(nodes.map((node) => node.root));
+      const padData = numNode % 2 === 1 ? Buffer.concat([data, zeroHash(0)]) : data;
+      expect(padData.length % 64).to.equal(0);
+      const blocks: Uint8Array[] = [];
+      for (let i = 0; i < padData.length; i += 64) {
+        blocks.push(padData.slice(i, i + 64));
+      }
+      const expectedRoot = Buffer.alloc(32);
+      // depth of 79 nodes are 7, make it 10 to test the padding
+      const chunkCount = Math.max(numNode, 10);
+      merkleizeBlockArray(blocks, chunkCount, expectedRoot, 0);
+      const roots = nodes.map((node) => node.root);
       expect(merkleize(roots, chunkCount)).to.be.deep.equal(expectedRoot);
     });
   }

--- a/packages/ssz/test/unit/merkleize.test.ts
+++ b/packages/ssz/test/unit/merkleize.test.ts
@@ -81,7 +81,11 @@ describe("merkleize should be equal to merkleizeBlockArray of hasher", () => {
       const expectedRoot = Buffer.alloc(32);
       // depth of 79 nodes are 7, make it 10 to test the padding
       const chunkCount = Math.max(numNode, 10);
-      merkleizeBlockArray(blocks, chunkCount, expectedRoot, 0);
+      // add redundant blocks, should not affect the result
+      const blockLimit = blocks.length;
+      blocks.push(Buffer.alloc(64, 1));
+      blocks.push(Buffer.alloc(64, 2));
+      merkleizeBlockArray(blocks, blockLimit, chunkCount, expectedRoot, 0);
       const roots = nodes.map((node) => node.root);
       expect(merkleize(roots, chunkCount)).to.be.deep.equal(expectedRoot);
     });


### PR DESCRIPTION
**Motivation**

- When we have a list of bytes or list of composite, if new value is over the cached chunk/block bytes, right now we reallocate the whole Uint8Array which is not good due to gc

**Description**

- Instead of that, implement `merkleizeBlockArray(blocks: Uint8Array[], ...)`. In the above case we only need to allocate some more Uint8Array instances, each 64 bytes
- refactor `merkleizeInto()` to `merkleizeBlocksBytes()` to avoid naming conflict
- model block bytes which is 64 bytes instead of chunk bytes which is 32 bytes


- this branch run on `feat` `16, 1, novc` for 5 days without issue

<img width="1670" alt="Screenshot 2024-11-06 at 15 21 25" src="https://github.com/user-attachments/assets/115400cc-c3d9-4b03-96a9-ffe6158d6375">

- persisting `gc` statistic on 1d interval of `md16`:
<img width="1341" alt="Screenshot 2024-11-06 at 15 22 39" src="https://github.com/user-attachments/assets/dafbb0dd-a2d3-4e8a-be07-d77eaee45188">

- vs stable md16

<img width="1342" alt="Screenshot 2024-11-06 at 15 24 09" src="https://github.com/user-attachments/assets/8697321f-6591-4597-b9c8-bf8db591d622">
