### PR TITLE
feat: allow array-like input for VectorCompositeType views

### DIFF
--- a/packages/ssz/src/type/vectorComposite.ts
+++ b/packages/ssz/src/type/vectorComposite.ts
@@ -1,10 +1,11 @@
 import {HashComputationLevel, Node, Tree} from "@chainsafe/persistent-merkle-tree";
+import type {ArrayLike} from "../interface.ts";
 import {maxChunksToDepth} from "../util/merkleize.ts";
 import {namedClass} from "../util/named.ts";
 import {Require} from "../util/types.ts";
 import {ArrayCompositeTreeView, ArrayCompositeType} from "../view/arrayComposite.ts";
 import {ArrayCompositeTreeViewDU} from "../viewDU/arrayComposite.ts";
-import {ByteViews, ValueOf} from "./abstract.ts";
+import {ByteViews, Type, ValueOf} from "./abstract.ts";
 import {ArrayType} from "./array.ts";
 import {
   maxSizeArrayComposite,
@@ -18,6 +19,19 @@ import {
   value_serializedSizeArrayComposite,
 } from "./arrayComposite.ts";
 import {CompositeType, CompositeView, CompositeViewDU} from "./composite.ts";
+import type {ListBasicType} from "./listBasic.ts";
+import type {VectorBasicType} from "./vectorBasic.ts";
+
+/**
+ * Input element type accepted by the outer composite.
+ * When the element is a basic vector/list, allow any `ArrayLike` of the basic value
+ * (e.g. `Uint32Array` for a `VectorBasicType<UintNumberType>`), not only plain `number[]`.
+ */
+type CompositeElementInput<ElementType extends Type<unknown>> = ElementType extends VectorBasicType<infer B>
+  ? ArrayLike<ValueOf<B>>
+  : ElementType extends ListBasicType<infer B>
+    ? ArrayLike<ValueOf<B>>
+    : ValueOf<ElementType>;
 
 export type VectorCompositeOpts = {
   typeName?: string;
@@ -82,11 +96,27 @@ export class VectorCompositeType<
     return new ArrayCompositeTreeView(this, tree);
   }
 
+  toView(value: ValueOf<ElementType>[]): ArrayCompositeTreeView<ElementType>;
+  toView(value: ArrayLike<CompositeElementInput<ElementType>>): ArrayCompositeTreeView<ElementType>;
+  toView(
+    value: ValueOf<ElementType>[] | ArrayLike<CompositeElementInput<ElementType>>
+  ): ArrayCompositeTreeView<ElementType> {
+    return super.toView(value as ValueOf<ElementType>[]);
+  }
+
   getViewDU(node: Node, cache?: unknown): ArrayCompositeTreeViewDU<ElementType> {
     // cache type should be validated (if applicate) in the view
 
     // biome-ignore lint/suspicious/noExplicitAny: We need to use `any` here explicitly
     return new ArrayCompositeTreeViewDU(this, node, cache as any);
+  }
+
+  toViewDU(value: ValueOf<ElementType>[]): ArrayCompositeTreeViewDU<ElementType>;
+  toViewDU(value: ArrayLike<CompositeElementInput<ElementType>>): ArrayCompositeTreeViewDU<ElementType>;
+  toViewDU(
+    value: ValueOf<ElementType>[] | ArrayLike<CompositeElementInput<ElementType>>
+  ): ArrayCompositeTreeViewDU<ElementType> {
+    return super.toViewDU(value as ValueOf<ElementType>[]);
   }
 
   commitView(view: ArrayCompositeTreeView<ElementType>): Node {

--- a/packages/ssz/test/unit/byType/vectorComposite/tree.test.ts
+++ b/packages/ssz/test/unit/byType/vectorComposite/tree.test.ts
@@ -4,6 +4,7 @@ import {
   ContainerType,
   UintNumberType,
   ValueOf,
+  VectorBasicType,
   VectorCompositeType,
 } from "../../../../src/index.ts";
 import {runViewTestMutation} from "../runViewTestMutation.ts";
@@ -124,4 +125,28 @@ describe("VectorCompositeType batchHashTreeRoot", () => {
       expect(viewDU.batchHashTreeRoot()).toEqual(expectedRoot);
     });
   }
+});
+
+describe("VectorCompositeType of basic vector array-like input", () => {
+  const uint32VectorType = new VectorBasicType(new UintNumberType(4), 4);
+  const vectorOfVectorsType = new VectorCompositeType(uint32VectorType, 2);
+
+  const arrayInput = [
+    [1, 2, 3, 4],
+    [5, 6, 7, 8],
+  ];
+  const typedInput = [new Uint32Array([1, 2, 3, 4]), new Uint32Array([5, 6, 7, 8])];
+  const mixedInput = [[1, 2, 3, 4], new Uint32Array([5, 6, 7, 8])];
+
+  it("accepts Uint32Array[] in toView", () => {
+    expect(vectorOfVectorsType.toView(typedInput).toValue()).toEqual(arrayInput);
+  });
+
+  it("accepts Uint32Array[] in toViewDU", () => {
+    expect(vectorOfVectorsType.toViewDU(typedInput).toValue()).toEqual(arrayInput);
+  });
+
+  it("accepts mixed number[] | Uint32Array[] in toViewDU", () => {
+    expect(vectorOfVectorsType.toViewDU(mixedInput).toValue()).toEqual(arrayInput);
+  });
 });


### PR DESCRIPTION
Continuation of https://github.com/ChainSafe/ssz/pull/512, to apply the same change `VectorCompositeType` views

When the element is a `VectorBasicType` or `ListBasicType`, accept any `ArrayLike` (eg. `Uint32Array`) in place of `number[]`.