### PR TITLE
fix: correct release workflow publish issues

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,14 +30,16 @@ jobs:
         if: ${{ steps.release.outputs.releases_created }}
 
       - uses: pnpm/action-setup@v4
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.releases_created }}
 
       - run: corepack enable
-      
+        if: ${{ steps.release.outputs.releases_created }}
+
       - uses: actions/setup-node@v6
         with:
           cache: 'pnpm'
           node-version: 20
+          registry-url: 'https://registry.npmjs.org'
         if: ${{ steps.release.outputs.releases_created }}
 
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- **Fix typo:** `release_created` (singular) → `releases_created` (plural) on the `pnpm/action-setup` step — this caused the step to silently be skipped on every release
- **Add missing conditional** to `corepack enable` so it only runs when a release is created
- **Add `registry-url`** to `actions/setup-node` so the OIDC token exchange can authenticate against npm for trusted publishing

## Test plan
- [ ] Verify release workflow runs correctly on next release-please PR merge
- [ ] Confirm npm packages are published with provenance

🤖 Generated with [Claude Code](https://claude.com/claude-code)