### PR TITLE
feat: hashInto() and digest64Into() api

### DIFF
--- a/packages/as-sha256/src/index.ts
+++ b/packages/as-sha256/src/index.ts
@@ -54,6 +54,19 @@ export function digest64(data: Uint8Array): Uint8Array {
   throw new Error("InvalidLengthForDigest64");
 }
 
+export function digest64Into(data: Uint8Array, output: Uint8Array): void {
+  if (data.length !== 64) {
+    throw new Error("InvalidLengthForDigest64, got" + data.length);
+  }
+  if (output.length !== 32) {
+    throw new Error("InvalidLengthForOutput32, got" + output.length);
+  }
+
+  inputUint8Array.set(data);
+  ctx.digest64(wasmInputValue, wasmOutputValue);
+  output.set(outputUint8Array32);
+}
+
 export function digest2Bytes32(bytes1: Uint8Array, bytes2: Uint8Array): Uint8Array {
   if (bytes1.length === 32 && bytes2.length === 32) {
     inputUint8Array.set(bytes1);
@@ -62,6 +75,20 @@ export function digest2Bytes32(bytes1: Uint8Array, bytes2: Uint8Array): Uint8Arr
     return allocDigest();
   }
   throw new Error("InvalidLengthForDigest64");
+}
+
+export function digest2Bytes32Into(bytes1: Uint8Array, bytes2: Uint8Array, output: Uint8Array): void {
+  if (bytes1.length !== 32 || bytes2.length !== 32) {
+    throw new Error("InvalidLengthForDigest64");
+  }
+  if (output.length !== 32) {
+    throw new Error("InvalidLengthForOutput32");
+  }
+
+  inputUint8Array.set(bytes1);
+  inputUint8Array.set(bytes2, 32);
+  ctx.digest64(wasmInputValue, wasmOutputValue);
+  output.set(outputUint8Array32);
 }
 
 /**

--- a/packages/as-sha256/test/unit/index.test.ts
+++ b/packages/as-sha256/test/unit/index.test.ts
@@ -5,8 +5,10 @@ import {
   byteArrayToHashObject,
   digest,
   digest2Bytes32,
+  digest2Bytes32Into,
   digest64,
   digest64HashObjects,
+  digest64Into,
   hashObjectToByteArray,
 } from "../../src/index.js";
 
@@ -74,11 +76,15 @@ describe("as-sha256 non-SIMD enabled methods", () => {
     }
   });
 
-  it("digest64()", () => {
+  it("digest64() and digest64Into()", () => {
     const input = Buffer.alloc(64, "lodestar");
     const output = Buffer.from(digest64(input)).toString("hex");
     const expected = createHash("sha256").update(input).digest("hex");
     expect(output).to.equal(expected);
+
+    const output2 = Buffer.alloc(32);
+    digest64Into(input, output2);
+    expect(output2.toString("hex")).to.equal(expected);
   });
 
   it("digest() and digest64() output matches", () => {
@@ -88,7 +94,7 @@ describe("as-sha256 non-SIMD enabled methods", () => {
     expect(output).to.be.equal(output64);
   });
 
-  it("digest2Bytes32()", () => {
+  it("digest2Bytes32() and digest2Bytes32Into()", () => {
     const input1 = randomBytes(32);
     const input2 = randomBytes(32);
     const output = Buffer.from(digest2Bytes32(input1, input2)).toString("hex");
@@ -96,6 +102,10 @@ describe("as-sha256 non-SIMD enabled methods", () => {
       .update(Buffer.of(...input1, ...input2))
       .digest("hex");
     expect(output).to.equal(expectedOutput);
+
+    const output2 = Buffer.alloc(32);
+    digest2Bytes32Into(input1, input2, output2);
+    expect(output2.toString("hex")).to.equal(expectedOutput);
   });
 
   it("digest2Bytes32() matches digest64()", () => {

--- a/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
+++ b/packages/persistent-merkle-tree/src/hasher/as-sha256.ts
@@ -1,6 +1,7 @@
 import {
   batchHash4HashObjectInputs,
   digest2Bytes32,
+  digest2Bytes32Into,
   digest64HashObjects,
   digest64HashObjectsInto,
   hashInto,
@@ -18,7 +19,9 @@ const buffer = new Uint8Array(4 * BLOCK_SIZE);
 
 export const hasher: Hasher = {
   name: "as-sha256",
+  hashInto,
   digest64: digest2Bytes32,
+  digest64Into: digest2Bytes32Into,
   digest64HashObjects: digest64HashObjectsInto,
   merkleizeBlocksBytes(blocksBytes: Uint8Array, padFor: number, output: Uint8Array, offset: number): void {
     doMerkleizeBlocksBytes(blocksBytes, padFor, output, offset, hashInto);

--- a/packages/persistent-merkle-tree/src/hasher/hashtree.ts
+++ b/packages/persistent-merkle-tree/src/hasher/hashtree.ts
@@ -26,6 +26,7 @@ const destNodes: Node[] = new Array<Node>(PARALLEL_FACTOR);
 
 export const hasher: Hasher = {
   name: "hashtree",
+  hashInto,
   digest64(obj1: Uint8Array, obj2: Uint8Array): Uint8Array {
     if (obj1.length !== 32 || obj2.length !== 32) {
       throw new Error("Invalid input length");
@@ -34,6 +35,18 @@ export const hasher: Hasher = {
     hash64Input.set(obj2, 32);
     hashInto(hash64Input, hash64Output);
     return hash64Output.slice();
+  },
+  digest64Into: (obj1: Uint8Array, obj2: Uint8Array, output: Uint8Array): void => {
+    if (obj1.length !== 32 || obj2.length !== 32) {
+      throw new Error("Invalid input length");
+    }
+    if (output.length !== 32) {
+      throw new Error("Invalid output length");
+    }
+
+    hash64Input.set(obj1, 0);
+    hash64Input.set(obj2, 32);
+    hashInto(hash64Input, output);
   },
   digest64HashObjects(left: HashObject, right: HashObject, parent: HashObject): void {
     hashObjectsToUint32Array(left, right, uint32Input);

--- a/packages/persistent-merkle-tree/src/hasher/noble.ts
+++ b/packages/persistent-merkle-tree/src/hasher/noble.ts
@@ -9,6 +9,8 @@ import {
   hashObjectToUint8Array,
 } from "./util.js";
 
+const hash64Input = new Uint8Array(64);
+
 const digest64 = (a: Uint8Array, b: Uint8Array): Uint8Array => sha256.create().update(a).update(b).digest();
 const hashInto = (input: Uint8Array, output: Uint8Array): void => {
   if (input.length % 64 !== 0) {
@@ -33,7 +35,20 @@ const buffer = new Uint8Array(4 * BLOCK_SIZE);
 
 export const hasher: Hasher = {
   name: "noble",
+  hashInto,
   digest64,
+  digest64Into: (a, b, output) => {
+    if (a.length !== 32 || b.length !== 32) {
+      throw new Error("Invalid input length");
+    }
+    if (output.length !== 32) {
+      throw new Error("Invalid output length");
+    }
+
+    hash64Input.set(a, 0);
+    hash64Input.set(b, 32);
+    hashInto(hash64Input, output);
+  },
   digest64HashObjects: (left, right, parent) => {
     byteArrayIntoHashObject(digest64(hashObjectToUint8Array(left), hashObjectToUint8Array(right)), 0, parent);
   },

--- a/packages/persistent-merkle-tree/src/hasher/types.ts
+++ b/packages/persistent-merkle-tree/src/hasher/types.ts
@@ -7,9 +7,18 @@ export type Hasher = {
   // name of the hashing library
   name: string;
   /**
+   * Hash input Uint8Array into output Uint8Array
+   * output.length = input.length / 2
+   */
+  hashInto(input: Uint8Array, output: Uint8Array): void;
+  /**
    * Hash two 32-byte Uint8Arrays
    */
   digest64(a32Bytes: Uint8Array, b32Bytes: Uint8Array): Uint8Array;
