### PR TITLE
fix: correct repository.url for provenance validation

### DIFF
--- a/packages/as-sha256/package.json
+++ b/packages/as-sha256/package.json
@@ -10,7 +10,8 @@
   "homepage": "https://github.com/ChainSafe/ssz/tree/master/packages/as-sha256/#readme",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chainsafe/ssz.git"
+    "url": "git+https://github.com/ChainSafe/ssz.git",
+    "directory": "packages/as-sha256"
   },
   "type": "module",
   "main": "./lib/index.js",

--- a/packages/persistent-merkle-tree/package.json
+++ b/packages/persistent-merkle-tree/package.json
@@ -44,7 +44,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ChainSafe/persistent-merkle-tree.git"
+    "url": "git+https://github.com/ChainSafe/ssz.git",
+    "directory": "packages/persistent-merkle-tree"
   },
   "keywords": [
     "hash",

--- a/packages/persistent-ts/package.json
+++ b/packages/persistent-ts/package.json
@@ -19,7 +19,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/cronokirby/persistent-ts.git"
+    "url": "git+https://github.com/ChainSafe/ssz.git",
+    "directory": "packages/persistent-ts"
   },
   "keywords": [
     "persistent",

--- a/packages/ssz/package.json
+++ b/packages/ssz/package.json
@@ -3,8 +3,13 @@
   "description": "Simple Serialize",
   "license": "Apache-2.0",
   "author": "ChainSafe Systems",
-  "homepage": "https://github.com/chainsafe/ssz",
+  "homepage": "https://github.com/ChainSafe/ssz",
   "version": "1.3.3",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ChainSafe/ssz.git",
+    "directory": "packages/ssz"
+  },
   "type": "module",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
## Summary

After adding Trusted Publisher configs on npmjs.com, run [24720353770](https://github.com/ChainSafe/ssz/actions/runs/24720353770/job/72307323202) progressed past the 404 but now fails with E422 on provenance validation:

```
npm error 422 Unprocessable Entity - PUT https://registry.npmjs.org/@chainsafe%2fas-sha256
Error verifying sigstore provenance bundle: Failed to validate repository information:
package.json: "repository.url" is "git+https://github.com/chainsafe/ssz.git",
expected to match "https://github.com/ChainSafe/ssz" from provenance
```

npm's provenance verifier does a case-sensitive match between \`repository.url\` in \`package.json\` and the repo declared in the OIDC token (\`ChainSafe/ssz\`). All four workspace packages had drifted \`repository\` fields:

| package | before | after |
|---|---|---|
| \`@chainsafe/as-sha256\` | \`chainsafe/ssz\` (lowercase) | \`ChainSafe/ssz\` |
| \`@chainsafe/persistent-merkle-tree\` | \`ChainSafe/persistent-merkle-tree\` (old standalone repo) | \`ChainSafe/ssz\` |
| \`@chainsafe/persistent-ts\` | \`cronokirby/persistent-ts\` (upstream origin) | \`ChainSafe/ssz\` |
| \`@chainsafe/ssz\` | *(missing)* | \`ChainSafe/ssz\` |

Also added a \`directory\` subpath on each entry so npm/GitHub links resolve to the correct package folder, and fixed the lowercase \`homepage\` URL on \`@chainsafe/ssz\`.

## Test plan

- [ ] Merge, let release-please produce a fresh release PR bumping patch versions, merge it, and confirm the publish step succeeds with provenance attestations on all four packages.

🤖 Generated with AI assistance