### PR TITLE
fix: do not rebind node if unchanged child ViewDUs

### DIFF
--- a/packages/ssz/src/viewDU/arrayComposite.ts
+++ b/packages/ssz/src/viewDU/arrayComposite.ts
@@ -195,9 +195,12 @@ export class ArrayCompositeTreeViewDU<
 
     for (const [index, view] of this.viewsChanged) {
       const node = this.type.elementType.commitViewDU(view, offsetView, byLevelView);
-      // Set new node in nodes array to ensure data represented in the tree and fast nodes access is equal
-      this.nodes[index] = node;
-      nodesChanged.push({index, node});
+      // there's a chance the view is not changed, no need to rebind nodes in that case
+      if (this.nodes[index] !== node) {
+        // Set new node in nodes array to ensure data represented in the tree and fast nodes access is equal
+        this.nodes[index] = node;
+        nodesChanged.push({index, node});
+      }
 
       // Cache the view's caches to preserve it's data after 'this.viewsChanged.clear()'
       const cache = this.type.elementType.cacheOfViewDU(view);

--- a/packages/ssz/src/viewDU/container.ts
+++ b/packages/ssz/src/viewDU/container.ts
@@ -101,9 +101,12 @@ export class BasicContainerTreeViewDU<Fields extends Record<string, Type<unknown
     for (const [index, view] of this.viewsChanged) {
       const fieldType = this.type.fieldsEntries[index].fieldType as unknown as CompositeTypeAny;
       const node = fieldType.commitViewDU(view, offsetView, byLevelView);
-      // Set new node in nodes array to ensure data represented in the tree and fast nodes access is equal
-      this.nodes[index] = node;
-      nodesChanged.push({index, node});
+      // there's a chance the view is not changed, no need to rebind nodes in that case
+      if (this.nodes[index] !== node) {
+        // Set new node in nodes array to ensure data represented in the tree and fast nodes access is equal
+        this.nodes[index] = node;
+        nodesChanged.push({index, node});
+      }
 
       // Cache the view's caches to preserve it's data after 'this.viewsChanged.clear()'
       const cache = fieldType.cacheOfViewDU(view);

--- a/packages/ssz/test/unit/unchangedViewDUs.test.ts
+++ b/packages/ssz/test/unit/unchangedViewDUs.test.ts
@@ -5,7 +5,7 @@ import {getRandomState} from "../utils/generateEth2Objs.js";
 describe("Unchanged ViewDUs", () => {
   const state = sszAltair.BeaconState.toViewDU(getRandomState(100));
 
-  it.skip("should not recompute batchHashTreeRoot() when no fields is changed", () => {
+  it("should not recompute batchHashTreeRoot() when no fields is changed", () => {
     const root = state.batchHashTreeRoot();
     // this causes viewsChanged inside BeaconState container
     state.validators.length;


### PR DESCRIPTION
**Motivation**

- some child ViewDUs are not changed for read-only operations, however parent still rebind it, see #379

**Description**

- do not rebind in that case. This applies for Container and ArrayComposite
- this was cherry-picked from #417 to make it easier to review

Closes #379

