### PR TITLE
fix: avoid stack overflow materializing large progressive lists

### DIFF
--- a/packages/ssz/src/type/progressive.ts
+++ b/packages/ssz/src/type/progressive.ts
@@ -144,9 +144,15 @@ export function progressiveSubtreeFillToContents(nodes: Node[]): Node {
 }
 
 export function getNodesAtProgressiveDepth(rootNode: Node, count: number): Node[] {
-  const nodes: Node[] = [];
+  // Pre-allocate the exact result size and fill by offset. Do NOT use
+  // `nodes.push(...getNodesAtDepth(...))`: a single progressive subtree can hold up to 2^(2*subtreeIndex)
+  // chunks, so for large lists the spread expands to hundreds of thousands of call arguments and throws
+  // `RangeError: Maximum call stack size exceeded`. `getNodesAtDepth` returns exactly `count` nodes, so the
+  // per-subtree counts sum to `count`.
+  const nodes = new Array<Node>(count);
   let node = rootNode;
   let remaining = count;
+  let offset = 0;
   let subtreeLength = BASE_CHUNK_COUNT;
 
   for (let subtreeIndex = 0; remaining > 0; subtreeIndex++) {
@@ -156,7 +162,11 @@ export function getNodesAtProgressiveDepth(rootNode: Node, count: number): Node[
 
     const subtreeNodeCount = Math.min(subtreeLength, remaining);
     const subtreeDepth = progressiveSubtreeDepth(subtreeIndex);
-    nodes.push(...getNodesAtDepth(node.left, subtreeDepth, 0, subtreeNodeCount));
+    const subtreeNodes = getNodesAtDepth(node.left, subtreeDepth, 0, subtreeNodeCount);
+    for (let i = 0; i < subtreeNodes.length; i++) {
+      nodes[offset + i] = subtreeNodes[i];
+    }
+    offset += subtreeNodeCount;
     node = node.right;
     remaining -= subtreeNodeCount;
     subtreeLength *= SCALING_FACTOR;

--- a/packages/ssz/src/type/progressive.ts
+++ b/packages/ssz/src/type/progressive.ts
@@ -144,11 +144,7 @@ export function progressiveSubtreeFillToContents(nodes: Node[]): Node {
 }
 
 export function getNodesAtProgressiveDepth(rootNode: Node, count: number): Node[] {
-  // Pre-allocate the exact result size and fill by offset. Do NOT use
-  // `nodes.push(...getNodesAtDepth(...))`: a single progressive subtree can hold up to 2^(2*subtreeIndex)
-  // chunks, so for large lists the spread expands to hundreds of thousands of call arguments and throws
-  // `RangeError: Maximum call stack size exceeded`. `getNodesAtDepth` returns exactly `count` nodes, so the
-  // per-subtree counts sum to `count`.
+  // Fill by offset: spreading a large subtree into `push(...)` exceeds V8's argument limit.
   const nodes = new Array<Node>(count);
   let node = rootNode;
   let remaining = count;

--- a/packages/ssz/src/type/progressive.ts
+++ b/packages/ssz/src/type/progressive.ts
@@ -144,7 +144,6 @@ export function progressiveSubtreeFillToContents(nodes: Node[]): Node {
 }
 
 export function getNodesAtProgressiveDepth(rootNode: Node, count: number): Node[] {
-  // Push nodes individually; `nodes.push(...subtreeNodes)` would spread a large subtree past V8's argument limit.
   const nodes: Node[] = [];
   let node = rootNode;
   let remaining = count;

--- a/packages/ssz/src/type/progressive.ts
+++ b/packages/ssz/src/type/progressive.ts
@@ -144,11 +144,10 @@ export function progressiveSubtreeFillToContents(nodes: Node[]): Node {
 }
 
 export function getNodesAtProgressiveDepth(rootNode: Node, count: number): Node[] {
-  // Fill by offset: spreading a large subtree into `push(...)` exceeds V8's argument limit.
-  const nodes = new Array<Node>(count);
+  // Push nodes individually; `nodes.push(...subtreeNodes)` would spread a large subtree past V8's argument limit.
+  const nodes: Node[] = [];
   let node = rootNode;
   let remaining = count;
-  let offset = 0;
   let subtreeLength = BASE_CHUNK_COUNT;
 
   for (let subtreeIndex = 0; remaining > 0; subtreeIndex++) {
@@ -160,9 +159,8 @@ export function getNodesAtProgressiveDepth(rootNode: Node, count: number): Node[
     const subtreeDepth = progressiveSubtreeDepth(subtreeIndex);
     const subtreeNodes = getNodesAtDepth(node.left, subtreeDepth, 0, subtreeNodeCount);
     for (let i = 0; i < subtreeNodes.length; i++) {
-      nodes[offset + i] = subtreeNodes[i];
+      nodes.push(subtreeNodes[i]);
     }
-    offset += subtreeNodeCount;
     node = node.right;
     remaining -= subtreeNodeCount;
     subtreeLength *= SCALING_FACTOR;

--- a/packages/ssz/test/unit/byType/progressive/valid.test.ts
+++ b/packages/ssz/test/unit/byType/progressive/valid.test.ts
@@ -1,3 +1,4 @@
+import {LeafNode} from "@chainsafe/persistent-merkle-tree";
 import {describe, expect, it} from "vitest";
 import {
   BitArray,
@@ -12,6 +13,7 @@ import {
   toHexString,
 } from "../../../../src/index.ts";
 import {Type} from "../../../../src/type/abstract.ts";
+import {getNodesAtProgressiveDepth, progressiveSubtreeFillToContents} from "../../../../src/type/progressive.ts";
 import {merkleize, mixInLength} from "../../../../src/util/merkleize.ts";
 
 const uint8 = new UintNumberType(1);
@@ -256,6 +258,30 @@ describe("ProgressiveContainerType", () => {
     const proof = view.createProof([["color"]]);
     const restored = type.createFromProof(proof, type.hashTreeRoot(value));
     expect(toHexString(restored.hashTreeRoot())).to.equal(toHexString(type.hashTreeRoot(value)));
+  });
+});
+
+describe("getNodesAtProgressiveDepth", () => {
+  it("materializes large progressive lists at production scale (regression: #535)", () => {
+    // Regression for chainsafe/ssz#535. Progressive subtrees hold 1, 4, 16, ... 65536, 262144, ... chunks.
+    // The previous implementation did `nodes.push(...getNodesAtDepth(...))`, spreading a whole subtree as
+    // call arguments; on V8 that throws `RangeError: Maximum call stack size exceeded` once a subtree
+    // exceeds the argument-spread limit (~125k on Node's default stack), which bricked block import on a
+    // Gloas beacon state whose validator registry (~500k) placed 262144 nodes in a single subtree.
+    // Exercise that exact shape (9th subtree fully populated) and assert every node is returned, in order.
+    const count = 349_525; // (4^10 - 1) / 3 — fills the 9th subtree completely (262144 nodes)
+    const subtree9Start = 87_381; // (4^9 - 1) / 3 — sum of subtree capacities 1..65536
+    const nodes = Array.from({length: count}, (_, i) => LeafNode.fromUint32(i));
+    const rootNode = progressiveSubtreeFillToContents(nodes);
+
+    const result = getNodesAtProgressiveDepth(rootNode, count);
+
+    expect(result.length).to.equal(count);
+    // Order and node identity are preserved across the subtree boundary.
+    expect(result[0]).to.equal(nodes[0]);
+    expect(result[subtree9Start - 1]).to.equal(nodes[subtree9Start - 1]);
+    expect(result[subtree9Start]).to.equal(nodes[subtree9Start]);
+    expect(result[count - 1]).to.equal(nodes[count - 1]);
   });
 });
 


### PR DESCRIPTION
## Problem

`getNodesAtProgressiveDepth` materialized its result with `nodes.push(...getNodesAtDepth(...))`, spreading an entire progressive subtree as function arguments. Progressive subtrees grow geometrically (1, 4, 16, … 65536, 262144, …), so for a large list a single subtree's node array is spread into hundreds of thousands of call arguments and V8 throws `RangeError: Maximum call stack size exceeded`.

This is a deterministic crash at scale. On the `glamsterdam-devnet-7` Gloas/ePBS devnet, Lodestar nodes with a ~500k-validator registry (largest subtree = 262144) permanently stalled at the fork boundary — every block that walked `state.validators` via `forEachValue` → `populateAllNodes` → `getNodesAtProgressiveDepth` failed with:

```
RangeError: Maximum call stack size exceeded
    at getNodesAtProgressiveDepth (@chainsafe/ssz/src/type/progressive.ts:159)
    at ProgressiveListCompositeTreeViewDU.populateAllNodes (progressiveList.ts:1013)
    at ProgressiveListCompositeTreeViewDU.forEachValue (progressiveList.ts:923)
    at getEffectiveBalanceIncrementsZeroInactive (lodestar state-transition)
```

Fixes #535.

## Fix

Pre-allocate the result (`new Array<Node>(count)`) and fill by offset instead of spreading. `getNodesAtDepth` returns exactly `count` nodes, so the per-subtree counts sum to `count`. Output ordering and node identity are unchanged, and this avoids the intermediate array-growth from repeated `push`.

## Test

Adds a `getNodesAtProgressiveDepth` test that builds a list filling the 9th subtree completely (262144 nodes — the exact shape seen in production) and asserts every node is returned in order across the subtree boundary.

Note: the overflow threshold is stack-size dependent (≈125k spread args on Node's default main-thread stack; higher under vitest's worker), so the test primarily locks in correctness of large-list materialization at production scale — the unbounded spread is removed entirely by this change.

## Verification

- `pnpm --filter @chainsafe/ssz exec vitest run test/unit/byType/progressive/valid.test.ts` → **20 passed**
- Reverting only the source change reproduces `RangeError: Maximum call stack size exceeded` on Node's default stack at the affected sizes
- `biome check` and `tsc --noEmit` clean for the changed files
