### PR TITLE
feat: add ephemeral fields to Container

### DIFF
--- a/packages/ssz/src/type/container.ts
+++ b/packages/ssz/src/type/container.ts
@@ -14,7 +14,14 @@ import {namedClass} from "../util/named.ts";
 import {Case} from "../util/strings.ts";
 import {Require} from "../util/types.ts";
 import {getContainerTreeViewClass} from "../view/container.ts";
-import {ContainerTreeViewType, ContainerTreeViewTypeConstructor, FieldEntry, ValueOfFields} from "../view/container.ts";
+import {
+  ContainerTreeViewType,
+  ContainerTreeViewTypeConstructor,
+  EphemeralFieldEntry,
+  EphemeralValueOfFields,
+  FieldEntry,
+  ValueOfFields,
+} from "../view/container.ts";
 import {
   ContainerTreeViewDUType,
   ContainerTreeViewDUTypeConstructor,
@@ -25,11 +32,21 @@ import {ByteViews, CompositeType, CompositeTypeAny} from "./composite.ts";
 
 type BytesRange = {start: number; end: number};
 
-export type ContainerOptions<Fields extends Record<string, unknown>> = {
+export type ContainerOptions<
+  Fields extends Record<string, unknown>,
+  EphemeralFields extends Record<string, Type<unknown>> = Record<string, never>,
+> = {
   typeName?: string;
   jsonCase?: KeyCase;
   casingMap?: CasingMap<Fields>;
   cachePermanentRootStruct?: boolean;
+  /**
+   * Optional declaration of additional fields that are NOT part of consensus serialization, hashing,
+   * JSON encoding, or equality. Ephemeral fields are accessible/settable on the value, View, and ViewDU
+   * (typed via their `Type`) but never affect any on-the-wire or merkle behavior. Useful for caching
+   * derived data on a container without forking the type.
+   */
+  ephemeralFields?: EphemeralFields;
   getContainerTreeViewClass?: typeof getContainerTreeViewClass;
   getContainerTreeViewDUClass?: typeof getContainerTreeViewDUClass;
 };
@@ -49,10 +66,13 @@ type CasingMap<Fields extends Record<string, unknown>> = Partial<{[K in keyof Fi
  * Container: ordered heterogeneous collection of values
  * - Notation: Custom name per instance
  */
-export class ContainerType<Fields extends Record<string, Type<unknown>>> extends CompositeType<
-  ValueOfFields<Fields>,
-  ContainerTreeViewType<Fields>,
-  ContainerTreeViewDUType<Fields>
+export class ContainerType<
+  Fields extends Record<string, Type<unknown>>,
+  EphemeralFields extends Record<string, Type<unknown>> = Record<string, never>,
+> extends CompositeType<
+  ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>,
+  ContainerTreeViewType<Fields, EphemeralFields>,
+  ContainerTreeViewDUType<Fields, EphemeralFields>
 > {
   readonly typeName: string;
   readonly depth: number;
@@ -65,6 +85,8 @@ export class ContainerType<Fields extends Record<string, Type<unknown>>> extends
 
   // Precomputed data for faster serdes
   readonly fieldsEntries: FieldEntry<Fields>[];
+  readonly ephemeralFields: EphemeralFields;
+  readonly ephemeralFieldsEntries: EphemeralFieldEntry<EphemeralFields>[];
   /** End of fixed section of serialized Container */
   readonly fixedEnd: number;
   protected readonly fieldsGindex: Record<keyof Fields, Gindex>;
@@ -75,12 +97,12 @@ export class ContainerType<Fields extends Record<string, Type<unknown>>> extends
   protected readonly variableOffsetsPosition: number[];
 
   /** Cached TreeView constuctor with custom prototype for this Type's properties */
-  protected readonly TreeView: ContainerTreeViewTypeConstructor<Fields>;
-  protected readonly TreeViewDU: ContainerTreeViewDUTypeConstructor<Fields>;
+  protected readonly TreeView: ContainerTreeViewTypeConstructor<Fields, EphemeralFields>;
+  protected readonly TreeViewDU: ContainerTreeViewDUTypeConstructor<Fields, EphemeralFields>;
 
   constructor(
     readonly fields: Fields,
-    readonly opts?: ContainerOptions<Fields>
+    readonly opts?: ContainerOptions<Fields, EphemeralFields>
   ) {
     super(opts?.cachePermanentRootStruct);
 
@@ -103,6 +125,26 @@ export class ContainerType<Fields extends Record<string, Type<unknown>>> extends
 
     if (this.fieldsEntries.length === 0) {
       throw Error("Container must have > 0 fields");
+    }
+
+    // Build ephemeralFieldsEntries. Ephemeral fields are NOT part of any consensus computation:
+    // they are excluded from maxChunkCount, gindex, serdes data, and chunk hashing. They exist
+    // only as application-level slots accessible on the value/View/ViewDU.
+    //
+    // NOTE: Avoid using ephemeral names that collide with View/ViewDU base-class members
+    // (`type`, `tree`, `node`, `cache`, `nodes`, etc.) — those properties are pre-existing on
+    // the view classes and the ephemeral accessor would conflict (often as a TS readonly error).
+    this.ephemeralFields = (opts?.ephemeralFields ?? ({} as EphemeralFields)) as EphemeralFields;
+    this.ephemeralFieldsEntries = [];
+    for (const fieldName of Object.keys(this.ephemeralFields) as (keyof EphemeralFields)[]) {
+      if (Object.prototype.hasOwnProperty.call(fields, fieldName as string)) {
+        throw Error(`Ephemeral field name '${String(fieldName as symbol)}' collides with a consensus field`);
+      }
+      this.ephemeralFieldsEntries.push({
+        fieldName,
+        fieldType: this.ephemeralFields[fieldName],
+        jsonKey: fieldName as string,
+      });
     }
 
     // Precalculate for Proofs API
@@ -143,37 +185,68 @@ export class ContainerType<Fields extends Record<string, Type<unknown>>> extends
     return new (namedClass(ContainerType, opts.typeName))(fields, opts);
   }
 
-  defaultValue(): ValueOfFields<Fields> {
+  defaultValue(): ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields> {
     const value = {} as ValueOfFields<Fields>;
     for (const {fieldName, fieldType} of this.fieldsEntries) {
       value[fieldName] = fieldType.defaultValue() as ValueOf<Fields[keyof Fields]>;
     }
-    return value;
+    // Ephemeral fields are intentionally omitted: they are optional and absent by default.
+    return value as ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>;
   }
 
-  getView(tree: Tree): ContainerTreeViewType<Fields> {
+  getView(tree: Tree): ContainerTreeViewType<Fields, EphemeralFields> {
     return new this.TreeView(this, tree);
   }
 
-  getViewDU(node: Node, cache?: unknown): ContainerTreeViewDUType<Fields> {
+  getViewDU(node: Node, cache?: unknown): ContainerTreeViewDUType<Fields, EphemeralFields> {
     return new this.TreeViewDU(this, node, cache);
   }
 
-  cacheOfViewDU(view: ContainerTreeViewDUType<Fields>): unknown {
+  cacheOfViewDU(view: ContainerTreeViewDUType<Fields, EphemeralFields>): unknown {
     return view.cache;
   }
 
-  commitView(view: ContainerTreeViewType<Fields>): Node {
+  commitView(view: ContainerTreeViewType<Fields, EphemeralFields>): Node {
     return view.node;
   }
 
   commitViewDU(
-    view: ContainerTreeViewDUType<Fields>,
+    view: ContainerTreeViewDUType<Fields, EphemeralFields>,
     hcOffset = 0,
     hcByLevel: HashComputationLevel[] | null = null
   ): Node {
     view.commit(hcOffset, hcByLevel);
     return view.node;
+  }
+
+  /**
+   * Override of {@link CompositeType.toView}: after building the tree-backed View, copy any present
+   * ephemeral fields from the source value onto the View's ephemeral storage. Ephemeral fields are
+   * not represented in the tree, so they would otherwise be lost.
+   */
+  toView(
+    value: ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>
+  ): ContainerTreeViewType<Fields, EphemeralFields> {
+    const view = super.toView(value);
+    for (const {fieldName} of this.ephemeralFieldsEntries) {
+      const v = (value as Record<string, unknown>)[fieldName as string];
+      if (v !== undefined) (view as unknown as Record<string, unknown>)[fieldName as string] = v;
+    }
+    return view;
+  }
+
+  /**
+   * Override of {@link CompositeType.toViewDU}: see {@link ContainerType.toView}.
+   */
+  toViewDU(
+    value: ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>
+  ): ContainerTreeViewDUType<Fields, EphemeralFields> {
+    const view = super.toViewDU(value);
+    for (const {fieldName} of this.ephemeralFieldsEntries) {
+      const v = (value as Record<string, unknown>)[fieldName as string];
+      if (v !== undefined) (view as unknown as Record<string, unknown>)[fieldName as string] = v;
+    }
+    return view;
   }
 
   // Serialization + deserialization
@@ -184,7 +257,7 @@ export class ContainerType<Fields extends Record<string, Type<unknown>>> extends
   // [field1 offset][field2 data       ][field1 data               ]
   // [0x000000c]    [0xaabbaabbaabbaabb][0xffffffffffffffffffffffff]
 
-  value_serializedSize(value: ValueOfFields<Fields>): number {
+  value_serializedSize(value: ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>): number {
     let totalSize = 0;
     for (let i = 0; i < this.fieldsEntries.length; i++) {
       const {fieldName, fieldType} = this.fieldsEntries[i];
@@ -195,7 +268,11 @@ export class ContainerType<Fields extends Record<string, Type<unknown>>> extends
     return totalSize;
   }
 
-  value_serializeToBytes(output: ByteViews, offset: number, value: ValueOfFields<Fields>): number {
+  value_serializeToBytes(
+    output: ByteViews,
+    offset: number,
+    value: ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>
+  ): number {
     let fixedIndex = offset;
     let variableIndex = offset + this.fixedEnd;
 
@@ -214,7 +291,12 @@ export class ContainerType<Fields extends Record<string, Type<unknown>>> extends
     return variableIndex;
   }
 
-  value_deserializeFromBytes(data: ByteViews, start: number, end: number, reuseBytes?: boolean): ValueOfFields<Fields> {
+  value_deserializeFromBytes(
+    data: ByteViews,
+    start: number,
+    end: number,
+    reuseBytes?: boolean
+  ): ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields> {
     const fieldRanges = this.getFieldRanges(data.dataView, start, end);
     const value = {} as {[K in keyof Fields]: unknown};
 
@@ -229,7 +311,7 @@ export class ContainerType<Fields extends Record<string, Type<unknown>>> extends
       );
     }
 
-    return value as ValueOfFields<Fields>;
+    return value as ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>;
   }
 
   tree_serializedSize(node: Node): number {
@@ -281,7 +363,7 @@ export class ContainerType<Fields extends Record<string, Type<unknown>>> extends
 
   // Merkleization
 
-  protected getBlocksBytes(struct: ValueOfFields<Fields>): Uint8Array {
+  protected getBlocksBytes(struct: ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>): Uint8Array {
     for (let i = 0; i < this.fieldsEntries.length; i++) {
       const {fieldName, fieldType} = this.fieldsEntries[i];
       fieldType.hashTreeRootInto(struct[fieldName], this.blocksBuffer, i * 32);
@@ -342,7 +424,7 @@ export class ContainerType<Fields extends Record<string, Type<unknown>>> extends
 
   // JSON
 
-  fromJson(json: unknown): ValueOfFields<Fields> {
+  fromJson(json: unknown): ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields> {
     if (typeof json !== "object") {
       throw Error("JSON must be of type object");
     }
@@ -360,22 +442,24 @@ export class ContainerType<Fields extends Record<string, Type<unknown>>> extends
       }
       value[fieldName] = fieldType.fromJson(jsonValue) as ValueOf<Fields[keyof Fields]>;
     }
-
-    return value;
+    // Ephemerals are intentionally not part of JSON encoding.
+    return value as ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>;
   }
 
-  toJson(value: ValueOfFields<Fields>): Record<string, unknown> {
+  toJson(value: ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>): Record<string, unknown> {
     const json: Record<string, unknown> = {};
 
     for (let i = 0; i < this.fieldsEntries.length; i++) {
       const {fieldName, fieldType, jsonKey} = this.fieldsEntries[i];
       json[jsonKey] = fieldType.toJson(value[fieldName]);
     }
-
+    // Ephemerals are intentionally not part of JSON encoding.
     return json;
   }
 
-  clone(value: ValueOfFields<Fields>): ValueOfFields<Fields> {
+  clone(
+    value: ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>
+  ): ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields> {
     const newValue = {} as ValueOfFields<Fields>;
 
     for (let i = 0; i < this.fieldsEntries.length; i++) {
@@ -383,17 +467,28 @@ export class ContainerType<Fields extends Record<string, Type<unknown>>> extends
       newValue[fieldName] = fieldType.clone(value[fieldName]) as ValueOf<Fields[keyof Fields]>;
     }
 
-    return newValue;
+    // Carry over present ephemeral fields, cloning each via its own type.
+    for (const {fieldName, fieldType} of this.ephemeralFieldsEntries) {
+      const v = (value as Record<string, unknown>)[fieldName as string];
+      if (v !== undefined) {
+        (newValue as Record<string, unknown>)[fieldName as string] = fieldType.clone(v);
+      }
+    }
+
+    return newValue as ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>;
   }
 
-  equals(a: ValueOfFields<Fields>, b: ValueOfFields<Fields>): boolean {
+  equals(
+    a: ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>,
+    b: ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>
+  ): boolean {
     for (let i = 0; i < this.fieldsEntries.length; i++) {
       const {fieldName, fieldType} = this.fieldsEntries[i];
       if (!fieldType.equals(a[fieldName], b[fieldName])) {
         return false;
       }
     }
-
+    // Ephemeral fields are NOT considered for equality — they are not part of consensus.
     return true;
   }
 

--- a/packages/ssz/src/type/containerNodeStruct.ts
+++ b/packages/ssz/src/type/containerNodeStruct.ts
@@ -2,7 +2,7 @@ import {Node} from "@chainsafe/persistent-merkle-tree";
 import {BranchNodeStruct} from "../branchNodeStruct.ts";
 import {namedClass} from "../util/named.ts";
 import {Require} from "../util/types.ts";
-import {ValueOfFields} from "../view/container.ts";
+import {EphemeralValueOfFields, ValueOfFields} from "../view/container.ts";
 import {getContainerTreeViewClass} from "../view/containerNodeStruct.ts";
 import {getContainerTreeViewDUClass} from "../viewDU/containerNodeStruct.ts";
 import {ByteViews, Type} from "./abstract.ts";
@@ -23,10 +23,13 @@ import {ContainerOptions, ContainerType, renderContainerTypeName} from "./contai
  *
  * This tradeoff is good for data that is read often, written rarely, and consumes a lot of memory (i.e. Validator)
  */
-export class ContainerNodeStructType<Fields extends Record<string, Type<unknown>>> extends ContainerType<Fields> {
+export class ContainerNodeStructType<
+  Fields extends Record<string, Type<unknown>>,
+  EphemeralFields extends Record<string, Type<unknown>> = Record<string, never>,
+> extends ContainerType<Fields, EphemeralFields> {
   constructor(
     readonly fields: Fields,
-    opts?: ContainerOptions<Fields>
+    opts?: ContainerOptions<Fields, EphemeralFields>
   ) {
     super(fields, {
       // Overwrite default "Container" typeName
@@ -65,17 +68,24 @@ export class ContainerNodeStructType<Fields extends Record<string, Type<unknown>
   }
 
   tree_serializedSize(node: Node): number {
-    return this.value_serializedSize((node as BranchNodeStruct<ValueOfFields<Fields>>).value);
+    return this.value_serializedSize(
+      (node as BranchNodeStruct<ValueOfFields<Fields>>).value as ValueOfFields<Fields> &
+        EphemeralValueOfFields<EphemeralFields>
+    );
   }
 
   tree_serializeToBytes(output: ByteViews, offset: number, node: Node): number {
     const {value} = node as BranchNodeStruct<ValueOfFields<Fields>>;
-    return this.value_serializeToBytes(output, offset, value);
+    return this.value_serializeToBytes(
+      output,
+      offset,
+      value as ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>
+    );
   }
 
   tree_deserializeFromBytes(data: ByteViews, start: number, end: number): Node {
     const value = this.value_deserializeFromBytes(data, start, end);
-    return new BranchNodeStruct(this.valueToTree.bind(this), value);
+    return new BranchNodeStruct(this.valueToTree.bind(this), value as ValueOfFields<Fields>);
   }
 
   // Proofs
@@ -103,18 +113,20 @@ export class ContainerNodeStructType<Fields extends Record<string, Type<unknown>
 
   // Overwrites for fast conversion node <-> value
 
-  tree_toValue(node: Node): ValueOfFields<Fields> {
-    return (node as BranchNodeStruct<ValueOfFields<Fields>>).value;
+  tree_toValue(node: Node): ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields> {
+    return (node as BranchNodeStruct<ValueOfFields<Fields>>).value as ValueOfFields<Fields> &
+      EphemeralValueOfFields<EphemeralFields>;
   }
 
-  value_toTree(value: ValueOfFields<Fields>): Node {
-    return new BranchNodeStruct(this.valueToTree.bind(this), value);
+  value_toTree(value: ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>): Node {
+    return new BranchNodeStruct(this.valueToTree.bind(this), value as ValueOfFields<Fields>);
   }
 
   private valueToTree(value: ValueOfFields<Fields>): Node {
-    const uint8Array = new Uint8Array(this.value_serializedSize(value));
+    const widened = value as ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>;
+    const uint8Array = new Uint8Array(this.value_serializedSize(widened));
     const dataView = new DataView(uint8Array.buffer, uint8Array.byteOffset, uint8Array.byteLength);
-    this.value_serializeToBytes({uint8Array, dataView}, 0, value);
+    this.value_serializeToBytes({uint8Array, dataView}, 0, widened);
     return super.tree_deserializeFromBytes({uint8Array, dataView}, 0, uint8Array.length);
   }
 }

--- a/packages/ssz/src/view/container.ts
+++ b/packages/ssz/src/view/container.ts
@@ -12,21 +12,56 @@ export type FieldEntry<Fields extends Record<string, Type<unknown>>> = {
   gindex: Gindex;
 };
 
+/**
+ * Entry for an ephemeral (non-consensus) field. No `gindex` because ephemeral fields are not part of the merkle tree.
+ */
+export type EphemeralFieldEntry<EphemeralFields extends Record<string, Type<unknown>>> = {
+  fieldName: keyof EphemeralFields;
+  fieldType: EphemeralFields[keyof EphemeralFields];
+  jsonKey: string;
+};
+
 /** Expected API of this View's type. This interface allows to break a recursive dependency between types and views */
-export type BasicContainerTypeGeneric<Fields extends Record<string, Type<unknown>>> = CompositeType<
-  ValueOfFields<Fields>,
-  ContainerTreeViewType<Fields>,
+export type BasicContainerTypeGeneric<
+  Fields extends Record<string, Type<unknown>>,
+  EphemeralFields extends Record<string, Type<unknown>> = Record<string, never>,
+> = CompositeType<
+  ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>,
+  ContainerTreeViewType<Fields, EphemeralFields>,
   unknown
 > & {
   readonly fields: Fields;
   readonly fieldsEntries: (FieldEntry<Fields> | FieldEntry<NonOptionalFields<Fields>>)[];
+  // Optional so that other consumers (ProfileType, StableContainerType) need not provide them.
+  // ContainerType always populates both — readers should default to `[]` for the loop.
+  readonly ephemeralFields?: EphemeralFields;
+  readonly ephemeralFieldsEntries?: EphemeralFieldEntry<EphemeralFields>[];
 };
 
-export type ContainerTypeGeneric<Fields extends Record<string, Type<unknown>>> = BasicContainerTypeGeneric<Fields> & {
+export type ContainerTypeGeneric<
+  Fields extends Record<string, Type<unknown>>,
+  EphemeralFields extends Record<string, Type<unknown>> = Record<string, never>,
+> = BasicContainerTypeGeneric<Fields, EphemeralFields> & {
   readonly fixedEnd: number;
 };
 
 export type ValueOfFields<Fields extends Record<string, Type<unknown>>> = {[K in keyof Fields]: ValueOf<Fields[K]>};
+
+/**
+ * `Partial<ValueOfFields<EphemeralFields>>`, but resolves to `unknown` when EphemeralFields is the unspecified
+ * default `Record<string, never>` (its `keyof` is `string`). Without this guard, intersecting with
+ * `Partial<{[K in string]: never}>` would force every string key of the consensus value to be `undefined`.
+ */
+export type EphemeralValueOfFields<EphemeralFields extends Record<string, Type<unknown>>> =
+  string extends keyof EphemeralFields ? unknown : Partial<ValueOfFields<EphemeralFields>>;
+
+/**
+ * Helper for callers that have populated all ephemeral fields and want them required (non-optional) at the type level.
+ */
+export type PopulatedValueOfFields<
+  Fields extends Record<string, Type<unknown>>,
+  EphemeralFields extends Record<string, Type<unknown>>,
+> = ValueOfFields<Fields> & ValueOfFields<EphemeralFields>;
 
 export type FieldsView<Fields extends Record<string, Type<unknown>>> = {
   [K in keyof Fields]: Fields[K] extends CompositeType<unknown, infer TV, unknown>
@@ -38,10 +73,17 @@ export type FieldsView<Fields extends Record<string, Type<unknown>>> = {
       : never;
 };
 
-export type ContainerTreeViewType<Fields extends Record<string, Type<unknown>>> = FieldsView<Fields> &
-  TreeView<BasicContainerTypeGeneric<Fields>>;
-export type ContainerTreeViewTypeConstructor<Fields extends Record<string, Type<unknown>>> = {
-  new (type: ContainerTypeGeneric<Fields>, tree: Tree): ContainerTreeViewType<Fields>;
+export type ContainerTreeViewType<
+  Fields extends Record<string, Type<unknown>>,
+  EphemeralFields extends Record<string, Type<unknown>> = Record<string, never>,
+> = FieldsView<Fields> &
+  EphemeralValueOfFields<EphemeralFields> &
+  TreeView<BasicContainerTypeGeneric<Fields, EphemeralFields>>;
+export type ContainerTreeViewTypeConstructor<
+  Fields extends Record<string, Type<unknown>>,
+  EphemeralFields extends Record<string, Type<unknown>> = Record<string, never>,
+> = {
+  new (type: ContainerTypeGeneric<Fields, EphemeralFields>, tree: Tree): ContainerTreeViewType<Fields, EphemeralFields>;
 };
 
 /**
@@ -59,9 +101,15 @@ export type ContainerTreeViewTypeConstructor<Fields extends Record<string, Type<
  *   iterate the entire data structure and views
  *
  */
-class ContainerTreeView<Fields extends Record<string, Type<unknown>>> extends TreeView<ContainerTypeGeneric<Fields>> {
+class ContainerTreeView<
+  Fields extends Record<string, Type<unknown>>,
+  EphemeralFields extends Record<string, Type<unknown>> = Record<string, never>,
+> extends TreeView<ContainerTypeGeneric<Fields, EphemeralFields>> {
+  /** Storage for ephemeral (non-consensus) field values. Kept per-instance, not in the tree. */
+  protected ephemeralValues: Record<string, unknown> = {};
+
   constructor(
-    readonly type: ContainerTypeGeneric<Fields>,
+    readonly type: ContainerTypeGeneric<Fields, EphemeralFields>,
     readonly tree: Tree
   ) {
     super();
@@ -72,10 +120,11 @@ class ContainerTreeView<Fields extends Record<string, Type<unknown>>> extends Tr
   }
 }
 
-export function getContainerTreeViewClass<Fields extends Record<string, Type<unknown>>>(
-  type: ContainerTypeGeneric<Fields>
-): ContainerTreeViewTypeConstructor<Fields> {
-  class CustomContainerTreeView extends ContainerTreeView<Fields> {}
+export function getContainerTreeViewClass<
+  Fields extends Record<string, Type<unknown>>,
+  EphemeralFields extends Record<string, Type<unknown>> = Record<string, never>,
+>(type: ContainerTypeGeneric<Fields, EphemeralFields>): ContainerTreeViewTypeConstructor<Fields, EphemeralFields> {
+  class CustomContainerTreeView extends ContainerTreeView<Fields, EphemeralFields> {}
 
   // Dynamically define prototype methods
   for (let index = 0; index < type.fieldsEntries.length; index++) {
@@ -133,8 +182,24 @@ export function getContainerTreeViewClass<Fields extends Record<string, Type<unk
     }
   }
 
+  // Define accessors for ephemeral fields. Backed by per-instance `ephemeralValues`, not the tree.
+  // No commit/sub-view machinery: ephemerals are stored as raw values.
+  for (const {fieldName} of type.ephemeralFieldsEntries ?? []) {
+    const key = fieldName as string;
+    Object.defineProperty(CustomContainerTreeView.prototype, fieldName, {
+      configurable: false,
+      enumerable: true,
+      get: function (this: CustomContainerTreeView) {
+        return (this as unknown as {ephemeralValues: Record<string, unknown>}).ephemeralValues[key];
+      },
+      set: function (this: CustomContainerTreeView, value: unknown) {
+        (this as unknown as {ephemeralValues: Record<string, unknown>}).ephemeralValues[key] = value;
+      },
+    });
+  }
+
   // Change class name
   Object.defineProperty(CustomContainerTreeView, "name", {value: type.typeName, writable: false});
 
-  return CustomContainerTreeView as unknown as ContainerTreeViewTypeConstructor<Fields>;
+  return CustomContainerTreeView as unknown as ContainerTreeViewTypeConstructor<Fields, EphemeralFields>;
 }

--- a/packages/ssz/src/view/containerNodeStruct.ts
+++ b/packages/ssz/src/view/containerNodeStruct.ts
@@ -3,7 +3,12 @@ import {BranchNodeStruct} from "../branchNodeStruct.ts";
 import {Type, ValueOf} from "../type/abstract.ts";
 import {isCompositeType} from "../type/composite.ts";
 import {TreeView} from "./abstract.ts";
-import {ContainerTreeViewTypeConstructor, ContainerTypeGeneric, ValueOfFields} from "./container.ts";
+import {
+  ContainerTreeViewTypeConstructor,
+  ContainerTypeGeneric,
+  EphemeralValueOfFields,
+  ValueOfFields,
+} from "./container.ts";
 
 /**
  * Intented usage:
@@ -20,9 +25,15 @@ import {ContainerTreeViewTypeConstructor, ContainerTypeGeneric, ValueOfFields} f
  *   iterate the entire data structure and views
  *
  */
-class ContainerTreeView<Fields extends Record<string, Type<unknown>>> extends TreeView<ContainerTypeGeneric<Fields>> {
+class ContainerTreeView<
+  Fields extends Record<string, Type<unknown>>,
+  EphemeralFields extends Record<string, Type<unknown>> = Record<string, never>,
+> extends TreeView<ContainerTypeGeneric<Fields, EphemeralFields>> {
+  /** Storage for ephemeral (non-consensus) field values. Kept per-instance, not in the tree. */
+  protected ephemeralValues: Record<string, unknown> = {};
+
   constructor(
-    readonly type: ContainerTypeGeneric<Fields>,
+    readonly type: ContainerTypeGeneric<Fields, EphemeralFields>,
     readonly tree: Tree
   ) {
     super();
@@ -33,10 +44,11 @@ class ContainerTreeView<Fields extends Record<string, Type<unknown>>> extends Tr
   }
 }
 
-export function getContainerTreeViewClass<Fields extends Record<string, Type<unknown>>>(
-  type: ContainerTypeGeneric<Fields>
-): ContainerTreeViewTypeConstructor<Fields> {
-  class CustomContainerTreeView extends ContainerTreeView<Fields> {}
+export function getContainerTreeViewClass<
+  Fields extends Record<string, Type<unknown>>,
+  EphemeralFields extends Record<string, Type<unknown>> = Record<string, never>,
+>(type: ContainerTypeGeneric<Fields, EphemeralFields>): ContainerTreeViewTypeConstructor<Fields, EphemeralFields> {
+  class CustomContainerTreeView extends ContainerTreeView<Fields, EphemeralFields> {}
 
   // Dynamically define prototype methods
   for (let index = 0; index < type.fieldsEntries.length; index++) {
@@ -57,7 +69,9 @@ export function getContainerTreeViewClass<Fields extends Record<string, Type<unk
 
         set: function (this: CustomContainerTreeView, value: unknown) {
           const node = this.tree.rootNode as BranchNodeStruct<ValueOfFields<Fields>>;
-          const newNodeValue = this.type.clone(node.value);
+          const newNodeValue = this.type.clone(
+            node.value as ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>
+          ) as ValueOfFields<Fields>;
 
           // TODO: Should this check for valid field name? Benchmark the cost
           newNodeValue[fieldName] = value as ValueOf<Fields[keyof Fields]>;
@@ -84,7 +98,9 @@ export function getContainerTreeViewClass<Fields extends Record<string, Type<unk
         // Expects TreeView of fieldName
         set: function (this: CustomContainerTreeView, view: unknown) {
           const node = this.tree.rootNode as BranchNodeStruct<ValueOfFields<Fields>>;
-          const newNodeValue = this.type.clone(node.value);
+          const newNodeValue = this.type.clone(
+            node.value as ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>
+          ) as ValueOfFields<Fields>;
 
           // TODO: Should this check for valid field name? Benchmark the cost
           newNodeValue[fieldName] = fieldType.toValueFromView(view) as ValueOf<Fields[keyof Fields]>;
@@ -101,8 +117,23 @@ export function getContainerTreeViewClass<Fields extends Record<string, Type<unk
     }
   }
 
+  // Define accessors for ephemeral fields. These never touch the BranchNodeStruct value.
+  for (const {fieldName} of type.ephemeralFieldsEntries ?? []) {
+    const key = fieldName as string;
+    Object.defineProperty(CustomContainerTreeView.prototype, fieldName, {
+      configurable: false,
+      enumerable: true,
+      get: function (this: CustomContainerTreeView) {
+        return (this as unknown as {ephemeralValues: Record<string, unknown>}).ephemeralValues[key];
+      },
+      set: function (this: CustomContainerTreeView, value: unknown) {
+        (this as unknown as {ephemeralValues: Record<string, unknown>}).ephemeralValues[key] = value;
+      },
+    });
+  }
+
   // Change class name
   Object.defineProperty(CustomContainerTreeView, "name", {value: type.typeName, writable: false});
 
-  return CustomContainerTreeView as unknown as ContainerTreeViewTypeConstructor<Fields>;
+  return CustomContainerTreeView as unknown as ContainerTreeViewTypeConstructor<Fields, EphemeralFields>;
 }

--- a/packages/ssz/src/viewDU/container.ts
+++ b/packages/ssz/src/viewDU/container.ts
@@ -9,7 +9,7 @@ import {
 import {ByteViews, Type} from "../type/abstract.ts";
 import {BasicType, isBasicType} from "../type/basic.ts";
 import {CompositeType, CompositeTypeAny, isCompositeType} from "../type/composite.ts";
-import {BasicContainerTypeGeneric, ContainerTypeGeneric} from "../view/container.ts";
+import {BasicContainerTypeGeneric, ContainerTypeGeneric, EphemeralValueOfFields} from "../view/container.ts";
 import {TreeViewDU} from "./abstract.ts";
 
 export type FieldsViewDU<Fields extends Record<string, Type<unknown>>> = {
@@ -22,10 +22,21 @@ export type FieldsViewDU<Fields extends Record<string, Type<unknown>>> = {
       : never;
 };
 
-export type ContainerTreeViewDUType<Fields extends Record<string, Type<unknown>>> = FieldsViewDU<Fields> &
-  TreeViewDU<ContainerTypeGeneric<Fields>>;
-export type ContainerTreeViewDUTypeConstructor<Fields extends Record<string, Type<unknown>>> = {
-  new (type: ContainerTypeGeneric<Fields>, node: Node, cache?: unknown): ContainerTreeViewDUType<Fields>;
+export type ContainerTreeViewDUType<
+  Fields extends Record<string, Type<unknown>>,
+  EphemeralFields extends Record<string, Type<unknown>> = Record<string, never>,
+> = FieldsViewDU<Fields> &
+  EphemeralValueOfFields<EphemeralFields> &
+  TreeViewDU<ContainerTypeGeneric<Fields, EphemeralFields>>;
+export type ContainerTreeViewDUTypeConstructor<
+  Fields extends Record<string, Type<unknown>>,
+  EphemeralFields extends Record<string, Type<unknown>> = Record<string, never>,
+> = {
+  new (
+    type: ContainerTypeGeneric<Fields, EphemeralFields>,
+    node: Node,
+    cache?: unknown
+  ): ContainerTreeViewDUType<Fields, EphemeralFields>;
 };
 
 export type ChangedNode = {index: number; node: Node};
@@ -36,17 +47,20 @@ type ContainerTreeViewDUCache = {
   nodesPopulated: boolean;
 };
 
-export class BasicContainerTreeViewDU<Fields extends Record<string, Type<unknown>>> extends TreeViewDU<
-  BasicContainerTypeGeneric<Fields>
-> {
+export class BasicContainerTreeViewDU<
+  Fields extends Record<string, Type<unknown>>,
+  EphemeralFields extends Record<string, Type<unknown>> = Record<string, never>,
+> extends TreeViewDU<BasicContainerTypeGeneric<Fields, EphemeralFields>> {
   protected nodes: Node[] = [];
   protected caches: unknown[];
   protected readonly nodesChanged = new Set<number>();
   protected readonly viewsChanged = new Map<number, unknown>();
+  /** Storage for ephemeral (non-consensus) field values. Kept per-instance, not in the tree. */
+  protected ephemeralValues: Record<string, unknown> = {};
   private nodesPopulated: boolean;
 
   constructor(
-    readonly type: BasicContainerTypeGeneric<Fields>,
+    readonly type: BasicContainerTypeGeneric<Fields, EphemeralFields>,
     protected _rootNode: Node,
     cache?: ContainerTreeViewDUCache
   ) {
@@ -157,9 +171,12 @@ export class BasicContainerTreeViewDU<Fields extends Record<string, Type<unknown
   }
 }
 
-class ContainerTreeViewDU<Fields extends Record<string, Type<unknown>>> extends BasicContainerTreeViewDU<Fields> {
+class ContainerTreeViewDU<
+  Fields extends Record<string, Type<unknown>>,
+  EphemeralFields extends Record<string, Type<unknown>> = Record<string, never>,
+> extends BasicContainerTreeViewDU<Fields, EphemeralFields> {
   constructor(
-    readonly type: ContainerTypeGeneric<Fields>,
+    readonly type: ContainerTypeGeneric<Fields, EphemeralFields>,
     protected _rootNode: Node,
     cache?: ContainerTreeViewDUCache
   ) {
@@ -205,10 +222,11 @@ class ContainerTreeViewDU<Fields extends Record<string, Type<unknown>>> extends 
   }
 }
 
-export function getContainerTreeViewDUClass<Fields extends Record<string, Type<unknown>>>(
-  type: ContainerTypeGeneric<Fields>
-): ContainerTreeViewDUTypeConstructor<Fields> {
-  class CustomContainerTreeViewDU extends ContainerTreeViewDU<Fields> {}
+export function getContainerTreeViewDUClass<
+  Fields extends Record<string, Type<unknown>>,
+  EphemeralFields extends Record<string, Type<unknown>> = Record<string, never>,
+>(type: ContainerTypeGeneric<Fields, EphemeralFields>): ContainerTreeViewDUTypeConstructor<Fields, EphemeralFields> {
+  class CustomContainerTreeViewDU extends ContainerTreeViewDU<Fields, EphemeralFields> {}
 
   // Dynamically define prototype methods
   for (let index = 0; index < type.fieldsEntries.length; index++) {
@@ -305,8 +323,24 @@ export function getContainerTreeViewDUClass<Fields extends Record<string, Type<u
     }
   }
 
+  // Define accessors for ephemeral fields. Backed by per-instance `ephemeralValues`, not the tree.
+  // No commit/cache machinery: ephemerals are stored as raw values and never appear in nodesChanged/viewsChanged.
+  for (const {fieldName} of type.ephemeralFieldsEntries ?? []) {
+    const key = fieldName as string;
+    Object.defineProperty(CustomContainerTreeViewDU.prototype, fieldName, {
+      configurable: false,
+      enumerable: true,
+      get: function (this: CustomContainerTreeViewDU) {
+        return (this as unknown as {ephemeralValues: Record<string, unknown>}).ephemeralValues[key];
+      },
+      set: function (this: CustomContainerTreeViewDU, value: unknown) {
+        (this as unknown as {ephemeralValues: Record<string, unknown>}).ephemeralValues[key] = value;
+      },
+    });
+  }
+
   // Change class name
   Object.defineProperty(CustomContainerTreeViewDU, "name", {value: type.typeName, writable: false});
 
-  return CustomContainerTreeViewDU as unknown as ContainerTreeViewDUTypeConstructor<Fields>;
+  return CustomContainerTreeViewDU as unknown as ContainerTreeViewDUTypeConstructor<Fields, EphemeralFields>;
 }

--- a/packages/ssz/src/viewDU/containerNodeStruct.ts
+++ b/packages/ssz/src/viewDU/containerNodeStruct.ts
@@ -2,18 +2,21 @@ import {HashComputationLevel, Node} from "@chainsafe/persistent-merkle-tree";
 import {BranchNodeStruct} from "../branchNodeStruct.ts";
 import {Type, ValueOf} from "../type/abstract.ts";
 import {isCompositeType} from "../type/composite.ts";
-import {ContainerTypeGeneric, ValueOfFields} from "../view/container.ts";
+import {ContainerTypeGeneric, EphemeralValueOfFields, ValueOfFields} from "../view/container.ts";
 import {TreeViewDU} from "./abstract.ts";
 import {ContainerTreeViewDUTypeConstructor} from "./container.ts";
 
-export class ContainerNodeStructTreeViewDU<Fields extends Record<string, Type<unknown>>> extends TreeViewDU<
-  ContainerTypeGeneric<Fields>
-> {
+export class ContainerNodeStructTreeViewDU<
+  Fields extends Record<string, Type<unknown>>,
+  EphemeralFields extends Record<string, Type<unknown>> = Record<string, never>,
+> extends TreeViewDU<ContainerTypeGeneric<Fields, EphemeralFields>> {
   protected valueChanged: ValueOfFields<Fields> | null = null;
   protected _rootNode: BranchNodeStruct<ValueOfFields<Fields>>;
+  /** Storage for ephemeral (non-consensus) field values. Kept per-instance, not in the tree. */
+  protected ephemeralValues: Record<string, unknown> = {};
 
   constructor(
-    readonly type: ContainerTypeGeneric<Fields>,
+    readonly type: ContainerTypeGeneric<Fields, EphemeralFields>,
     node: Node
   ) {
     super();
@@ -43,7 +46,9 @@ export class ContainerNodeStructTreeViewDU<Fields extends Record<string, Type<un
       const value = this.valueChanged;
       this.valueChanged = null;
 
-      this._rootNode = this.type.value_toTree(value) as BranchNodeStruct<ValueOfFields<Fields>>;
+      this._rootNode = this.type.value_toTree(
+        value as ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>
+      ) as BranchNodeStruct<ValueOfFields<Fields>>;
     }
 
     if (this._rootNode.h0 === null && hcByLevel !== null) {
@@ -57,10 +62,11 @@ export class ContainerNodeStructTreeViewDU<Fields extends Record<string, Type<un
   }
 }
 
-export function getContainerTreeViewDUClass<Fields extends Record<string, Type<unknown>>>(
-  type: ContainerTypeGeneric<Fields>
-): ContainerTreeViewDUTypeConstructor<Fields> {
-  class CustomContainerTreeViewDU extends ContainerNodeStructTreeViewDU<Fields> {}
+export function getContainerTreeViewDUClass<
+  Fields extends Record<string, Type<unknown>>,
+  EphemeralFields extends Record<string, Type<unknown>> = Record<string, never>,
+>(type: ContainerTypeGeneric<Fields, EphemeralFields>): ContainerTreeViewDUTypeConstructor<Fields, EphemeralFields> {
+  class CustomContainerTreeViewDU extends ContainerNodeStructTreeViewDU<Fields, EphemeralFields> {}
 
   // Dynamically define prototype methods
   for (let index = 0; index < type.fieldsEntries.length; index++) {
@@ -81,7 +87,9 @@ export function getContainerTreeViewDUClass<Fields extends Record<string, Type<u
 
         set: function (this: CustomContainerTreeViewDU, value: ValueOf<Fields[keyof Fields]>) {
           if (this.valueChanged === null) {
-            this.valueChanged = this.type.clone(this._rootNode.value);
+            this.valueChanged = this.type.clone(
+              this._rootNode.value as ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>
+            ) as ValueOfFields<Fields>;
           }
 
           this.valueChanged[fieldName] = value;
@@ -106,7 +114,9 @@ export function getContainerTreeViewDUClass<Fields extends Record<string, Type<u
         // Expects TreeViewDU of fieldName
         set: function (this: CustomContainerTreeViewDU, view: unknown) {
           if (this.valueChanged === null) {
-            this.valueChanged = this.type.clone(this._rootNode.value);
+            this.valueChanged = this.type.clone(
+              this._rootNode.value as ValueOfFields<Fields> & EphemeralValueOfFields<EphemeralFields>
+            ) as ValueOfFields<Fields>;
           }
 
           const value = fieldType.toValueFromViewDU(view);
@@ -122,8 +132,23 @@ export function getContainerTreeViewDUClass<Fields extends Record<string, Type<u
     }
   }
 
+  // Define accessors for ephemeral fields. These never touch valueChanged or the BranchNodeStruct value.
+  for (const {fieldName} of type.ephemeralFieldsEntries ?? []) {
+    const key = fieldName as string;
+    Object.defineProperty(CustomContainerTreeViewDU.prototype, fieldName, {
+      configurable: false,
+      enumerable: true,
+      get: function (this: CustomContainerTreeViewDU) {
+        return (this as unknown as {ephemeralValues: Record<string, unknown>}).ephemeralValues[key];
+      },
+      set: function (this: CustomContainerTreeViewDU, value: unknown) {
+        (this as unknown as {ephemeralValues: Record<string, unknown>}).ephemeralValues[key] = value;
+      },
+    });
+  }
+
   // Change class name
   Object.defineProperty(CustomContainerTreeViewDU, "name", {value: type.typeName, writable: false});
 
-  return CustomContainerTreeViewDU as unknown as ContainerTreeViewDUTypeConstructor<Fields>;
+  return CustomContainerTreeViewDU as unknown as ContainerTreeViewDUTypeConstructor<Fields, EphemeralFields>;
 }

--- a/packages/ssz/test/unit/byType/container/ephemeral.test.ts
+++ b/packages/ssz/test/unit/byType/container/ephemeral.test.ts
@@ -1,0 +1,204 @@
+import {Tree} from "@chainsafe/persistent-merkle-tree";
+import {describe, expect, expectTypeOf, it} from "vitest";
+import {ContainerNodeStructType, ContainerType, ListBasicType, UintNumberType} from "../../../../src/index.ts";
+import {byteType, uint64NumInfType} from "../../../utils/primitiveTypes.ts";
+
+const uint16 = new UintNumberType(2);
+
+// Run the same suite for both ContainerType and ContainerNodeStructType to confirm both honor
+// the "ephemerals are excluded from consensus, included on value/View/ViewDU" contract.
+for (const Variant of [ContainerType, ContainerNodeStructType] as const) {
+  const variantName = Variant === ContainerType ? "ContainerType" : "ContainerNodeStructType";
+
+  describe(`${variantName} ephemeralFields`, () => {
+    const consensusFields = {a: uint64NumInfType, b: uint64NumInfType};
+    const ephemeralFields = {total: uint64NumInfType, tag: byteType};
+
+    const typeWith = new Variant(consensusFields, {
+      typeName: `${variantName}WithEphemerals`,
+      ephemeralFields,
+    });
+    const typeWithout = new Variant(consensusFields, {typeName: `${variantName}NoEphemerals`});
+
+    it("does not advertise ephemeral fields as consensus fields", () => {
+      expect(typeWith.fieldsEntries).toHaveLength(2);
+      expect(typeWith.maxChunkCount).toBe(2);
+      expect(typeWith.depth).toBe(typeWithout.depth);
+      expect(typeWith.fixedSize).toBe(typeWithout.fixedSize);
+
+      expect(typeWith.ephemeralFieldsEntries).toHaveLength(2);
+      expect(typeWith.ephemeralFieldsEntries.map((e) => e.fieldName)).toEqual(["total", "tag"]);
+    });
+
+    it("rejects ephemeral field names that collide with consensus fields", () => {
+      expect(
+        () =>
+          new Variant(consensusFields, {
+            ephemeralFields: {a: uint64NumInfType},
+          })
+      ).toThrow(/collides/);
+    });
+
+    it("serialize is identical to a sibling type without ephemeralFields", () => {
+      const consensusValue = {a: 1, b: 2};
+      const valueWithEphemerals = {...consensusValue, total: 999, tag: 7};
+
+      const bytesWith = typeWith.serialize(valueWithEphemerals);
+      const bytesWithout = typeWithout.serialize(consensusValue);
+      expect(bytesWith).toEqual(bytesWithout);
+    });
+
+    it("hashTreeRoot ignores ephemerals", () => {
+      const v1 = {a: 1, b: 2, total: 100, tag: 1};
+      const v2 = {a: 1, b: 2, total: 999, tag: 9};
+      const v3 = {a: 1, b: 2};
+      expect(typeWith.hashTreeRoot(v1)).toEqual(typeWith.hashTreeRoot(v2));
+      expect(typeWith.hashTreeRoot(v1)).toEqual(typeWith.hashTreeRoot(v3));
+      // and same as the consensus-only sibling
+      expect(typeWith.hashTreeRoot(v1)).toEqual(typeWithout.hashTreeRoot({a: 1, b: 2}));
+    });
+
+    it("equals ignores ephemerals (consensus-only)", () => {
+      expect(typeWith.equals({a: 1, b: 2, total: 1}, {a: 1, b: 2, total: 99})).toBe(true);
+      expect(typeWith.equals({a: 1, b: 2}, {a: 1, b: 3})).toBe(false);
+    });
+
+    it("clone copies present ephemerals through (using each ephemeral type's clone)", () => {
+      const src = {a: 1, b: 2, total: 42, tag: 9};
+      const cloned = typeWith.clone(src);
+      expect(cloned).toEqual(src);
+      // Distinct object reference
+      expect(cloned).not.toBe(src);
+
+      const srcNoEphemeral = {a: 1, b: 2};
+      const clonedNoEphemeral = typeWith.clone(srcNoEphemeral);
+      expect(Object.prototype.hasOwnProperty.call(clonedNoEphemeral, "total")).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(clonedNoEphemeral, "tag")).toBe(false);
+    });
+
+    it("defaultValue does not include ephemeral keys", () => {
+      const dv = typeWith.defaultValue();
+      expect(Object.prototype.hasOwnProperty.call(dv, "total")).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(dv, "tag")).toBe(false);
+    });
+
+    it("fromJson(toJson(value)) drops ephemerals", () => {
+      const value = {a: 1, b: 2, total: 999, tag: 5};
+      const json = typeWith.toJson(value);
+      expect(Object.prototype.hasOwnProperty.call(json, "total")).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(json, "tag")).toBe(false);
+
+      const back = typeWith.fromJson(json);
+      expect(back).toEqual({a: 1, b: 2});
+    });
+
+    it("View accepts and returns ephemerals via property accessors", () => {
+      const view = typeWith.toView({a: 1, b: 2, total: 77, tag: 3});
+      expect(view.a).toBe(1);
+      expect(view.b).toBe(2);
+      expect(view.total).toBe(77);
+      expect(view.tag).toBe(3);
+
+      view.total = 88;
+      expect(view.total).toBe(88);
+      // Setting an ephemeral does not affect the consensus root.
+      expect(view.hashTreeRoot()).toEqual(typeWithout.hashTreeRoot({a: 1, b: 2}));
+    });
+
+    it("ViewDU accepts and returns ephemerals via property accessors", () => {
+      const viewDU = typeWith.toViewDU({a: 1, b: 2, total: 77, tag: 3});
+      expect(viewDU.a).toBe(1);
+      expect(viewDU.b).toBe(2);
+      expect(viewDU.total).toBe(77);
+      expect(viewDU.tag).toBe(3);
+
+      viewDU.total = 88;
+      expect(viewDU.total).toBe(88);
+      expect(viewDU.hashTreeRoot()).toEqual(typeWithout.hashTreeRoot({a: 1, b: 2}));
+    });
+
+    it("getView(tree) starts with empty ephemerals (no value source)", () => {
+      const node = typeWith.value_toTree({a: 1, b: 2});
+      const view = typeWith.getView(new Tree(node));
+      expect(view.total).toBeUndefined();
+      expect(view.tag).toBeUndefined();
+    });
+
+    it("re-deserializing serialized bytes produces no ephemeral keys", () => {
+      const value = {a: 1, b: 2, total: 77, tag: 3};
+      const bytes = typeWith.serialize(value);
+      const back = typeWith.deserialize(bytes);
+      expect(back).toEqual({a: 1, b: 2});
+      expect(Object.prototype.hasOwnProperty.call(back, "total")).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(back, "tag")).toBe(false);
+    });
+  });
+}
+
+// Composite ephemeral field — exercise that types containing children work too.
+describe("ContainerType ephemeralFields with composite ephemeral type", () => {
+  const totalList = new ListBasicType(uint64NumInfType, 4);
+  const consensusFields = {a: uint64NumInfType};
+
+  const containerType = new ContainerType(consensusFields, {
+    typeName: "ContainerWithListEphemeral",
+    ephemeralFields: {totalList},
+  });
+
+  it("clone deep-copies the ephemeral list value", () => {
+    const original = [10, 20];
+    const src = {a: 1, totalList: [...original]};
+    const cloned = containerType.clone(src);
+    expect(cloned.totalList).toEqual(original);
+    expect(cloned.totalList).not.toBe(src.totalList);
+  });
+
+  it("toView/toViewDU carry over composite ephemerals as raw values", () => {
+    const src = {a: 1, totalList: [10, 20]};
+    const view = containerType.toView(src);
+    expect(view.totalList).toEqual([10, 20]);
+
+    const viewDU = containerType.toViewDU(src);
+    expect(viewDU.totalList).toEqual([10, 20]);
+  });
+});
+
+// Compile-time assertions on the public type surface.
+describe("ContainerType ephemeralFields type-level surface", () => {
+  const consensusFields = {a: uint64NumInfType, b: uint16};
+  const ephemeralFields = {total: uint64NumInfType};
+
+  const typeWith = new ContainerType(consensusFields, {ephemeralFields});
+
+  it("consensus fields are required, ephemerals are optional on the value type", () => {
+    const v = typeWith.defaultValue();
+    expectTypeOf(v.a).toEqualTypeOf<number>();
+    expectTypeOf(v.b).toEqualTypeOf<number>();
+    expectTypeOf(v.total).toEqualTypeOf<number | undefined>();
+  });
+
+  it("View getter returns T | undefined for ephemerals; setter accepts T", () => {
+    const view = typeWith.toView({a: 1, b: 2, total: 7});
+    expectTypeOf(view.a).toEqualTypeOf<number>();
+    expectTypeOf(view.total).toEqualTypeOf<number | undefined>();
+    // Setter accepts T (not undefined)
+    view.total = 99;
+  });
+
+  it("ViewDU getter/setter shape mirrors View", () => {
+    const viewDU = typeWith.toViewDU({a: 1, b: 2, total: 7});
+    expectTypeOf(viewDU.a).toEqualTypeOf<number>();
+    expectTypeOf(viewDU.total).toEqualTypeOf<number | undefined>();
+    viewDU.total = 88;
+  });
+
+  it("a ContainerType without ephemeralFields keeps its existing value type unchanged", () => {
+    const plain = new ContainerType(consensusFields);
+    const v = plain.defaultValue();
+    expectTypeOf(v.a).toEqualTypeOf<number>();
+    expectTypeOf(v.b).toEqualTypeOf<number>();
+    // No `total` key on the type
+    // @ts-expect-error - total is not declared
+    v.total;
+  });
+});


### PR DESCRIPTION
## Summary
- Adds an optional `ephemeralFields` map to `ContainerType` and `ContainerNodeStructType` for declaring application-only fields that are first-class on the value/View/ViewDU but **strictly excluded from consensus**: serialization, deserialization, `hashTreeRoot`, JSON, equality, and tree storage all ignore them.
- Lets callers cache derived data (precomputed indices, totals, etc.) directly on a container without forking the type.
- Non-breaking: new generic `EphemeralFields` defaults to `Record<string, never>`, so existing call sites compile unchanged.

## Motivation
`ContainerType<Fields>` currently requires every declared field to participate in consensus. Applications that want to attach derived/cached data on top of a container value have no first-class place to put it — they either fork the SSZ type, attach untyped sidebands, or wrap the type. This PR makes that pattern first-class.

Concrete consumer: ChainSafe/lodestar#9341 — pending deposit requests are currently re-validated on every access. With this PR, lodestar can attach `{valid: BooleanType}` as an ephemeral field on `PendingDeposit`, validate once, and cache the result on the container value/View/ViewDU without polluting the consensus type or its hash.

## API
```ts
new ContainerType(consensusFields, {
  ephemeralFields: { totalActiveBalance: UintNum64, ... },
});
```
- Value type widens to `ValueOfFields<F> & Partial<ValueOfFields<EF>>` (consensus required, ephemerals optional).
- View/ViewDU expose ephemeral accessors backed by per-instance storage (`ephemeralValues`); they never touch the merkle tree, \nodesChanged`, or `viewsChanged`.
- `clone(value)` deep-copies present ephemerals via each ephemeral type's own `clone`.
- `toView(value)` / `toViewDU(value)` carry present ephemerals from the source value to the resulting view's ephemeral storage. `getView(tree)` / `getViewDU(node)\ start with empty ephemerals (no value source).
- Constructor throws if an ephemeral name collides with a consensus field name.
- Avoid ephemeral names that collide with View/ViewDU base members (`type`, `tree`, `node`, `cache`, `nodes`, …) — they already exist on the view classes.

## Excluded from consensus (verified by tests)
- `serialize` / `deserialize` — ephemerals never appear in bytes; deserialized values have no ephemeral keys
- `hashTreeRoot` — identical regardless of ephemeral values
- `equals` — compares consensus only; differing ephemerals are still equal
- `toJson` / `fromJson` — ephemerals are not part of JSON encoding
- `defaultValue` — emits no ephemeral keys
- `maxChunkCount` / `depth` /`fixedSize` / `serdes` layout — derived from consensus fields only

🤖 Generated with [Claude Code](https://claude.com/claude-code)