+  /**
+   * The same to digest64, but output is passed as argument
+   */
+  digest64Into(a32Bytes: Uint8Array, b32Bytes: Uint8Array, output: Uint8Array): void;
   /**
    * Hash two 32-byte HashObjects
    */

--- a/packages/persistent-merkle-tree/test/perf/hasher.test.ts
+++ b/packages/persistent-merkle-tree/test/perf/hasher.test.ts
@@ -6,6 +6,8 @@ import {hasher as nobleHasher} from "../../src/hasher/noble.js";
 import {HashComputationLevel, getHashComputations} from "../../src/index.js";
 import {buildComparisonTrees} from "../utils/tree.js";
 
+const PARALLEL_FACTOR = 16;
+
 describe("hasher", () => {
   const iterations = 500_000;
 
@@ -18,20 +20,38 @@ describe("hasher", () => {
     root2[i] = 2;
   }
 
+  const batchInput = new Uint8Array(PARALLEL_FACTOR * 64).fill(1);
+  const batchOutput = new Uint8Array(PARALLEL_FACTOR * 32);
   const hashers: Hasher[] = [hashtreeHasher, asSha256Hasher, nobleHasher];
 
   const runsFactor = 10;
   for (const hasher of hashers) {
     describe(hasher.name, () => {
       bench({
-        id: `hash 2 Uint8Array ${iterations} times - ${hasher.name}`,
+        id: `hash 2 32 bytes Uint8Array ${iterations} times - ${hasher.name}`,
         fn: () => {
+          const output = new Uint8Array(32);
           for (let i = 0; i < runsFactor; i++) {
-            for (let j = 0; j < iterations; j++) hasher.digest64(root1, root2);
+            // should not use `hasher.digest64` here because of memory allocation, and it's not comparable
+            // to the batch hash test below and `digest64HashObjects`
+            for (let j = 0; j < iterations; j++) hasher.digest64Into(root1, root2, output);
           }
         },
         runsFactor,
       });
+
+      // use this test to see how faster batch hash is compared to single hash in `digest64`
+      bench({
+        id: `batch hash ${PARALLEL_FACTOR} x 64 Uint8Array ${iterations / PARALLEL_FACTOR} times - ${hasher.name}`,
+        fn: () => {
+          for (let i = 0; i < runsFactor; i++) {
+            for (let j = 0; j < iterations / PARALLEL_FACTOR; j++) {
+              hasher.hashInto(batchInput, batchOutput);
+            }
+          }
+        },
+        runsFactor,
+      })
 
       bench({
         id: `hashTwoObjects ${iterations} times - ${hasher.name}`,
@@ -49,6 +69,7 @@ describe("hasher", () => {
         runsFactor,
       });
 
+      // use to compare performance between hashers
       bench({
         id: `executeHashComputations - ${hasher.name}`,
         beforeEach: () => {
@@ -78,6 +99,7 @@ describe("hashtree", () => {
     },
   });
 
+  // compare this to "get root" to see how efficient the hash computation is
   bench({
     id: "executeHashComputations",
     beforeEach: () => {
@@ -91,6 +113,7 @@ describe("hashtree", () => {
     },
   });
 
+  // the traditional/naive way of getting the root
   bench({
     id: "get root",
     beforeEach: async () => {


### PR DESCRIPTION
**Motivation**

- we have inefficient `executeHashComputations()` on Linux but have no idea how much overhead of this function

**Description**

- add more benchmarks to compare how much batch hash is better for each hasher
- the `hashInto()` is not comparable to `digest64()` because `digest64()` causes memory allocation, so I implemented `*Into()` apis to make a fair comparison
- for some scenarios in lodestar, it's better to use "*Into" apis
