### PR TITLE
fix: optimize the leaf node creation

### DIFF
--- a/packages/persistent-merkle-tree/src/packedNode.ts
+++ b/packages/persistent-merkle-tree/src/packedNode.ts
@@ -57,14 +57,14 @@ export function packedRootsBytesToLeafNodes(dataView: DataView, start: number, e
   for (let i = 0; i < fullNodeCount; i++) {
     const offset = start + i * 32;
     leafNodes[i] = new LeafNode(
-      dataView.getInt32(offset + 0, true),
-      dataView.getInt32(offset + 4, true),
-      dataView.getInt32(offset + 8, true),
-      dataView.getInt32(offset + 12, true),
-      dataView.getInt32(offset + 16, true),
-      dataView.getInt32(offset + 20, true),
-      dataView.getInt32(offset + 24, true),
-      dataView.getInt32(offset + 28, true)
+      dataView.getUint32(offset + 0, true),
+      dataView.getUint32(offset + 4, true),
+      dataView.getUint32(offset + 8, true),
+      dataView.getUint32(offset + 12, true),
+      dataView.getUint32(offset + 16, true),
+      dataView.getUint32(offset + 20, true),
+      dataView.getUint32(offset + 24, true),
+      dataView.getUint32(offset + 28, true)
     );
   }
 

--- a/packages/persistent-merkle-tree/src/packedNode.ts
+++ b/packages/persistent-merkle-tree/src/packedNode.ts
@@ -45,7 +45,7 @@ export function packedUintNum64sToLeafNodes(values: number[]): LeafNode[] {
  */
 export function packedRootsBytesToLeafNodes(dataView: DataView, start: number, end: number): Node[] {
   const size = end - start;
-  
+
   // If the offset in data is not a multiple of 4, Uint32Array can't be used
   // > start offset of Uint32Array should be a multiple of 4
   // NOTE: Performance tests show that using a DataView is as fast as Uint32Array
@@ -53,7 +53,7 @@ export function packedRootsBytesToLeafNodes(dataView: DataView, start: number, e
   const fullNodeCount = Math.floor(size / 32);
   const leafNodes = new Array<LeafNode>(Math.ceil(size / 32));
 
- // Efficiently construct the tree writing to hashObjects directly
+  // Efficiently construct the tree writing to hashObjects directly
   for (let i = 0; i < fullNodeCount; i++) {
     const offset = start + i * 32;
     leafNodes[i] = new LeafNode(
@@ -68,7 +68,7 @@ export function packedRootsBytesToLeafNodes(dataView: DataView, start: number, e
     );
   }
 
-// Consider that the last node may only include partial data
+  // Consider that the last node may only include partial data
   const remainderBytes = size % 32;
 
   // Instead of creating a LeafNode with zeros and then overwriting some properties, we do a
@@ -96,8 +96,14 @@ export function packedRootsBytesToLeafNodes(dataView: DataView, start: number, e
 
     // Create the partial node with all h values set once
     leafNodes[fullNodeCount] = new LeafNode(
-      hValues[0], hValues[1], hValues[2], hValues[3],
-      hValues[4], hValues[5], hValues[6], hValues[7]
+      hValues[0],
+      hValues[1],
+      hValues[2],
+      hValues[3],
+      hValues[4],
+      hValues[5],
+      hValues[6],
+      hValues[7]
     );
   }
 

--- a/packages/persistent-merkle-tree/src/packedNode.ts
+++ b/packages/persistent-merkle-tree/src/packedNode.ts
@@ -28,7 +28,14 @@ export function packedUintNum64sToLeafNodes(values: number[]): LeafNode[] {
   let i = 0; // index into values
   for (let nodeIndex = 0; nodeIndex < leaves; nodeIndex++) {
     // Pre-fill with zeros; we’ll assign the used slots below.
-    let h0 = 0, h1 = 0, h2 = 0, h3 = 0, h4 = 0, h5 = 0, h6 = 0, h7 = 0;
+    let h0 = 0,
+      h1 = 0,
+      h2 = 0,
+      h3 = 0,
+      h4 = 0,
+      h5 = 0,
+      h6 = 0,
+      h7 = 0;
 
     // Up to 4 uint64 numbers per leaf → 8 x uint32 words (lo,hi) pairs
     for (let slot = 0; slot < 4 && i < values.length; slot++, i++) {
@@ -45,10 +52,22 @@ export function packedUintNum64sToLeafNodes(values: number[]): LeafNode[] {
       }
 
       switch (slot) {
-        case 0: h0 = lo; h1 = hi; break;
-        case 1: h2 = lo; h3 = hi; break;
-        case 2: h4 = lo; h5 = hi; break;
-        case 3: h6 = lo; h7 = hi; break;
+        case 0:
+          h0 = lo;
+          h1 = hi;
+          break;
+        case 1:
+          h2 = lo;
+          h3 = hi;
+          break;
+        case 2:
+          h4 = lo;
+          h5 = hi;
+          break;
+        case 3:
+          h6 = lo;
+          h7 = hi;
+          break;
       }
     }
 
@@ -86,7 +105,6 @@ export function packedRootsBytesToLeafNodes(dataView: DataView, start: number, e
       dataView.getUint32(offset + 28, true)
     );
   }
-
 
   // Instead of creating a LeafNode with zeros and then overwriting some properties, we do a
   // single write in the constructor: We pass all eight hValues to the LeafNode constructor.


### PR DESCRIPTION
**Motivation**

Improve the performance of lead node creation during the packing values. 

**Description**

- Initialize primitive values instead of `LeafNode` object
- Create the `LeftNode` object once with those values. 

Based on the work started in this PR https://github.com/ChainSafe/ssz/pull/493

**Steps to test or reproduce**

Run all tests. 