### PR TITLE
fix: update npm publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Check npm config
         run: npm config list
           
-      - run: node_modules/.bin/lerna exec --ignore root --ignore simpleserialize.com --no-private "npm publish --access public"
+      - run: node_modules/.bin/lerna publish from-package --no-verify-access
         if: ${{ steps.release.outputs.releases_created }}
 
 


### PR DESCRIPTION
Update npm publish to how it was "before" yarn 3 migration - see https://github.com/ChainSafe/ssz/pull/290/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L17
