### PR TITLE
feat: get list composite by range

### DIFF
--- a/packages/ssz/src/viewDU/arrayComposite.ts
+++ b/packages/ssz/src/viewDU/arrayComposite.ts
@@ -189,6 +189,7 @@ export class ArrayCompositeTreeViewDU<
     if (startIndex >= originalLength) {
       return [];
     }
+    count = Math.min(count, originalLength - startIndex);
 
     let dataAvailable = true;
     for (let i = startIndex; i < startIndex + count; i++) {
@@ -198,7 +199,7 @@ export class ArrayCompositeTreeViewDU<
       }
     }
 
-    count = Math.min(count, originalLength - startIndex);
+    // if one of nodes is not available, get all nodes at depth
     if (!dataAvailable) {
       const nodes = getNodesAtDepth(this._rootNode, this.type.depth, startIndex, count);
       for (const [i, node] of nodes.entries()) {

--- a/packages/ssz/src/viewDU/arrayComposite.ts
+++ b/packages/ssz/src/viewDU/arrayComposite.ts
@@ -187,13 +187,14 @@ export class ArrayCompositeTreeViewDU<
 
     const originalLength = this.dirtyLength ? this.type.tree_getLength(this._rootNode) : this._length;
     if (startIndex >= originalLength) {
-      return [];
+      throw Error(`Error getting by range, startIndex >= length: ${startIndex} >= ${originalLength}`);
     }
+
     count = Math.min(count, originalLength - startIndex);
 
     let dataAvailable = true;
     for (let i = startIndex; i < startIndex + count; i++) {
-      if (this.nodes[i] === undefined) {
+      if (this.nodes[i] == null) {
         dataAvailable = false;
         break;
       }

--- a/packages/ssz/test/unit/byType/listComposite/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listComposite/tree.test.ts
@@ -339,7 +339,7 @@ describe("ListCompositeType batchHashTreeRoot", () => {
   }
 });
 
-describe("ListCompositeType getAllReadOnly - no commit", () => {
+describe("ListCompositeType", () => {
   it("getAllReadOnly() without commit", () => {
     const listType = new ListCompositeType(ssz.Root, 1024);
     const listLength = 2;
@@ -357,5 +357,26 @@ describe("ListCompositeType getAllReadOnly - no commit", () => {
 
     // getAllReadOnlyValues() will throw
     expect(() => listView.getAllReadonlyValues()).toThrow("Must commit changes before reading all nodes");
+  });
+
+  it("getReadonlyByRange", () => {
+    const listType = new ListCompositeType(ssz.Root, 1024);
+    for (const listLength of [5, 10, 15, 20]) {
+      const list = Array.from({length: listLength}, (_, i) => Buffer.alloc(32, i));
+      const listView = listType.toViewDU(list);
+
+      const total: Buffer[] = [];
+      let start = 0;
+      const count = 10;
+      // this is equivalent to getAllReadonly()
+      // but consumer can break in the middle to improve performance
+      while (start < listLength) {
+        listView.getReadonlyByRange(start, count).forEach((item) => total.push(item as Buffer));
+        start += count;
+      }
+
+      expect(total.length).to.equal(listLength);
+      expect(total).to.deep.equal(list);
+    }
   });
 });

--- a/packages/ssz/test/unit/byType/listComposite/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listComposite/tree.test.ts
@@ -361,22 +361,29 @@ describe("ListCompositeType", () => {
 
   it("getReadonlyByRange", () => {
     const listType = new ListCompositeType(ssz.Root, 1024);
-    for (const listLength of [5, 10, 15, 20]) {
-      const list = Array.from({length: listLength}, (_, i) => Buffer.alloc(32, i));
-      const listView = listType.toViewDU(list);
 
-      const total: Buffer[] = [];
-      let start = 0;
-      const count = 10;
-      // this is equivalent to getAllReadonly()
-      // but consumer can break in the middle to improve performance
-      while (start < listLength) {
-        listView.getReadonlyByRange(start, count).forEach((item) => total.push(item as Buffer));
-        start += count;
+    for (const loadNodes of [false, true]) {
+      for (const listLength of [5, 10, 15, 20]) {
+        const list = Array.from({length: listLength}, (_, i) => Buffer.alloc(32, i));
+        const listView = listType.toViewDU(list);
+
+        if (loadNodes) {
+          listView.getAllReadonly();
+        }
+
+        const total: Buffer[] = [];
+        let start = 0;
+        const count = 10;
+        // this is equivalent to getAllReadonly()
+        // but consumer can break in the middle to improve performance
+        while (start < listLength) {
+          listView.getReadonlyByRange(start, count).forEach((item) => total.push(item as Buffer));
+          start += count;
+        }
+
+        expect(total.length).to.equal(listLength);
+        expect(total).to.deep.equal(list);
       }
-
-      expect(total.length).to.equal(listLength);
-      expect(total).to.deep.equal(list);
     }
   });
 });

--- a/packages/ssz/test/unit/byType/listComposite/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listComposite/tree.test.ts
@@ -363,7 +363,7 @@ describe("ListCompositeType", () => {
     const listType = new ListCompositeType(ssz.Root, 1024);
 
     for (const loadNodes of [false, true]) {
-      for (const listLength of [5, 10, 15, 20]) {
+      for (const listLength of [5, 10, 15, 20, 21, 22, 23, 24, 25]) {
         const list = Array.from({length: listLength}, (_, i) => Buffer.alloc(32, i));
         const listView = listType.toViewDU(list);
 

--- a/packages/ssz/test/unit/byType/listComposite/tree.test.ts
+++ b/packages/ssz/test/unit/byType/listComposite/tree.test.ts
@@ -385,5 +385,13 @@ describe("ListCompositeType", () => {
         expect(total).to.deep.equal(list);
       }
     }
+
+    // test the bound of "count" parameter
+    const list = Array.from({length: 10}, (_, i) => Buffer.alloc(32, i));
+    const listView = listType.toViewDU(list);
+    for (let start = 5; start < 10; start++) {
+      const items = listView.getReadonlyByRange(start, list.length);
+      expect(items.length).to.equal(list.length - start);
+    }
   });
 });


### PR DESCRIPTION
**Motivation**

- when the list length is big, application may want to get by chunk instead of get all of items because logic may break in the middle and using `getAllReadonly()` is not performant

see https://github.com/ChainSafe/lodestar/issues/7565

**Description**

- implement `getReadonlyByRange()` api
- unit test added
