### PR TITLE
fix: restore NPM_TOKEN for publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,6 @@ on:
       - completed
 
 permissions:
-  id-token: write       # Required for OIDC
   contents: write       # Required to create a Github release
   pull-requests: write  # Required to add tags to pull requests
 
@@ -53,5 +52,7 @@ jobs:
       - run: pnpm build
         if: ${{ steps.release.outputs.releases_created }}
       
-      - run: pnpm publish -r --access public --provenance --no-git-check
+      - run: pnpm publish -r --access public --no-git-check
         if: ${{ steps.release.outputs.releases_created }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

Release workflow run [24694938027](https://github.com/ChainSafe/ssz/actions/runs/24694938027) failed with `npm error 404 Not Found - PUT https://registry.npmjs.org/@chainsafe%2fas-sha256` while trying to publish `@chainsafe/as-sha256@1.2.2` — the first actual publish attempt since #510 migrated the workflow to npm trusted publishing.

The 404 is npm's standard "auth failure on a scoped package" response. `actions/setup-node` wrote the placeholder `NODE_AUTH_TOKEN=XXXXX-XXXXX-XXXXX-XXXXX` into `.npmrc` because no token was supplied, and there is no per-package Trusted Publisher config on npmjs.com for the three packages in this monorepo:

| package | last publish | `dist.attestations` | `_npmUser` |
|---|---|---|---|
| `@chainsafe/as-sha256@1.2.0` | 2025-05-30 | none | wemeetagain (manual) |
| `@chainsafe/persistent-merkle-tree@1.2.1` | 2025-08-25 | none | wemeetagain (manual) |
| `@chainsafe/ssz@1.3.0` | 2025-11-22 | none | wemeetagain (manual) |

Every "success" run since #510 was a no-op because `steps.release.outputs.releases_created` was false. The first real run hit the 404.

This PR reverts the publish step to `secrets.NPM_TOKEN` and drops `--provenance` so 1.2.2 can ship today.

## Follow-up (separate)

To re-enable trusted publishing later, add a Trusted Publisher entry on npmjs.com for each of the three packages (Settings → Trusted Publishers → GitHub Actions, repo `ChainSafe/ssz`, workflow `release.yml`). Once all three exist, revert this PR and provenance attestations will appear on subsequent releases.

## Test plan

- [ ] Merge this + re-run release workflow on master; verify `@chainsafe/as-sha256@1.2.2`, `@chainsafe/persistent-merkle-tree@X.Y.Z`, `@chainsafe/ssz@X.Y.Z` land on the registry.

🤖 Generated with AI assistance