### PR TITLE
fix: check for AVX and return as-sha256 is missing

### DIFF
--- a/packages/persistent-merkle-tree/package.json
+++ b/packages/persistent-merkle-tree/package.json
@@ -58,9 +58,13 @@
     "url": "https://github.com/ChainSafe/persistent-merkle-tree/issues"
   },
   "homepage": "https://github.com/ChainSafe/persistent-merkle-tree#readme",
+  "devDependencies": {
+    "@types/cpu-features": "^0.0.3"
+  },
   "dependencies": {
     "@chainsafe/as-sha256": "1.1.0",
     "@chainsafe/hashtree": "1.0.1",
-    "@noble/hashes": "^1.3.0"
+    "@noble/hashes": "^1.3.0",
+    "cpu-features": "^0.0.10"
   }
 }

--- a/packages/persistent-merkle-tree/src/hasher/hashtree.ts
+++ b/packages/persistent-merkle-tree/src/hasher/hashtree.ts
@@ -136,7 +136,9 @@ if (
   cpuFeatures.arch === "x86" &&
   !(cpuFeatures.flags.avx || cpuFeatures.flags.avx2 || cpuFeatures.flags.avx512f || cpuFeatures.flags.avx512vl)
 ) {
-  console.log("Hashtree hasher was requested but the CPU architecture does not support AVX, AVX2 or the correct AVX512 instruction sets. Falling back to as-sha256 hasher instead.")
+  console.log(
+    "Hashtree hasher was requested but the CPU architecture does not support AVX, AVX2 or the correct AVX512 instruction sets. Falling back to as-sha256 hasher instead."
+  );
   hasher = asSha256Hasher;
 }
 

--- a/packages/persistent-merkle-tree/src/hasher/hashtree.ts
+++ b/packages/persistent-merkle-tree/src/hasher/hashtree.ts
@@ -136,6 +136,7 @@ if (
   cpuFeatures.arch === "x86" &&
   !(cpuFeatures.flags.avx || cpuFeatures.flags.avx2 || cpuFeatures.flags.avx512f || cpuFeatures.flags.avx512vl)
 ) {
+  console.log("Hashtree hasher was requested but the CPU architecture does not support AVX, AVX2 or the correct AVX512 instruction sets. Falling back to as-sha256 hasher instead.")
   hasher = asSha256Hasher;
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3009,6 +3009,11 @@
   resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
   integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
 
+"@types/cpu-features@^0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@types/cpu-features/-/cpu-features-0.0.3.tgz#a2bec076eb5dc95e0a6c23d1f8d389be4109b309"
+  integrity sha512-W/Ep+LDZoxMbCcH7LHRB3RN+TY4gbHl3u4uRq4XsxOh1gnpf5Lkwy5xWTBKSaJYQuMLW2XPAmRWA5Ucsy2EGVQ==
+
 "@types/deep-equal@^1.0.1":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@types/deep-equal/-/deep-equal-1.0.4.tgz#c0a854be62d6b9fae665137a6639aab53389a147"
@@ -4871,6 +4876,11 @@ buffer@^6.0.3:
     base64-js "^1.3.1"
     ieee754 "^1.2.1"
 
+buildcheck@~0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/buildcheck/-/buildcheck-0.0.6.tgz#89aa6e417cfd1e2196e3f8fe915eb709d2fe4238"
+  integrity sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==
+
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
@@ -5684,6 +5694,14 @@ cosmiconfig@^8.2.0:
     js-yaml "^4.1.0"
     parse-json "^5.2.0"
     path-type "^4.0.0"
+
+cpu-features@^0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/cpu-features/-/cpu-features-0.0.10.tgz#9aae536db2710c7254d7ed67cb3cbc7d29ad79c5"
+  integrity sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA==
+  dependencies:
+    buildcheck "~0.0.6"
+    nan "^2.19.0"
 
 crc-32@^1.2.0:
   version "1.2.2"
@@ -9822,6 +9840,11 @@ nan@^2.12.1:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.19.0.tgz#bb58122ad55a6c5bc973303908d5b16cfdd5a8c0"
   integrity sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==
+
+nan@^2.19.0:
+  version "2.22.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.22.2.tgz#6b504fd029fb8f38c0990e52ad5c26772fdacfbb"
+  integrity sha512-DANghxFkS1plDdRsX0X9pm0Z6SJNN6gBdtXfanwoZ8hooC5gosGFSBGRYHUVPz1asKA/kMRqDRdHrluZ61SpBQ==
 
 nanoid@^3.3.7:
   version "3.3.7"


### PR DESCRIPTION
**Motivation**

A crash was reported by several parties running Lodestar on a VPS.  The problem was tracked down to no AVX support on the host which causes OffchainLabs/hashtree to crash.  The go binding do a similar check, at the bindings level, and revert to a non-assembly SHA256 lib.  This PR does the same.  Checks the hardware for the supported AVX types and returns `as-sha256` hasher from the `hashtree` hasher so there is no crash.


https://github.com/OffchainLabs/hashtree/blob/67979dccfc99b02b488ed8f5fddee9f09aea411e/src/hashtree.c#L53-L67