### PR TITLE
feat!: use named exports to expose different hashers

### DIFF
--- a/packages/persistent-merkle-tree/package.json
+++ b/packages/persistent-merkle-tree/package.json
@@ -3,8 +3,29 @@
   "version": "0.9.1",
   "description": "Merkle tree implemented as a persistent datastructure",
   "type": "module",
-  "main": "./lib/index.js",
-  "types": "./lib/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./lib/index.js"
+    },
+    "./hashtree": {
+      "import": "./lib/hasher/hashtree.js"
+    },
+    "./nobel": {
+      "import": "./lib/hasher/nobel.js"
+    },
+    "./as-sha256": {
+      "import": "./lib/hasher/as-sha256.js"
+    }
+  },
+  "typesVersions": {
+    "*": {
+      "*": [
+        "*",
+        "lib/*",
+        "lib/*/index"
+      ]
+    }
+  },
   "files": [
     "lib"
   ],

--- a/packages/persistent-merkle-tree/package.json
+++ b/packages/persistent-merkle-tree/package.json
@@ -5,16 +5,20 @@
   "type": "module",
   "exports": {
     ".": {
-      "import": "./lib/index.js"
+      "import": "./lib/index.js",
+      "types": "./lib/index.d.ts"
     },
     "./hashtree": {
-      "import": "./lib/hasher/hashtree.js"
+      "import": "./lib/hasher/hashtree.js",
+      "types": "./lib/hasher/hashtree.d.ts"
     },
-    "./nobel": {
-      "import": "./lib/hasher/nobel.js"
+    "./noble": {
+      "import": "./lib/hasher/noble.js",
+      "types": "./lib/hasher/noble.d.ts"
     },
     "./as-sha256": {
-      "import": "./lib/hasher/as-sha256.js"
+      "import": "./lib/hasher/as-sha256.js",
+      "types": "./lib/hasher/as-sha256.d.ts"
     }
   },
   "typesVersions": {

--- a/setHasher.mjs
+++ b/setHasher.mjs
@@ -1,7 +1,7 @@
 // Set the hasher to hashtree
 // Used to run benchmarks with with visibility into hashtree performance, useful for Lodestar
-import {setHasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/index.js";
-import {hasher} from "@chainsafe/persistent-merkle-tree/lib/hasher/hashtree.js";
+import {setHasher} from "@chainsafe/persistent-merkle-tree";
+import {hasher} from "@chainsafe/persistent-merkle-tree/hashtree";
 setHasher(hasher);
 
 export {};


### PR DESCRIPTION
**Motivation**

Allow users to easily choose the hasher. 

**Description**

- Use named exports for different hashers 
- Limit users to not load build directories directly

**Steps to test or reproduce**

Run all tests