### PR TITLE
fix: fix digest when input length = n * 64 - 1

### DIFF
--- a/packages/as-sha256/assembly/common.ts
+++ b/packages/as-sha256/assembly/common.ts
@@ -254,20 +254,15 @@ export function update(dataPtr: usize, dataLength: i32): void {
 }
 
 export function final(outPtr: usize): void {
-  // one additional round of hashes required
-  // because padding will not fit
-  if ((bytesHashed & 63) < 63) {
-    store8(mPtr, mLength, 0x80);
-    mLength++;
-  }
-  if ((bytesHashed & 63) >= 56) {
+  // add padding bit
+  store8(mPtr, mLength, 0x80);
+  mLength++;
+
+  // one additional round of hashes required if the input length can't fit in the current block
+  if (mLength > 56) {
     fill(mPtr + mLength, 0, 64 - mLength);
     hashBlocks(wPtr, mPtr, 1);
     mLength = 0;
-  }
-  if ((bytesHashed & 63) >= 63) {
-    store8(mPtr, mLength, 0x80);
-    mLength++;
   }
   fill(mPtr + mLength, 0, 64 - mLength - 8);
 

--- a/packages/as-sha256/test/unit/index.test.ts
+++ b/packages/as-sha256/test/unit/index.test.ts
@@ -139,4 +139,13 @@ describe("as-sha256 non-SIMD enabled methods", () => {
 
     expect(Buffer.from(output).toString("hex")).to.be.equal(Buffer.from(outputByteArray).toString("hex"));
   });
+
+  it("digest and node crypto match", () => {
+    for (let i = 0; i < 200; i++) {
+      const input = Buffer.alloc(i);
+      const output = Buffer.from(digest(input)).toString("hex");
+      const expectedOutput = createHash("sha256").update(input).digest().toString("hex");
+      expect(output).to.equal(expectedOutput, `Mismatch for input length ${i}`);
+    }
+  });
 });


### PR DESCRIPTION
**Motivation**

- resolve #488 

**Description**

- simplify (and correct) the padding logic (see https://www.rfc-editor.org/rfc/rfc6234#section-4)