### PR TITLE
fix: update the hasher for benchmarks

### DIFF
--- a/setHasher.mjs
+++ b/setHasher.mjs
@@ -1,7 +1,7 @@
 // Set the hasher to hashtree
 // Used to run benchmarks with with visibility into hashtree performance, useful for Lodestar
-import {setHasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/index.js";
-import {hasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/hashtree.js";
+import {setHasher} from "@chainsafe/persistent-merkle-tree/lib/cjs/hasher/index.js";
+import {hasher} from "@chainsafe/persistent-merkle-tree/lib/cjs/hasher/hashtree.js";
 setHasher(hasher);
 
 export {};


### PR DESCRIPTION
**Motivation**

Use the `hashtree` hasher for the benchmarks.

**Description**

- During the PR https://github.com/ChainSafe/ssz/pull/426/ the hasher was changed for the benchmarks 
- We have `main` field in `package.json` pointed to the `lib/cjs/index.js` folder and `module` field pointed to `lib/index.js`. 
- It seems that in TS it's by default loading up the `main` instead of `module` for package import. 
- So we have to set proper hasher for the benchmarks. 

**Steps to test or reproduce**

- Run all tests

**Reference**

https://www.typescriptlang.org/docs/handbook/modules/reference.html#packagejson-main-and-types