### PR TITLE
feat: forEach() api for ArrayComposite()

### DIFF
--- a/packages/ssz/src/view/arrayBasic.ts
+++ b/packages/ssz/src/view/arrayBasic.ts
@@ -87,14 +87,18 @@ export class ArrayBasicTreeView<ElementType extends BasicType<unknown>> extends 
 
   /**
    * Get all values of this array as Basic element type values, from index zero to `this.length - 1`
+   * @param values optional output parameter, if is provided it must be an array of the same length as this array
    */
-  getAll(): ValueOf<ElementType>[] {
+  getAll(values?: ValueOf<ElementType>[]): ValueOf<ElementType>[] {
+    if (values && values.length !== this.length) {
+      throw Error(`Expected ${this.length} values, got ${values.length}`);
+    }
     const length = this.length;
     const chunksNode = this.type.tree_getChunksNode(this.node);
     const chunkCount = Math.ceil(length / this.type.itemsPerChunk);
     const leafNodes = getNodesAtDepth(chunksNode, this.type.chunkDepth, 0, chunkCount) as LeafNode[];
 
-    const values = new Array<ValueOf<ElementType>>(length);
+    values = values ?? new Array<ValueOf<ElementType>>(length);
     const itemsPerChunk = this.type.itemsPerChunk; // Prevent many access in for loop below
     const lenFullNodes = Math.floor(length / itemsPerChunk);
     const remainder = length % itemsPerChunk;

--- a/packages/ssz/src/view/arrayComposite.ts
+++ b/packages/ssz/src/view/arrayComposite.ts
@@ -73,12 +73,16 @@ export class ArrayCompositeTreeView<
    * Returns an array of views of all elements in the array, from index zero to `this.length - 1`.
    * The returned views don't have a parent hook to this View's Tree, so changes in the returned views won't be
    * propagated upwards. To get linked element Views use `this.get()`
+   * @param views optional output parameter, if is provided it must be an array of the same length as this array
    */
-  getAllReadonly(): CompositeView<ElementType>[] {
+  getAllReadonly(views?: CompositeView<ElementType>[]): CompositeView<ElementType>[] {
+    if (views && views.length !== this.length) {
+      throw Error(`Expected ${this.length} views, got ${views.length}`);
+    }
     const length = this.length;
     const chunksNode = this.type.tree_getChunksNode(this.node);
     const nodes = getNodesAtDepth(chunksNode, this.type.chunkDepth, 0, length);
-    const views = new Array<CompositeView<ElementType>>(length);
+    views = views ?? new Array<CompositeView<ElementType>>(length);
     for (let i = 0; i < length; i++) {
       // TODO: Optimize
       views[i] = this.type.elementType.getView(new Tree(nodes[i]));
@@ -90,12 +94,16 @@ export class ArrayCompositeTreeView<
    * Returns an array of values of all elements in the array, from index zero to `this.length - 1`.
    * The returned values are not Views so any changes won't be propagated upwards.
    * To get linked element Views use `this.get()`
+   * @param values optional output parameter, if is provided it must be an array of the same length as this array
    */
-  getAllReadonlyValues(): ValueOf<ElementType>[] {
+  getAllReadonlyValues(values?: ValueOf<ElementType>[]): ValueOf<ElementType>[] {
+    if (values && values.length !== this.length) {
+      throw Error(`Expected ${this.length} values, got ${values.length}`);
+    }
     const length = this.length;
     const chunksNode = this.type.tree_getChunksNode(this.node);
     const nodes = getNodesAtDepth(chunksNode, this.type.chunkDepth, 0, length);
-    const values = new Array<ValueOf<ElementType>>(length);
+    values = values ?? new Array<ValueOf<ElementType>>(length);
     for (let i = 0; i < length; i++) {
       values[i] = this.type.elementType.tree_toValue(nodes[i]);
     }

--- a/packages/ssz/src/viewDU/arrayBasic.ts
+++ b/packages/ssz/src/viewDU/arrayBasic.ts
@@ -109,8 +109,12 @@ export class ArrayBasicTreeViewDU<ElementType extends BasicType<unknown>> extend
 
   /**
    * Get all values of this array as Basic element type values, from index zero to `this.length - 1`
+   * @param values optional output parameter, if is provided it must be an array of the same length as this array
    */
-  getAll(): ValueOf<ElementType>[] {
+  getAll(values?: ValueOf<ElementType>[]): ValueOf<ElementType>[] {
+    if (values && values.length !== this._length) {
+      throw Error(`Expected ${this._length} values, got ${values.length}`);
+    }
     if (!this.nodesPopulated) {
       const nodesPrev = this.nodes;
       const chunksNode = this.type.tree_getChunksNode(this.node);
@@ -125,7 +129,7 @@ export class ArrayBasicTreeViewDU<ElementType extends BasicType<unknown>> extend
       this.nodesPopulated = true;
     }
 
-    const values = new Array<ValueOf<ElementType>>(this._length);
+    values = values ?? new Array<ValueOf<ElementType>>(this._length);
     const itemsPerChunk = this.type.itemsPerChunk; // Prevent many access in for loop below
     const lenFullNodes = Math.floor(this._length / itemsPerChunk);
     const remainder = this._length % itemsPerChunk;


### PR DESCRIPTION
**Motivation**

- avoid memory allocation when consumer want to loop through all item of a ListComposite

**Description**

- new `forEach() & forEachValue()` api: no memory allocation for array needed
- optional "out" param for getAll() apis so that consumer can allocate memory once and reuse if they want to

cherry-picked from #417