### PR TITLE
fix: ListCompositeTreeViewDU to getAllReadonly() without commit

### DIFF
--- a/packages/ssz/test/unit/byType/listComposite/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listComposite/tree.test.ts
@@ -344,8 +344,7 @@ describe("ListCompositeType getAllReadOnly - no commit", () => {
     const listType = new ListCompositeType(ssz.Root, 1024);
     const listLength = 2;
     const list = Array.from({length: listLength}, (_, i) => Buffer.alloc(32, i));
-    let listView: ListCompositeTreeViewDU<typeof ssz.Root>;
-    listView = listType.toViewDU(list);
+    const listView = listType.toViewDU(list);
     expect(listView.getAllReadonly()).to.deep.equal(list);
 
     // modify

--- a/packages/ssz/test/unit/byType/listComposite/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listComposite/tree.test.ts
@@ -120,7 +120,8 @@ describe("ListCompositeType tree reads", () => {
 
       // Only for viewDU
       if (view instanceof ArrayCompositeTreeViewDU) {
-        expect(() => view.getAllReadonly()).toThrow("Must commit changes before reading all nodes");
+        expect(() => view.getAllReadonly()).not.toThrow();
+        expect(() => view.getAllReadonlyValues()).toThrow("Must commit changes before reading all nodes");
         view.commit();
       }
 
@@ -336,4 +337,26 @@ describe("ListCompositeType batchHashTreeRoot", () => {
       expect(viewDU.sliceTo(1).batchHashTreeRoot()).toEqual(expectedRoot);
     });
   }
+});
+
+describe("ListCompositeType getAllReadOnly - no commit", () => {
+  it("getAllReadOnly() without commit", () => {
+    const listType = new ListCompositeType(ssz.Root, 1024);
+    const listLength = 2;
+    const list = Array.from({length: listLength}, (_, i) => Buffer.alloc(32, i));
+    let listView: ListCompositeTreeViewDU<typeof ssz.Root>;
+    listView = listType.toViewDU(list);
+    expect(listView.getAllReadonly()).to.deep.equal(list);
+
+    // modify
+    listView.set(0, Buffer.alloc(32, 1));
+    // push
+    listView.push(Buffer.alloc(32, 1));
+
+    // getAllReadOnly() without commit, now all items should be the same
+    expect(listView.getAllReadonly()).to.deep.equal(Array.from({length: 3}, () => Buffer.alloc(32, 1)));
+
+    // getAllReadOnlyValues() will throw
+    expect(() => listView.getAllReadonlyValues()).toThrow("Must commit changes before reading all nodes");
+  });
 });


### PR DESCRIPTION
**Motivation**
got `Must commit changes before reading all nodes` error in devnet-5 of electra https://github.com/ChainSafe/lodestar/pull/7375

**Description**

- getAllReadonly() without commit
  - we should be able to populate nodes array up until the old length
  - then get from the pending change, if not then get from the ViewDU of loaded `this.nodes`
- getAllReadonlyValues() still need the commit change because we want the nodes of pending changes. So although the name is similar, it's different from `getllReadonly()`

**Steps to test or reproduce**

- unit test was added

cc @nflaig @wemeetagain 
